### PR TITLE
fix data table loading order

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -178,6 +178,7 @@ galaxy_config:
     tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data"
 
     tool_data_table_config_path:
+      - "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml"
       - /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml
       - /cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
 


### PR DESCRIPTION
Put shed_tool_data_table_conf.xml before the cvmfs data tables in tool_data_table_config_path so that Minikraken will be first on the list for kraken_databases.