### PR TITLE
change mode of worker tmpdisk to '1777'

### DIFF
--- a/pawsey-workers_playbook.yml
+++ b/pawsey-workers_playbook.yml
@@ -49,7 +49,7 @@
                 state: directory
                 owner: root
                 group: root
-                mode: 01777
+                mode: '1777'
           - name: stat links
             stat:
                 path: /tmp


### PR DESCRIPTION
A few tools are failing with permission errors.  This could be due to permissions on the tmpdisks being slightly different since these were added to the ansible.