### PR TITLE
Dynamic pulsar destinations

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
@@ -2,8 +2,8 @@
 
 import os
 
-from galaxy.jobs import JobDestination
-from galaxy.jobs.mapper import JobMappingException
+# from galaxy.jobs import JobDestination
+# from galaxy.jobs.mapper import JobMappingException
 
 from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination
 from random import sample

--- a/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/dev/dynamic_rules/destination_mapper.py
@@ -2,14 +2,15 @@
 
 import os
 
-# from galaxy.jobs import JobDestination
-# from galaxy.jobs.mapper import JobMappingException
+from galaxy.jobs import JobDestination
+from galaxy.jobs.mapper import JobMappingException
 
 from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination
 from random import sample
 
 TOOL_DESTINATION_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tool_destinations.yml')
 
+pulsar_user_destinations = {'pulsar_user@usegalaxy.org.au': 'pulsar_destination'}
 
 def gateway(job, app, tool, user_email):
     """
@@ -20,6 +21,11 @@ def gateway(job, app, tool, user_email):
     Arguments to this function can include app, job, job_id, job_wrapper, tool, tool_id,
     user, user_email (see https://docs.galaxyproject.org/en/latest/admin/jobs.html)
     """
+
+    if user_email in pulsar_user_destinations.keys():
+        if hasattr(tool, 'id') and isinstance(tool.id, str) and tool.id.startswith('toolshed'):  # map shed tools only
+            return pulsar_user_destinations[user_email]
+
     destination = map_tool_to_destination(job, app, tool, user_email, path=TOOL_DESTINATION_PATH)
     return destination
 

--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/destination_mapper.py
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/destination_mapper.py
@@ -10,6 +10,11 @@ from random import sample
 
 TOOL_DESTINATION_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tool_destinations.yml')
 
+pulsar_user_destinations = {  # test pulsar users whose shed-tool jobs will always run on pulsars
+    'pulsar_mel2_user@usegalaxy.org.au': 'pulsar-mel_small',
+    'pulsar_mel3_user@usegalaxy.org.au': 'pulsar-mel3_small',
+    'pulsar_paw_user@usegalaxy.org.au': 'pulsar-paw_small',
+}
 
 def gateway(job, app, tool, user_email):
     """
@@ -20,6 +25,12 @@ def gateway(job, app, tool, user_email):
     Arguments to this function can include app, job, job_id, job_wrapper, tool, tool_id,
     user, user_email (see https://docs.galaxyproject.org/en/latest/admin/jobs.html)
     """
+
+    # map jobs from pulsar_user_destinations
+    if user_email in pulsar_user_destinations.keys():
+        if hasattr(tool, 'id') and isinstance(tool.id, str) and tool.id.startswith('toolshed'):  # map shed tools only
+            return pulsar_user_destinations[user_email]
+
     destination = map_tool_to_destination(job, app, tool, user_email, path=TOOL_DESTINATION_PATH)
     return destination
 


### PR DESCRIPTION
Pulsar destinations for users whose shed-tool jobs will always go to various pulsars depending on the user email.

This is working on dev.

These accounts can be used to test any shed tool to see if it will work at the pulsar destinations.  Anything that is not a toolshed tool will run at its regular slurm destination (upload1, converters etc)