### PR TITLE
Update staging terraform, add security groups

### DIFF
--- a/terraform/dev/dev-initial.tf
+++ b/terraform/dev/dev-initial.tf
@@ -1,47 +1,47 @@
 # dev database
 resource "openstack_compute_instance_v2" "dev-db" {
   name            = "dev-db"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
   flavor_name     = "m3.small"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "galaxy-dev-db"]
+  security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-dev-db.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 # application server / web server
 resource "openstack_compute_instance_v2" "dev" {
   name            = "dev"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
   flavor_name     = "m3.medium"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "Web-Services", "galaxy-dev", "galaxy-dev-db"]
+  security_groups = ["SSH", "Web-Services", "${openstack_networking_secgroup_v2.galaxy-dev.name}", "${openstack_networking_secgroup_v2.galaxy-dev-db.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 # slurm / rabbitMQ
 resource "openstack_compute_instance_v2" "dev-queue" {
   name            = "dev-queue"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
   flavor_name     = "m3.small"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "Web-Services", "rabbitmq", "galaxy-dev"]
+  security_groups = ["SSH", "Web-Services", "rabbitmq", "${openstack_networking_secgroup_v2.galaxy-dev.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 # slurm worker
 resource "openstack_compute_instance_v2" "dev-w1" {
   name            = "dev-w1"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
   flavor_name     = "m3.medium"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "galaxy-dev"]
+  security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-dev.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 #pulsar test server
 resource "openstack_compute_instance_v2" "dev-pulsar" {
   name            = "dev-pulsar"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
   flavor_name     = "m3.medium"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH"]

--- a/terraform/dev/dev-secgroups.tf
+++ b/terraform/dev/dev-secgroups.tf
@@ -1,0 +1,45 @@
+# galaxy-dev-db security group
+resource "openstack_networking_secgroup_v2" "galaxy-dev-db" {
+    description = "Security group for the galaxy australia development server and it's own db server"
+    name        = "galaxy-dev-db"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-dev-db-ingress-dev-5432" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_max    = 5432
+    port_range_min    = 5432
+    protocol          = "tcp"
+    remote_ip_prefix  = "${openstack_compute_instance_v2.dev.network[0].fixed_ip_v4}/0"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-dev-db.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-dev-db-ingress-group" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    protocol          = "tcp"
+    remote_group_id   = "${openstack_networking_secgroup_v2.galaxy-dev-db.id}"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-dev-db.id}"
+}
+
+# galaxy-dev security group
+resource "openstack_networking_secgroup_v2" "galaxy-dev" {
+    description = "Security group for all machines in the Galaxy Australia Development server ecosystem"
+    name        = "galaxy-dev"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-dev-ingress-tcp-group" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    protocol          = "tcp"
+    remote_group_id   = "${openstack_networking_secgroup_v2.galaxy-dev.id}"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-dev.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-dev-ingress-udp-group" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    protocol          = "udp"
+    remote_group_id   = "${openstack_networking_secgroup_v2.galaxy-dev.id}"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-dev.id}"
+}

--- a/terraform/one-offs/rabbitmq/rabbitmq.tf
+++ b/terraform/one-offs/rabbitmq/rabbitmq.tf
@@ -1,0 +1,22 @@
+# rabbitmq security group
+resource "openstack_networking_secgroup_v2" "rabbitmq" {
+    name        = "rabbitmq"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "rabbitmq-ingress-tcp-5671" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_max    = 5671
+    port_range_min    = 5671
+    protocol          = "tcp"
+    security_group_id = "${openstack_networking_secgroup_v2.rabbitmq.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "rabbitmq-ingress-udp-5671" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_max    = 5671
+    port_range_min    = 5671
+    protocol          = "udp"
+    security_group_id = "${openstack_networking_secgroup_v2.rabbitmq.id}"
+}

--- a/terraform/staging/backends.tf
+++ b/terraform/staging/backends.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "swift" {
-    container         = "terraform-state"
-    archive_container = "terraform-state-archive"
+    container         = "terraform-state-staging"
+    archive_container = "terraform-state-staging-archive"
   }
 }

--- a/terraform/staging/staging-initial.tf
+++ b/terraform/staging/staging-initial.tf
@@ -1,63 +1,63 @@
-# dev database
-resource "openstack_compute_instance_v2" "dev-db" {
-  name            = "dev-db"
+# staging database
+resource "openstack_compute_instance_v2" "staging-db" {
+  name            = "staging-db"
   image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
   flavor_name     = "m3.small"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "galaxy-dev-db"]
+  security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-staging-db.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 # application server / web server
-resource "openstack_compute_instance_v2" "dev" {
-  name            = "dev"
+resource "openstack_compute_instance_v2" "staging" {
+  name            = "staging"
   image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
-  flavor_name     = "m3.medium"
+  flavor_name     = "m3.large"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "Web-Services", "galaxy-dev", "galaxy-dev-db"]
+  security_groups = ["SSH", "Web-Services", "${openstack_networking_secgroup_v2.galaxy-staging.name}", "${openstack_networking_secgroup_v2.galaxy-staging-db.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 # slurm / rabbitMQ
-resource "openstack_compute_instance_v2" "dev-queue" {
-  name            = "dev-queue"
+resource "openstack_compute_instance_v2" "staging-queue" {
+  name            = "staging-queue"
   image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
   flavor_name     = "m3.small"
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "Web-Services", "rabbitmq", "galaxy-dev"]
+  security_groups = ["SSH", "Web-Services", "rabbitmq", "${openstack_networking_secgroup_v2.galaxy-staging.name}"]
   availability_zone = "melbourne-qh2"
 }
 
 # slurm worker
-resource "openstack_compute_instance_v2" "dev-w1" {
-  name            = "dev-w1"
+resource "openstack_compute_instance_v2" "staging-w1" {
+  name            = "staging-w1"
   image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
-  flavor_name     = "m3.medium"
+  flavor_name     = "m3.large"  # intended to be c3.xlarge
   key_pair        = "galaxy-australia"
-  security_groups = ["SSH", "galaxy-dev"]
+  security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-staging.name}"]
   availability_zone = "melbourne-qh2"
 }
 
-#pulsar test server
-resource "openstack_compute_instance_v2" "dev-pulsar" {
-  name            = "dev-pulsar"
+# pulsar test server
+resource "openstack_compute_instance_v2" "staging-pulsar" {
+  name            = "staging-pulsar"
   image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
-  flavor_name     = "m3.medium"
+  flavor_name     = "r3.large"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH"]
   availability_zone = "melbourne-qh2"
 }
 
 # Volume for application/web server
-resource "openstack_blockstorage_volume_v2" "dev-volume" {
+resource "openstack_blockstorage_volume_v2" "staging-volume" {
   availability_zone = "melbourne-qh2"
-  name        = "dev-volume"
-  description = "Galaxy Australia Dev volume"
-  size        = 200
+  name        = "staging-volume"
+  description = "Galaxy Australia Staging volume"
+  size        = 1200
 }
 
 # Attachment between application/web server and volume
-resource "openstack_compute_volume_attach_v2" "attach-dev-volume-to-dev" {
-  instance_id = "${openstack_compute_instance_v2.dev.id}"
-  volume_id   = "${openstack_blockstorage_volume_v2.dev-volume.id}"
+resource "openstack_compute_volume_attach_v2" "attach-staging-volume-to-staging" {
+  instance_id = "${openstack_compute_instance_v2.staging.id}"
+  volume_id   = "${openstack_blockstorage_volume_v2.staging-volume.id}"
 }

--- a/terraform/staging/staging-secgroups.tf
+++ b/terraform/staging/staging-secgroups.tf
@@ -1,0 +1,45 @@
+# galaxy-staging-db security group
+resource "openstack_networking_secgroup_v2" "galaxy-staging-db" {
+    description = "Security group for the galaxy australia staging server and it's own db server"
+    name        = "galaxy-staging-db"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-staging-db-ingress-staging-5432" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    port_range_max    = 5432
+    port_range_min    = 5432
+    protocol          = "tcp"
+    remote_ip_prefix  = "${openstack_compute_instance_v2.staging.network[0].fixed_ip_v4}/0"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-staging-db.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-staging-db-ingress-group" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    protocol          = "tcp"
+    remote_group_id   = "${openstack_networking_secgroup_v2.galaxy-staging-db.id}"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-staging-db.id}"
+}
+
+# galaxy-staging security group
+resource "openstack_networking_secgroup_v2" "galaxy-staging" {
+    description = "Security group for all machines in the Galaxy Australia staging server ecosystem"
+    name        = "galaxy-staging"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-staging-ingress-tcp-group" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    protocol          = "tcp"
+    remote_group_id   = "${openstack_networking_secgroup_v2.galaxy-staging.id}"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-staging.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "galaxy-staging-ingress-udp-group" {
+    direction         = "ingress"
+    ethertype         = "IPv4"
+    protocol          = "udp"
+    remote_group_id   = "${openstack_networking_secgroup_v2.galaxy-staging.id}"
+    security_group_id = "${openstack_networking_secgroup_v2.galaxy-staging.id}"
+}


### PR DESCRIPTION
Non-default rules for custom security groups have been imported and the security group configs are in dev-secgroups.tf and staging-secgroups.tf.

Due to changes in naming of images, the dev images now correspond to slightly different names in nectar ("NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]" instead of "NeCTAR Ubuntu 20.04 LTS (Focal) amd64".  We should probably store the image_id instead of image_name in our terraform configuration.

The is also `terraform/one-offs/rabbitmq` for the rabbitmq security group.  As a one-off, this does not need backends.tf, it's just for adding rabbitmq to a tenancy that does not have it yet.