### PR TITLE
set pulsar_pycurl_ssl_library to openssl

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -50,6 +50,7 @@ pulsar_persistence_dir: /mnt/pulsar/files/persistent_data
 pulsar_dependencies_dir: /mnt/pulsar/deps
 
 pulsar_pip_install: true
+pulsar_pycurl_ssl_library: openssl
 pulsar_systemd: true
 pulsar_systemd_runner: webless
 


### PR DESCRIPTION
On dev pulsar jobs were not running because 'import pycurl' threw an exception.  Using this variable sets the pycurl backend correctly (the default from the role is gnutls for Debian)