### PR TITLE
add gxadmin-local.sh to each user's home dir and add some functions

### DIFF
--- a/roles/pg-post-tasks/tasks/main.yml
+++ b/roles/pg-post-tasks/tasks/main.yml
@@ -30,5 +30,5 @@
         mode: "755"
         group: ubuntu
         owner: ubuntu
-        force: no # do not replace the file unless it has been deleted
+        force: yes
       

--- a/roles/pg-post-tasks/tasks/main.yml
+++ b/roles/pg-post-tasks/tasks/main.yml
@@ -19,16 +19,18 @@
       loop: "{{ ( machine_users | map(attribute='name') | list ) + ['ubuntu'] }}"
       loop_control:
         loop_var: username
-    - name: Ensure gxadmin config directory exists for user ubuntu
+    - name: Ensure gxadmin config directory exists for all users including ubuntu
       file:
-        path: "{{ gxadmin_ubuntu_config_dir }}"
+        path: "/home/{{ item }}/.config"
         state: directory
-    - name: Ensure that ubuntu user has a copy of gxadmin-local.sh
+      with_items: "{{ (machine_users | map(attribute='name') | list) + ['ubuntu'] }}"
+    - name: Ensure that all users + ubuntu have a copy of gxadmin-local.sh
       copy: 
         src: files/galaxy/gxadmin/gxadmin-local.sh
-        dest: "{{ gxadmin_ubuntu_config_dir }}/gxadmin-local.sh"
+        dest: "/home/{{ item }}/.config/gxadmin-local.sh"
         mode: "755"
-        group: ubuntu
-        owner: ubuntu
+        group: "{{ item }}"
+        owner: "{{ item }}"
         force: yes
+      with_items: "{{ (machine_users | map(attribute='name') | list) + ['ubuntu'] }}"
       


### PR DESCRIPTION
Replace gxadmin-local.sh when it is updated here (this was previously not the case).  Any gxadmin commands can be added in this repo or to gxadmin-local-extra.sh in the same dir as gxadmin-local.sh.

Addresses https://github.com/usegalaxy-au/infrastructure/issues/118

There are also some new functions around job input file size using pg_pretty_size.
```
	$ gxadmin local query-job-input-datasets 4092986755
	 hda_id  |            hda_name             |  d_id   | d_state | d_file_size | d_total_size
	---------+---------------------------------+---------+---------+-------------+--------------
	91237625 | SRR7692603:forward uncompressed | 3545195 | ok      | 4810 MB     | 4810 MB
	91237627 | SRR7692603:reverse uncompressed | 3545196 | ok      | 4845 MB     | 4845 MB
```



```
	$ gxadmin local query-job-input-size 4212421
	 job_id  |          created           |          updated           | username | state |                       tool_id                        | sum_input_size | destination  | external_id
	---------+----------------------------+----------------------------+----------+-------+------------------------------------------------------+----------------+--------------+-------------
	 4212421 | 2021-03-01 23:14:05.770694 | 2021-03-01 23:14:12.965732 | koala    | error | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9 | 1615 kB        | slurm_3slots | 444
```

```
	$ gxadmin local query-jobs-input-size-by-tool multiqc
	 job_id  |          created           |          updated           |   username   | state |                       tool_id                        | sum_input_size | destination  | external_id
	---------+----------------------------+----------------------------+--------------+-------+------------------------------------------------------+----------------+--------------+-------------
	 4212521 | 2021-03-01 23:40:43.571578 | 2021-03-01 23:40:57.23172  | platypus     | ok    | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9 | 27 kB          | slurm_3slots | 492
	 4212432 | 2021-03-01 23:19:33.729478 | 2021-03-01 23:19:46.422826 | emu          | ok    | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9 | 18 kB          | slurm_3slots | 460
	 4212427 | 2021-03-01 23:15:36.339832 | 2021-03-01 23:15:46.32736  | koala        | ok    | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9 | 18 kB          | slurm_3slots | 446
	 4212426 | 2021-03-01 23:15:20.785234 | 2021-03-01 23:15:32.484563 | wombat       | ok    | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9 | 27 kB          | slurm_3slots | 445
	 4212421 | 2021-03-01 23:14:05.770694 | 2021-03-01 23:14:12.965732 | koala        | error | toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9 | 1615 kB        | slurm_3slots | 444

```

