### PR TITLE
set pulsar_user: ubuntu in pulsar group vars

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -54,6 +54,10 @@ pulsar_pycurl_ssl_library: openssl
 pulsar_systemd: true
 pulsar_systemd_runner: webless
 
+pulsar_user:
+  name: ubuntu
+  shell: /bin/bash
+
 pulsar_ssl_pem: /etc/ssl/certs/host.pem
 
 pulsar_optional_dependencies:


### PR DESCRIPTION
Tested on dev.  New conda environments belong to ubuntu.