### PR TITLE
 tool destination rules from galaxy production

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -1,80 +1,1301 @@
+
 tools:
-  bwa_mem:
-    default_destination: pulsar-mel_big
-  canu:
-      default_destination: slurm_32slots  # pulsar-mel3_big_canu on galaxy prod qld
-  fasta-stats:
-    default_destination: slurm_1slot
-  fastp:
-    default_destination: slurm_5slots
-  ivar_consensus:
-    default_destination: slurm_5slots
-  ivar_filtervariants:
-    default_destination: slurm_5slots
-  ivar_getmasked:
-    default_destination: slurm_5slots
-  ivar_removereads:
-    default_destination: slurm_5slots
-  ivar_trim:
-    default_destination: slurm_5slots
-  ivar_variants:
-    default_destination: slurm_5slots
-  lofreq_indelqual:
-    default_destination: slurm_5slots
-  lofreq_viterbi:
-    default_destination: slurm_5slots
-  prokka:
-    default_destination: pulsar-mel_big
-  samtools_view: 
-    default_destination: slurm_5slots
-  spades:
-    rules:
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 0
-        upper_bound: 15 MB
-        destination: slurm_1slot
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 15 MB
-        upper_bound: 2 GB
-        destination: slurm_3slots
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 2 GB
-        upper_bound: 20 GB
-        destination: slurm_16slots # pulsar-mel3_big on galaxy prod qld
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 20 GB
-        upper_bound: Infinity
-        fail_message: Too much data, please don't use Spades for this
-        destination: fail
-    default_destination: slurm_5slots
-  trinotate:
-    default_destination: slurm_16slots
-  unicycler:
-    rules:
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 0
-        upper_bound: 200 MB
-        destination: slurm_1slot
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 200 MB
-        upper_bound: 2 GB
-        destination: slurm_9slots # pulsar-mel3_mid on galaxy prod qld
-      - rule_type: file_size
-        nice_value: 0
-        lower_bound: 2 GB
-        upper_bound: 60 GB
-        destination: slurm_16slots # pulsar-mel3_big on galaxy prod qld
-    default_destination: slurm_16slots
-  upload1:
-    default_destination: slurm_1slot_upload
-  zip_collection:
-    default_destination: slurm_2slots
-default_destination: slurm_2slots
+    upload1:
+        default_destination: slurm_1slot_upload
+    shovill:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 15 MB
+            destination: slurm_1slot
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 15 MB
+            upper_bound: 2 GB
+            destination: slurm_7slots
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 2 GB
+            upper_bound: 10 GB
+            destination: pulsar-mel3_big
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 10 GB
+            upper_bound: Infinity
+            fail_message: Too much data, shoudn't run
+            destination: fail
+        default_destination: slurm_5slots
+    spades:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 15 MB
+            destination: slurm_1slot
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 15 MB
+            upper_bound: 2 GB
+            destination: slurm_3slots
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 2 GB
+            upper_bound: 20 GB
+            destination: pulsar-mel3_big
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 20 GB
+            upper_bound: Infinity
+            fail_message: Too much data, please don't use Spades for this
+            destination: fail
+        default_destination: slurm_5slots
+    metaspades:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 50 MB
+            destination: slurm_1slot
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 50 MB
+            upper_bound: 1 GB
+            destination: pulsar-mel3_mid
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 1 GB
+            upper_bound: 20 GB
+            destination: pulsar-mel3_big
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 20 GB
+            upper_bound: 60 GB
+            destination: pulsar-mel3_big
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 60 GB
+            upper_bound: Infinity
+            fail_message: Too much data, please don't use Spades for this
+            destination: fail
+        default_destination: slurm_5slots
+    velvet:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 15 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 15 MB
+              upper_bound: 1 GB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, please don't use Velvet for this, it is here for training purposes only
+        default_destination: slurm_5slots
+    velvetoptimiser:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 15 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 15 MB
+              upper_bound: 1 GB
+              destination: slurm_3slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, please don't use the Velvet Optimiser for this, it is here only for training purposes with small (< 1 GB) datasets. Use SPAdes instead.
+        default_destination: slurm_1slot
+    trinity:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: pulsar-mel3_big
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 100 MB
+              upper_bound: 30 GB
+              destination: pulsar-mel3_big_trinity
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 30 GB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, we cannot support such large Trinity assemblies with our backend. Please use another server for your job.
+        default_destination: pulsar-mel3_big_trinity
+    trinity_align_and_estimate_abundance:
+        default_destination: pulsar-mel3_big_trinity
+    ggplot2_point:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    datamash_ops:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    Grouping1:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    tp_sorted_uniq:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    Cut1:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    Remove beginning1:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    cshl_fastq_quality_filter:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+        default_destination: slurm_1slot
+    trim_galore:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 200 MB
+              destination: slurm_3slots
+        default_destination: slurm_5slots
+    prokka:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 1 MB
+            destination: pulsar-mel_small
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 1 MB
+            upper_bound: 10 MB
+            destination: pulsar-mel_big
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 10 MB
+            upper_bound: 30 MB
+            destination: pulsar-mel3_mid
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 30 MB
+            upper_bound: Infinity
+            destination: fail
+            fail_message: Too much data, Prokka is designed to annotate bacterial/virus genomes only. Prokka will not annotate eukaryotic genomes nor metagenomes.
+        default_destination: slurm_7slots
+    fastp:
+        default_destination: slurm_5slots
+    samtool_filter2:
+        default_destination: slurm_3slots
+    lastz_wrapper_2:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 1 MB
+            destination: pulsar-mel3_small
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 1 MB
+            upper_bound: 1 GB
+            destination: pulsar-mel3_mid
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 1 GB
+            upper_bound: 20 GB
+            destination: pulsar-mel3_big
+        default_destination: slurm_5slots
+    hyphy_gard:
+        default_destination: slurm_32slots
+    hyphy_absrel:
+        default_destination: slurm_16slots
+    maxquant:
+        default_destination: pulsar-mel3_big
+    fasterq_dump:
+        default_destination: slurm_3slots
+    fastq_dump:
+        default_destination: slurm_3slots
+    sam_dump:
+        default_destination: slurm_3slots
+    raxml:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 10 KB
+            destination: slurm_1slot
+        default_destination: pulsar-mel3_big
+    canu:
+        default_destination: pulsar-mel3_big_canu
+    poretools_events:
+        default_destination: slurm_3slots
+    poretools_extract:
+        default_destination: slurm_3slots
+    poretools_hist:
+        default_destination: slurm_3slots
+    poretools_nucdist:
+        default_destination: slurm_3slots
+    poretools_occupancy:
+        default_destination: slurm_3slots
+    poretools_qualdist:
+        default_destination: slurm_3slots
+    poretools_qualpos:
+        default_destination: slurm_3slots
+    poretools_squiggle:
+        default_destination: slurm_3slots
+    poretools_stats:
+        default_destination: slurm_3slots
+    poretools_tabular:
+        default_destination: slurm_3slots
+    poretools_times:
+        default_destination: slurm_3slots
+    poretools_winner:
+        default_destination: slurm_3slots
+    poretools_yield_plot:
+        default_destination: slurm_3slots
+    nanopolish_variants:
+        default_destination: slurm_3slots
+    nanopolish_methylation:
+        default_destination: slurm_3slots
+    nanopolish_eventalign:
+        default_destination: slurm_3slots
+    nanopolish_polya:
+        default_destination: slurm_3slots
+    nanoplot:
+        default_destination: slurm_3slots
+    porechop:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 5 GB
+              upper_bound: Infinity
+              destination: slurm_9slots
+        default_destination: slurm_3slots
+    barrnap:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 300 KB
+              destination: slurm_1slot
+        default_destination: slurm_3slots
+    busco:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 50 MB
+              destination: slurm_1slot
+        default_destination: slurm_3slots
+    circos:
+        default_destination: slurm_1slot
+    fastqc:
+        rules:
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 0
+            upper_bound: 10 MB
+            destination: slurm_1slot
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 10 MB
+            upper_bound: 2 GB
+            destination: slurm_3slots
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 2 GB
+            upper_bound: 5 GB
+            destination: slurm_3slots
+          - rule_type: file_size
+            nice_value: 0
+            lower_bound: 5 GB
+            upper_bound: Infinity
+            destination: slurm_5slots
+        default_destination: slurm_3slots
+    iuc_pear:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 15 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 15 MB
+              upper_bound: 1 GB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: Infinity
+              destination: slurm_7slots
+        default_destination: slurm_5slots
+    trimmomatic:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 15 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 15 MB
+              upper_bound: 3 GB
+              destination: slurm_3slots
+        default_destination: slurm_3slots
+    abricate:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 5 MB
+              destination: pulsar-mel_small
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 5 MB
+              upper_bound: 20 MB
+              destination: slurm_3slots
+        default_destination: slurm_3slots
+    snippy:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 15 MB
+              destination: slurm_1slot
+        default_destination: slurm_5slots
+    bwa:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 250 MB
+              destination: pulsar-mel_small
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 250 MB
+              upper_bound: 1 GB
+              destination: slurm_3slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: 10 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    bwa_mem:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 250 MB
+              destination: pulsar-mel_small
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 250 MB
+              upper_bound: 1 GB
+              destination: pulsar-mel_mid
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: 10 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    bowtie2:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 100 MB
+              upper_bound: 9 GB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 9 GB
+              upper_bound: Infinity
+              destination: slurm_7slots
+        default_destination: slurm_5slots
+    hisat2:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: 3 GB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 3 GB
+              upper_bound: 20 GB
+              destination: slurm_7slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 GB
+              upper_bound: Infinity
+              destination: slurm_16slots
+        default_destination: slurm_5slots
+    tophat2:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: 20 GB
+              destination: pulsar-mel3_mid
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 GB
+              upper_bound: Infinity
+              destination: slurm_7slots
+        default_destination: slurm_5slots
+    freebayes:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 200 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 200 MB
+              upper_bound: 4 GB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 4 GB
+              upper_bound: 20 GB
+              destination: slurm_9slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 GB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, please don't use the FreeBayes for this
+        default_destination: slurm_7slots
+    bcftools_mpileup:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: 10 GB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 10 GB
+              upper_bound: Infinity
+              destination: slurm_7slots
+        default_destination: slurm_7slots
+    lofreq_call:
+        default_destination: slurm_5slots
+    lofreq_indelqual:
+        default_destination: slurm_3slots
+    qualimap_bamqc:
+        default_destination: slurm_5slots
+    multiqc:
+        default_destination: slurm_3slots
+    lofreq_filter:
+        default_destination: pulsar-paw_mid
+    lofreq_viterbi:
+        default_destination: pulsar-paw_mid
+
+    htseq_count:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 200 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 200 MB
+              upper_bound: 10 GB
+              destination: pulsar-mel3_mid
+        default_destination: slurm_9slots
+    deseq2:
+        default_destination: slurm_3slots
+    circos_bundlelinks:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 200 KB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 200 KB
+              upper_bound: 10 MB
+              destination: slurm_2slots
+        default_destination: slurm_5slots
+    generate_count_matrix:
+        default_destination: slurm_2slots
+    join1:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 10 GB
+              upper_bound: Infinity
+              destination: slurm_5slots
+        default_destination: slurm_2slots
+    fastq_groomer:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 100 MB
+              upper_bound: 20 GB
+              destination: pulsar-mel3_small
+        default_destination: slurm_2slots
+    iqtree:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 KB
+              destination: slurm_1slot
+        default_destination: slurm_5slots
+    picard_SamToFastq:
+        default_destination: slurm_5slots
+    edger:
+        default_destination: slurm_5slots
+    pilon:
+        default_destination: slurm_5slots
+    fml_gtf2gff:
+        default_destination: slurm_3slots
+    wig_to_bigWig:
+        default_destination: slurm_5slots
+    gops_join_1:
+        default_destination: slurm_5slots
+    sam_merge2:
+        default_destination: slurm_3slots
+    Extract genomic DNA 1:
+        default_destination: slurm_3slots
+    snpEff:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_3slots
+        default_destination: slurm_3slots
+    snpSift_annotate:
+        default_destination: slurm_3slots
+    gemini_load:
+        default_destination: slurm_3slots
+    ncbi_makeblastdb:
+        default_destination: slurm_5slots
+    bcftools_norm:    
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 MB
+              destination: slurm_1slot
+        default_destination: slurm_2slots
+    samtools_rmdup:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: 10 GB
+              destination: pulsar-mel3_small
+        default_destination: slurm_2slots
+    cuffmerge:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 10
+              lower_bound: 100 MB
+              upper_bound: Infinity
+              destination: slurm_3slots
+        default_destination: slurm_3slots
+    cufflinks:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 10
+              lower_bound: 100 MB
+              upper_bound: 4 GB
+              destination: slurm_3slots
+            - rule_type: file_size
+              nice_value: 10
+              lower_bound: 4 GB
+              upper_bound: Infinity
+              destination: slurm_5slots
+        default_destination: slurm_5slots
+    velveth:
+        default_destination: slurm_2slots
+    velvetg:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_2slots
+        default_destination: slurm_5slots
+    fastq_paired_end_interlacer:    
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 1 GB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: 20 GB
+              destination: pulsar-mel3_mid
+        default_destination: slurm_5slots
+    fastq_paired_end_deinterlacer:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 1 GB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: 20 GB
+              destination: pulsar-mel3_mid
+        default_destination: slurm_5slots
+    deeptools_compute_matrix:
+        default_destination: slurm_9slots
+    deeptools_plot_heatmap:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 300 MB
+              upper_bound: 10 GB
+              destination: slurm_7slots
+        default_destination: slurm_3slots
+    deeptools_bam_coverage:
+        default_destination: slurm_7slots
+    deeptools_bam_compare:
+        default_destination: slurm_9slots
+    htseqsams2mxlocal:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 150 MB
+              destination: slurm_2slots
+        default_destination: slurm_3slots
+    cuffdiff:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 200 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 200 MB
+              upper_bound: 4 GB
+              destination: slurm_3slots
+        default_destination: slurm_5slots
+    cuffnorm:
+        default_destination: slurm_5slots
+    stringtie:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 200 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 200 MB
+              upper_bound: 2 GB
+              destination: slurm_3slots
+        default_destination: slurm_5slots
+    stringtie_merge:
+        default_destination: slurm_1slot
+    gatk2_unified_genotyper:
+        default_destination: slurm_5slots
+    rsem_calculate_expression:
+        default_destination: slurm_5slots
+    macs2_1_peakcalling:
+        default_destination: slurm_9slots
+    macs2_callpeak:
+        default_destination: slurm_9slots
+    macs2_bdgdiff:
+        default_destination: slurm_5slots
+    gatk2_variant_recalibrator:
+        default_destination: slurm_5slots
+    gatk2_unified_genotyper:
+        default_destination: slurm_5slots
+    gatk2_print_reads:
+        default_destination: slurm_5slots
+    gatk2_indel_realigner:
+        default_destination: slurm_5slots
+    gatk2_variant_eval:
+        default_destination: slurm_5slots
+    gatk2_haplotype_caller:
+        default_destination: slurm_5slots
+    gatk2_variant_validate:
+        default_destination: slurm_5slots
+    gatk2_reduce_reads:
+        default_destination: slurm_5slots
+    gatk2_realigner_target_creator:
+        default_destination: slurm_5slots
+    gatk2_depth_of_coverage:
+        default_destination: slurm_5slots
+    gatk2_variant_apply_recalibration:
+        default_destination: slurm_5slots
+    gatk2_variant_filtration:
+        default_destination: slurm_5slots
+    gatk2_base_recalibrator:
+        default_destination: slurm_5slots
+    gatk2_variant_combine:
+        default_destination: slurm_5slots
+    gatk2_variant_select:
+        default_destination: slurm_5slots
+    gatk2_variant_annotator:
+        default_destination: slurm_5slots
+    ncbi_blastn_wrapper:
+        default_destination: slurm_5slots
+    ncbi_blastp_wrapper:
+        default_destination: slurm_5slots
+    kraken:
+        rules:
+            - rule_type: arguments
+              nice_value: -19
+              destination: fail
+              fail_message: Please use mini-kraken database, or Kraken2 tool for the full size database
+              arguments:
+                  kraken_database: bacteria
+        default_destination: slurm_5slots
+    kraken2:
+        rules:
+            - rule_type: arguments
+              nice_value: 0
+              destination: slurm_16slots
+              arguments:
+                  kraken2_database: "2020-02-04T223652Z_standard_kmer-len_35_minimizer-len_31_minimizer-spaces_6"
+            - rule_type: arguments
+              nice_value: 0
+              destination: slurm_5slots
+              arguments:
+                  kraken2_database: "2020-02-05T235531Z_minikraken2_v2_8GB"
+        default_destination: slurm_16slots
+    kraken2_build_database:
+        default_destination: slurm_16slots
+    minimap2:
+        default_destination: pulsar-mel3_big
+    kallisto_quant:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: slurm_2slots
+        default_destination: slurm_5slots
+    samtools_mpileup:
+        default_destination: slurm_5slots
+    gubbins:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 KB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 KB
+              upper_bound: 500 MB
+              destination: slurm_16slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, please don't use the gubbins for this.
+        default_destination: slurm_5slots
+    rbc_mafft:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 KB
+              destination: pulsar-mel3_small
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 KB
+              upper_bound: 500 MB
+              destination: pulsar-mel3_big
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, please don't use MAFFT for this.
+        default_destination: slurm_5slots
+    salmon:
+        default_destination: slurm_5slots
+    dexseq:
+        default_destination: slurm_9slots
+    dexseq_count:
+        default_destination: slurm_5slots
+    ggplot2_heatmap2:
+        default_destination: slurm_2slots
+    jbrowse:
+        default_destination: slurm_3slots
+    wig_to_bigWig:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 1 GB
+              destination: slurm_3slots
+        default_destination: slurm_5slots
+    fastq_paired_end_joiner:
+        default_destination: slurm_3slots
+    tabular_to_csv:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 1 GB
+              upper_bound: Infinity
+              destination: slurm_3slots
+        default_destination: slurm_1slot
+    repenrich:
+        default_destination: slurm_7slots
+    unicycler:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 200 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 200 MB
+              upper_bound: 2 GB
+              destination: pulsar-mel3_mid
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 2 GB
+              upper_bound: 60 GB
+              destination: pulsar-mel3_big
+        default_destination: slurm_16slots
+    megahit:
+        default_destination: slurm_9slots
+    rna_star:
+        default_destination: slurm_9slots
+    rna_starsolo:
+        default_destination: slurm_9slots
+    rna_star_index_builder_data_manager:
+        default_destination: slurm_32slots
+    roary:
+        default_destination: slurm_7slots
+    rseqc_RPKM_saturation:
+        default_destination: slurm_9slots
+    rseqc_geneBody_coverage:
+        default_destination: slurm_5slots
+    rseqc_geneBody_coverage2:
+        default_destination: slurm_5slots
+    rseqc_read_distribution:
+        default_destination: slurm_5slots
+    cutadapt:
+        default_destination: slurm_5slots
+    ncbi_blastx_wrapper:
+        default_destination: slurm_16slots
+    ncbi_tblastn_wrapper:
+        default_destination: slurm_16slots
+    ncbi_tblastx_wrapper:
+        default_destination: slurm_16slots
+    mira_4_0_mapping:
+        default_destination: slurm_16slots
+    mira_4_0_bait:
+        default_destination: slurm_16slots
+    mira_4_0_de_novo:
+        default_destination: slurm_16slots
+    phyloseq_nmds:
+        default_destination: slurm_16slots
+    phyloseq_ordinate:
+        default_destination: slurm_16slots
+    biom_filter:
+        default_destination: slurm_16slots
+    fasta-stats:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 10 MB
+              destination: slurm_1slot
+        default_destination: slurm_3slots
+    ivar_trim:
+        default_destination: pulsar-paw_big
+    ivar_variants:
+        default_destination: pulsar-paw_big
+    ivar_consensus:
+        default_destination: pulsar-paw_big
+    #
+    # Mothur tools
+    #
+    mothur_merge_files:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_3slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_make_group:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_dist_shared:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 2 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 2 MB
+              upper_bound: 5 MB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_unique_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_count_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_summary_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_screen_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_align_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_filter_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_pre_cluster:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_classify_seqs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_cluster_split:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_2slots
+        default_destination: pulsar-mel3_mid
+    mothur_make_shared:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_classify_otu:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_make_contigs:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_chimera_vsearch:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_2slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    mothur_taxonomy_to_krona:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    krona_text:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 20 MB
+              destination: slurm_1slot
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 20 MB
+              upper_bound: 2 GB
+              destination: slurm_5slots
+        default_destination: slurm_7slots
+    clustalw:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 300 KB
+              destination: slurm_3slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 300 KB
+              upper_bound: 2 MB
+              destination: slurm_5slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 2 MB
+              upper_bound: 40 MB
+              destination: slurm_9slots
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 40 MB
+              upper_bound: Infinity
+              destination: fail
+              fail_message: Too much data, please don't use the clustalw for this.
+        default_destination: slurm_5slots
+    flye:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 150 MB
+              destination: slurm_3slots
+        default_destination: slurm_16slots
+    limma_voom:
+        default_destination: slurm_7slots
+    #
+    # Data managers
+    #
+    bwa_mem_index_builder_data_manager:
+        default_destination: slurm_16slots
+    hisat2_index_builder_data_manager:
+        default_destination: slurm_5slots
+    bwameth_index_builder_data_manager:
+        default_destination: slurm_5slots
+    bowtie2_index_builder_data_manager:    
+        default_destination: slurm_16slots
+    twobit_builder_data_manager:    
+        default_destination: slurm_16slots
+
+default_destination: slurm_1slot
 
 verbose: True


### PR DESCRIPTION
This is a WIP.  The tools need to be in order.  This is all from galaxy prod except that user-specific rules have been removed, some blocks refactored,
Rules for and tool destinations for SRA tools have been changed from
```
    fasterq_dump:
        default_destination: slurm_1slot
    fastq_dump:
        default_destination: slurm_1slot
    sam_dump:
        default_destination: slurm_1slot_upload
```
to `slurm_3slots` for each of them.
