### PR TITLE
comment out enable_tool_recommendations

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -124,7 +124,7 @@ galaxy_config:
     enable_quotas: true
     enable_job_recovery: true
     outputs_to_working_directory: false
-    enable_tool_recommendations: true
+    # enable_tool_recommendations: true  # this config option causes an error when installing galaxy dependencies, skip it for now
 
     static_enabled: true
     show_welcome_with_login: true


### PR DESCRIPTION
If `enable_tool_recommendations` is true, galaxy detects extra dependencies that need to be installed but these cannot be installed.   It's not clear whether this is a bug in ansible-galaxy, galaxy or our setup.  Leave out this config option for now.