### PR TITLE
Dynamic job rules for dev and staging

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
@@ -11,13 +11,15 @@ from random import sample
 TOOL_DESTINATION_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tool_destinations.yml')
 
 
-def gateway(job, app, tool, user):
+def gateway(job, app, tool, user_email):
     """
     Function to specify the destination for a job.  At present this is exactly the same
     as using dynamic_dtd with tool_destinations.yml but can be extended to more complex
     mapping such as limiting resources based on user group or selecting destinations
-    based on queue size
+    based on queue size.
+    Arguments to this function can include app, job, job_id, job_wrapper, tool, tool_id,
+    user, user_email (see https://docs.galaxyproject.org/en/latest/admin/jobs.html)
     """
-    destination = map_tool_to_destination(job, app, tool, user.email, path=TOOL_DESTINATION_PATH)
+    destination = map_tool_to_destination(job, app, tool, user_email, path=TOOL_DESTINATION_PATH)
     return destination
 

--- a/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import os
+
+# from galaxy.jobs import JobDestination
+# from galaxy.jobs.mapper import JobMappingException
+
+from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination
+from random import sample
+
+TOOL_DESTINATION_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tool_destinations.yml')
+
+
+def gateway(job, app, tool, user):
+    """
+    Function to specify the destination for a job.  At present this is exactly the same
+    as using dynamic_dtd with tool_destinations.yml but can be extended to more complex
+    mapping such as limiting resources based on user group or selecting destinations
+    based on queue size
+    """
+    destination = map_tool_to_destination(job, app, tool, user.email, path=TOOL_DESTINATION_PATH)
+    return destination
+

--- a/files/galaxy/dynamic_job_rules/dev/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/dev/dynamic_rules/tool_destinations.yml
@@ -1,0 +1,10 @@
+tools:
+  upload1:
+    default_destination: slurm_dest
+  fasta-stats:
+    default_destination: pulsar_destination
+  bwa_mem:
+    default_destination: pulsar_destination
+default_destination: slurm_dest
+
+verbose: True

--- a/files/galaxy/dynamic_job_rules/dev/readme.txt
+++ b/files/galaxy/dynamic_job_rules/dev/readme.txt
@@ -1,0 +1,9 @@
+Arbitrary file to live below the dynamic job rules module.  Copied from 
+usegalaxy-eu/infrastructure-playbook's dynamic rules setup:
+
+Rules need to go in subdir otherwise can't be added to galaxy path because
+galaxy path demands it is in a submodule
+
+This file is necessary so the role detects the parent dir to mark for adding
+__init__.py
+

--- a/files/galaxy/dynamic_job_rules/staging/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/staging/dynamic_rules/destination_mapper.py
@@ -11,13 +11,15 @@ from random import sample
 TOOL_DESTINATION_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tool_destinations.yml')
 
 
-def gateway(job, app, tool, user):
+def gateway(job, app, tool, user_email):
     """
     Function to specify the destination for a job.  At present this is exactly the same
     as using dynamic_dtd with tool_destinations.yml but can be extended to more complex
     mapping such as limiting resources based on user group or selecting destinations
-    based on queue size
+    based on queue size.
+    Arguments to this function can include app, job, job_id, job_wrapper, tool, tool_id,
+    user, user_email (see https://docs.galaxyproject.org/en/latest/admin/jobs.html)
     """
-    destination = map_tool_to_destination(job, app, tool, user.email, path=TOOL_DESTINATION_PATH)
+    destination = map_tool_to_destination(job, app, tool, user_email, path=TOOL_DESTINATION_PATH)
     return destination
 

--- a/files/galaxy/dynamic_job_rules/staging/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/staging/dynamic_rules/destination_mapper.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import os
+
+# from galaxy.jobs import JobDestination
+# from galaxy.jobs.mapper import JobMappingException
+
+from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination
+from random import sample
+
+TOOL_DESTINATION_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tool_destinations.yml')
+
+
+def gateway(job, app, tool, user):
+    """
+    Function to specify the destination for a job.  At present this is exactly the same
+    as using dynamic_dtd with tool_destinations.yml but can be extended to more complex
+    mapping such as limiting resources based on user group or selecting destinations
+    based on queue size
+    """
+    destination = map_tool_to_destination(job, app, tool, user.email, path=TOOL_DESTINATION_PATH)
+    return destination
+

--- a/files/galaxy/dynamic_job_rules/staging/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/staging/dynamic_rules/tool_destinations.yml
@@ -1,0 +1,6 @@
+tools:
+  upload1:
+    default_destination: slurm_dest
+default_destination: slurm_dest
+
+verbose: True

--- a/files/galaxy/dynamic_job_rules/staging/readme.txt
+++ b/files/galaxy/dynamic_job_rules/staging/readme.txt
@@ -1,0 +1,9 @@
+Arbitrary file to live below the dynamic job rules module.  Copied from 
+usegalaxy-eu/infrastructure-playbook's dynamic rules setup:
+
+Rules need to go in subdir otherwise can't be added to galaxy path because
+galaxy path demands it is in a submodule
+
+This file is necessary so the role detects the parent dir to mark for adding
+__init__.py
+

--- a/files/galaxyservers/static/welcome.html
+++ b/files/galaxyservers/static/welcome.html
@@ -1,9 +1,0 @@
-<!-- <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"> -->
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-</head>
-<body>
-    <iframe src="https://usegalaxy-au.github.io/galaxy/" style="width: 100%; height: 100%; border: 0; top: 0; left: 0; position: absolute"></iframe>
-</body>
-</html>

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -2,6 +2,14 @@
 
 galaxy_db_user_password: "{{ vault_dev_db_user_password }}"
 
+# ansible-galaxy
+galaxy_dynamic_job_rules_src_dir: files/galaxy/dynamic_job_rules/dev
+galaxy_dynamic_job_rules_dir: "{{ galaxy_root }}/dynamic_job_rules"
+galaxy_dynamic_job_rules:
+  - dynamic_rules/destination_mapper.py
+  - dynamic_rules/tool_destinations.yml
+  - readme.txt
+
 __galaxy_config:
   galaxy:
     admin_users: "{{ machine_users | selectattr('email', 'defined') | map(attribute='email') | join(',') }}" # everyone is an admin on dev
@@ -19,6 +27,9 @@ galaxy_jobconf:
     handlers:
         count: "{{ galaxy_handler_count }}"
     plugins:
+      - id: dynamic
+        params:
+          rules_module: dynamic_rules
       - id: local
         load: galaxy.jobs.runners.local:LocalJobRunner
         workers: 4
@@ -35,10 +46,15 @@ galaxy_jobconf:
             amqp_consumer_timeout: 2.0
             amqp_publish_retry: True
             amqp_publish_retry_max_retries: 60
-    default_destination: "slurm_dest"
+    default_destination: gateway
     destinations:
       - id: local
         runner: local
+      - id: gateway
+        runner: dynamic
+        params:
+            type: python
+            function: gateway
       - id: dynamic_dtd
         runner: dynamic
         params:
@@ -58,13 +74,6 @@ galaxy_jobconf:
               rewrite_parameters: "true"
               persistence_directory: /mnt/pulsar/files/persisted_data
               submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2"
-    tools:
-      - id: upload1
-        destination: slurm_dest
-      - id: toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/1.0.1
-        destination: pulsar_destination
-      - id: toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1
-        destination: pulsar_destination
     limits:
       #General limits for user submission
       - type: anonymous_user_concurrent_jobs

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -13,6 +13,14 @@ __galaxy_config:
 nfs_exports:
     - "{{ galaxy_root }}  *(rw,async,no_root_squash,no_subtree_check)"
 
+# ansible-galaxy
+galaxy_dynamic_job_rules_src_dir: files/galaxy/dynamic_job_rules/staging
+galaxy_dynamic_job_rules_dir: "{{ galaxy_root }}/dynamic_job_rules"
+galaxy_dynamic_job_rules:
+  - dynamic_rules/destination_mapper.py
+  - dynamic_rules/tool_destinations.yml
+  - readme.txt
+
 #Galaxy Job Conf
 galaxy_jobconf:
     plugin_workers: 4
@@ -22,6 +30,9 @@ galaxy_jobconf:
       - id: local
         load: galaxy.jobs.runners.local:LocalJobRunner
         workers: 4
+      - id: dynamic
+        params:
+          rules_module: dynamic_rules
       - id: slurm
         load: galaxy.jobs.runners.slurm:SlurmJobRunner
       - id: pulsar_au_01
@@ -35,10 +46,15 @@ galaxy_jobconf:
             amqp_consumer_timeout: 2.0
             amqp_publish_retry: True
             amqp_publish_retry_max_retries: 60
-    default_destination: "slurm_dest"
+    default_destination: gateway
     destinations:
       - id: local
         runner: local
+      - id: gateway
+        runner: dynamic
+        params:
+            type: python
+            function: gateway
       - id: dynamic_dtd
         runner: dynamic
         params:


### PR DESCRIPTION
Modules with functions that call galaxy's `map_tool_to_destination` using a tool_destinations.yml file.  These are equivalent to using dynamic_dtd with the tool_destionations.yml file but can be extended to do things like limiting resources to a group or choosing destinations based on queue sizes while still defaulting to the destination chosen by `map_tool_to_destination`.

This has the [WIP] label - it still needs to be tested on staging.