### PR TITLE
add galaxy_infrastructure_url to galaxyservers.yml

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -125,6 +125,7 @@ galaxy_config:
     database_connection: "{{ __galaxy_config['galaxy']['database_connection']}}"
     id_secret: "{{ __galaxy_config['galaxy']['id_secret']}}"
     file_path: "{{ __galaxy_config['galaxy']['file_path']}}"
+    galaxy_infrastructure_url: "{{ __galaxy_config['galaxy']['galaxy_infrastructure_url'] }}"
     object_store_config_file: "{{ __galaxy_config['galaxy']['object_store_config_file']|default(omit) }}"
     smtp_server: "{{ __galaxy_config['galaxy']['smtp_server']|default(omit) }}"
     ga_code: "{{ __galaxy_config['galaxy']['ga_code']|default(omit) }}"

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -36,6 +36,7 @@ __galaxy_config:
     database_connection: "postgres://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
     id_secret: "{{ vault_dev_id_secret }}"
     file_path: "{{ galaxy_root }}/data"
+    galaxy_infrastructure_url: 'https://dev.usegalaxy.org.au'
 
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -83,6 +83,7 @@ __galaxy_config:
     object_store_config_file: "{{ galaxy_config_dir }}/object_store_conf.xml"
     smtp_server: localhost
     ga_code: "{{ vault_pawsey_ga_code }}"
+    galaxy_infrastructure_url: 'https://usegalaxy.org.au'
 
 
 # cvmfs

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -41,6 +41,7 @@ __galaxy_config:
     database_connection: "postgres://galaxy:{{ vault_staging_db_user_password }}@staging-db.usegalaxy.org.au:5432/galaxy"
     id_secret: "{{ vault_staging_id_secret }}"
     file_path: "{{ galaxy_root }}/data"
+    galaxy_infrastructure_url: 'https://staging.usegalaxy.org.au'
 
 #Galaxy Job Conf
 galaxy_jobconf:


### PR DESCRIPTION
The galaxy_infrastructure_url is included in job completion emails and defaults to localhost