### PR TITLE
host file and variable path updates

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -1,5 +1,9 @@
-- hosts: galaxyservers
+- hosts: dev_galaxy_server
   become: true
+  vars_files:
+      - group_vars/all.yml
+      - group_vars/galaxyservers.yml
+      - host_vars/dev.usegalaxy.org.au.yml
   pre_tasks:
     # The following 3 tasks are for mounting the volume attached to the galaxy
     # application server.  If this script is being run for the first time,

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,3 +1,6 @@
+# append domain to ansible_hostname (from hosts file) for hostname variable
+hostname: "{{ ansible_hostname }}.usegalaxy.org.au"
+
 #List of users to install and setup /homes for
 machine_users:
     - name: simon

--- a/group_vars/dev_slurm.yml
+++ b/group_vars/dev_slurm.yml
@@ -1,8 +1,8 @@
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['dev-queue-head'] }}"
-worker_nodes: "{{ groups['dev-workers'] }}"
+head_nodes: "{{ groups['dev_slurm_head'] }}"
+worker_nodes: "{{ groups['dev_workers'] }}"
 
 # SLURM
 slurm_nodes:

--- a/group_vars/rabbitservers.yml
+++ b/group_vars/rabbitservers.yml
@@ -20,7 +20,6 @@ certbot_domains:
 certbot_agree_tos: --agree-tos
 
 # NGINX
-hostname: "{{ ansible_hostname }}.usegalaxy.org.au"
 nginx_selinux_allow_local_connections: true
 nginx_servers:
   - redirect-ssl

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -1,0 +1,1 @@
+# hello world

--- a/hosts
+++ b/hosts
@@ -1,8 +1,8 @@
-[dbservers]
-dev-db.usegalaxy.org.au ansible_ssh_host=115.146.86.251
+[dev_db_server]
+dev-db ansible_ssh_host=115.146.86.251
 
-[galaxyservers]
-dev.usegalaxy.org.au ansible_ssh_host=115.146.86.50
+[dev_galaxy_server]
+dev ansible_ssh_host=115.146.86.50
 
 [rabbitservers]
 dev-queue ansible_ssh_host=115.146.85.163
@@ -10,10 +10,10 @@ dev-queue ansible_ssh_host=115.146.85.163
 [slurmcontrollers]
 dev-queue ansible_ssh_host=115.146.85.163
 
-[dev-slurm-head]
+[dev_slurm_head]
 dev-queue ansible_ssh_host=115.146.85.163
 
-[dev-workers]
+[dev_workers]
 dev-w1 ansible_ssh_host=115.146.87.253
 
 [all:vars]


### PR DESCRIPTION
- As per Simon's work with rabbit, have `hostname: "{{ ansible_hostname }}.usegalaxy.org.au"` in all.yml
- Replace hyphens in group names with underscores.  Ansible gives a warning  `Invalid characters were found in group names but not replaced, use -vvvv to see details'.  It probably doesn't matter but it's difficult to tell.
- add vars_files to dev_playbook