### PR TITLE
create staging playbook from dev playbook and add staging host_vars file

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -9,10 +9,9 @@ pip_virtualenv_command: /usr/bin/python3 -m virtualenv # usegalaxy_eu.certbot, u
 certbot_virtualenv_package_name: python3-virtualenv    # usegalaxy_eu.certbot
 
 # Postgres
-galaxy_dev_db_user_password: "{{ vault_dev_db_user_password }}"
 postgresql_objects_users:
   - name: galaxy
-    password: "{{ galaxy_dev_db_user_password}}"
+    password: "{{ galaxy_db_user_password }}"
 postgresql_objects_databases:
   - name: galaxy
     owner: galaxy
@@ -114,6 +113,7 @@ galaxy_config:
     admin_users: "{{ __galaxy_config['galaxy']['admin_users']}}"
     brand: "{{ __galaxy_config['galaxy']['brand']}}"
     database_connection: "{{ __galaxy_config['galaxy']['database_connection']}}"
+    id_secret: "{{ __galaxy_config['galaxy']['id_secret']}}"
 
     allow_user_impersonation: true
     allow_user_deletion: true
@@ -187,7 +187,6 @@ galaxy_config:
     # template_cache_path: /mnt/galaxy-app/database/template_cache
 
     # whoosh_index_dir: /mnt/galaxy-app/database/whoosh_cache
-    # id_secret: ....  # this is a hexadecimal in production config, if we use this we could encrypt it
     # openid_config_file: /mnt/galaxy-app/config/openid_conf.xml.sample
     # openid_consumer_cache_path: /mnt/galaxy-app/database/openid_consumer_cache
     # object_store_cache_path: /mnt/galaxy-app/database/object_store_cache

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -1,13 +1,13 @@
-# Specific settings for galaxy dev application/web server
+# Specific settings for galaxy staging application/web server
 
-galaxy_db_user_password: "{{ vault_dev_db_user_password }}"
+galaxy_db_user_password: "{{ vault_staging_db_user_password }}"
 
 __galaxy_config:
   galaxy:
-    admin_users: "{{ machine_users | selectattr('email', 'defined') | map(attribute='email') | join(',') }}" # everyone is an admin on dev
-    brand: "Australia Dev"
-    database_connection: "postgres://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
-    id_secret: "{{ vault_dev_id_secret }}"
+    admin_users: "{{ machine_users | selectattr('email', 'defined') | map(attribute='email') | join(',') }}" # everyone is an admin on staging: # TODO: update this
+    brand: "Australia Staging"
+    database_connection: "postgres://galaxy:{{ vault_staging_db_user_password }}@staging-db.usegalaxy.org.au:5432/galaxy"
+    id_secret: "{{ vault_staging_id_secret }}"
 
 # NFS stuff
 nfs_exports:
@@ -27,8 +27,8 @@ galaxy_jobconf:
       - id: pulsar_au_01
         load: galaxy.jobs.runners.pulsar:PulsarMQJobRunner
         params:
-            amqp_url: "pyamqp://galaxy_au:{{ vault_rabbitmq_password_galaxy_au_dev }}@dev-queue.usegalaxy.org.au:5671//pulsar/galaxy_au?ssl=1"
-            galaxy_url: "https://dev.usegalaxy.org.au"
+            amqp_url: "pyamqp://galaxy_au:{{ vault_rabbitmq_password_galaxy_au_staging }}@staging-queue.usegalaxy.org.au:5671//pulsar/galaxy_au?ssl=1"
+            galaxy_url: "https://staging.usegalaxy.org.au"
             manager: _default_
             amqp_acknowledge: True
             amqp_ack_republish_time: 300
@@ -58,13 +58,6 @@ galaxy_jobconf:
               rewrite_parameters: "true"
               persistence_directory: /mnt/pulsar/files/persisted_data
               submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2"
-    tools:
-      - id: upload1
-        destination: slurm_dest
-      - id: toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/1.0.1
-        destination: pulsar_destination
-      - id: toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1
-        destination: pulsar_destination
     limits:
       #General limits for user submission
       - type: anonymous_user_concurrent_jobs

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -1,0 +1,56 @@
+- hosts: staging_galaxy_server
+  become: true
+  vars_files:
+      - group_vars/all.yml
+      - group_vars/VAULT
+      - group_vars/galaxyservers.yml
+      - group_vars/staging_slurm.yml
+      - host_vars/staging.usegalaxy.org.au.yml
+  pre_tasks:
+    - name: Attach volume to instance
+      # If this script is being run for the first time, review the value of galaxyserver_attached_volume_device in group_vars
+      block: # TODO: This is pretty generic code for attaching a volume to a device and should probably live in another file to be reused
+        - name: Detect attached volume
+          parted:
+            device: "{{ galaxyserver_attached_volume_device }}"
+            unit: GiB
+          register: volume_info
+        - name: Create a filesystem on volume
+          filesystem:
+            fstype: "{{ galaxyserver_attached_volume_fstype }}"
+            dev: "{{ galaxyserver_attached_volume_device }}"
+          when: volume_info.disk is defined and volume_info.disk.dev is defined and volume_info.disk.dev == galaxyserver_attached_volume_device
+        - name: Mount volume
+          mount:
+            path: "{{ galaxyserver_attached_volume_path }}"
+            src: "{{ galaxyserver_attached_volume_device }}"
+            fstype: "{{ galaxyserver_attached_volume_fstype }}"
+            state: mounted
+      when: galaxyserver_attached_volume_device is defined
+  handlers:
+    - name: Restart Galaxy
+      systemd:
+        name: galaxy
+        state: restarted
+  roles:
+    - galaxyproject.repos
+    - common
+    - galaxyproject.postgresql
+    - role: natefoo.postgresql_objects
+      become: true
+      become_user: postgres
+    - geerlingguy.pip
+    - galaxyproject.galaxy
+    - usegalaxy_eu.galaxy_systemd
+    - galaxyproject.nginx
+    - geerlingguy.nfs
+    - galaxyproject.slurm
+    - galaxyproject.cvmfs
+  post_tasks:
+    - name: Install slurm-drmaa
+      package:
+        name: slurm-drmaa1
+    - name: Reload exportfs
+      command: exportfs -ra
+      become: yes
+      become_user: root


### PR DESCRIPTION
This is a WIP, there is an assumption of a file called `group_vars/staging_slurm.yml` and I couldn't remember whether we needed the group vars for slurm to be divided into dev/staging/prod

There are opportunities to refactor things in galaxyservers.yml that will not be the same for all servers, i.e. uwsgi settings but am leaving it as is for now

This is mostly copy/paste with 'staging' in place of 'dev'.  The job_conf is the same but with the tools section removed.