### PR TITLE
add tool_sheds_conf.xml allowing tools from test toolshed

### DIFF
--- a/files/galaxy/config/tool_sheds_conf.xml
+++ b/files/galaxy/config/tool_sheds_conf.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_sheds>
+    <tool_shed name="Galaxy Main Tool Shed" url="https://toolshed.g2.bx.psu.edu/"/>
+    <tool_shed name="Galaxy Test Tool Shed" url="https://testtoolshed.g2.bx.psu.edu/"/>
+</tool_sheds>
+

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -157,6 +157,7 @@ galaxy_config:
     tool_dependency_dir: "{{ galaxy_root }}/tools"
 
     job_config_file: "{{ galaxy_config_dir }}/job_conf.xml"
+    tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
 
     tool_data_table_config_path:
       - /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml
@@ -173,7 +174,6 @@ galaxy_config:
     # galaxy_data_manager_data_path: /mnt/galaxy/custom-indices
     # builds_file_path: /cvmfs/data.galaxyproject.org/managed/location/builds.txt
     # shed_tool_data_table_config: /mnt/galaxy/var/shed_tool_data_table_conf.xml
-    # tool_sheds_config_file: /mnt/galaxy-app/config/tool_sheds_conf.xml
     # datatypes_config_file: /mnt/galaxy-app/config/datatypes_conf.xml
 
     # shed_tool_data_path: /mnt/galaxy/custom-indices/tool-data/shed_tool_data
@@ -228,6 +228,10 @@ galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/job_conf.xml.j2"
     dest: "{{ galaxy_config_dir}}/job_conf.xml"
 
+galaxy_config_file_src_dir: files/galaxy
+galaxy_config_files:
+  - src: "{{ galaxy_config_file_src_dir }}/config/tool_sheds_conf.xml"
+    dest: "{{ galaxy_config['galaxy']['tool_sheds_config_file'] }}"
 
 #Slurm client
 slurm_roles: ['exec']


### PR DESCRIPTION
A few of the tools on production are from the test toolshed.  To allow these on the new galaxy we need to allow installations from testtoolshed.