### PR TITLE
changes for 20.09 to galaxyservers.yml and templates/nginx/galaxy.j2

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -171,11 +171,7 @@ galaxy_config:
     galaxy_data_manager_data_path: "{{ galaxy_tools_indices_dir }}/custom-indices"
     shed_tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data/shed_tool_data"
     tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data"
-
-    tool_data_table_config_path:
-      - "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml"
-      - /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml
-      - /cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
+    tool_data_table_config_path: "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml"
 
     library_import_dir: "{{ galaxy_tmp_dir }}/library_import_dir"
     cluster_files_directory: "{{ galaxy_tmp_dir }}/pbs"

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -52,6 +52,10 @@ server {
         alias /;
     }
 
+    location /training-material/ {
+        proxy_pass https://training.galaxyproject.org/training-material/;
+    }
+
     location /robots.txt {
         alias {{ galaxy_server_dir }}/static/robots.txt;
     }


### PR DESCRIPTION
changed
```
tool_data_table_config_path:
  - file1
  - file2
```
to `tool_data_table_config_path: file1,file2`
and added route to nginx conf for GTN in galaxy

This will be compatible with the the 20.05 branch