### PR TITLE
include path to dependency resolvers sample file in galaxyservers.yml

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -167,6 +167,7 @@ galaxy_config:
     job_config_file: "{{ galaxy_config_dir }}/job_conf.xml"
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
     tool_config_file: "{{ tool_config_files }}"
+    dependency_resolvers_config_file: "{{ galaxy_server_dir }}/config/dependency_resolvers_conf.xml.sample"
     user_preferences_extra_conf_path: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
 
     galaxy_data_manager_data_path: "{{ galaxy_tools_indices_dir }}/custom-indices"


### PR DESCRIPTION
From testing legacy tools on dev... apparently this file is not being used by default