### PR TITLE
Added a 9slot_1off destination to the job_conf

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -1296,6 +1296,8 @@ tools:
         default_destination: slurm_16slots
     limma_voom:
         default_destination: slurm_7slots
+    gffread:
+        default_destination: slurm_9slots_1off
     #
     # Data managers
     #

--- a/host_vars/pawsey_job_conf.yml
+++ b/host_vars/pawsey_job_conf.yml
@@ -102,6 +102,10 @@ galaxy_jobconf:
         runner: slurm
         params:
           nativeSpecification: "--nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=124160"
+      - id: slurm_9slots_1off
+        runner: slurm
+        params:
+          nativeSpecification: "--nodes=1 --ntasks=9 --ntasks-per-node=9 --mem=34920"
       # Pulsar mel destinations
       - id: pulsar-mel_small
         runner: pulsar_mel2_runner
@@ -259,6 +263,9 @@ galaxy_jobconf:
         value: 2
       - type: destination_user_concurrent_jobs
         id: slurm_32slots
+        value: 1
+      - type: destination_total_concurrent_jobs
+        id: slurm_9slots_1off
         value: 1
       #Pulsar Mel limits
       - type: destination_user_concurrent_jobs

--- a/pawsey-workers_playbook.yml
+++ b/pawsey-workers_playbook.yml
@@ -50,8 +50,12 @@
                 owner: root
                 group: root
                 mode: 1777
+          - stat:
+                path: /tmp
+            register: links
           - name: Move /tmp to vdc
             command: "rm -r /tmp && ln -s /mnt/tmpdisk /tmp"
             become: yes
             become_user: root
+            when: links.stat.islnk is defined and not links.stat.islnk
         when: attached_volume_device is defined

--- a/pawsey-workers_playbook.yml
+++ b/pawsey-workers_playbook.yml
@@ -41,3 +41,17 @@
         systemd:
             name: munge
             state: restarted
+      - name: Move /tmp to vdc
+        block:
+          - name: Create worker tmpdir on vdc
+            file:
+                path: /mnt/tmpdisk
+                state: directory
+                owner: root
+                group: root
+                mode: 1777
+          - name: Move /tmp to vdc
+            command: "rm -r /tmp && ln -s /mnt/tmpdisk /tmp"
+            become: yes
+            become_user: root
+        when: attached_volume_device is defined


### PR DESCRIPTION
This is for jobs that will use a lot of disk space. We can assign them 9 slots but ensure that only one of them runs at a time.