### PR TITLE
upgrade galaxyproject roles to current versions

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -151,6 +151,8 @@ galaxy_config:
     email_from: <galaxy-no-reply@usegalaxy.org.au>
     support_url: "{{ galaxy_australia_website }}/help"
 
+    data_dir: "{{ galaxy_root }}/cache"  # cache paths are set relative to data_dir (cache_dir will become a config option in 21.05)
+
     conda_debug: true
     conda_prefix: "{{ galaxy_tools_indices_dir }}/tool_dependencies/_conda"
   

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,9 @@
 - name: galaxyproject.galaxy
-  version: 0.9.6
+  version: 0.9.11
 - name: galaxyproject.nginx
   version: 0.6.4
 - name: galaxyproject.postgresql
-  version: 1.0.2
+  version: 1.0.3
 - name: natefoo.postgresql_objects
   version: 1.1
 - name: geerlingguy.pip
@@ -20,7 +20,7 @@
 #- src: galaxyproject.slurm - Waiting for a new release that sets up clustering for dbd properly
 #  version: 0.1.2
 - src: galaxyproject.cvmfs
-  version: 0.2.13
+  version: 0.2.14
 #- src: galaxyproject.repos - Waiting for a new release with Ubuntu >= 18.04
 #  version: 0.0.1
 - src: galaxyproject.pulsar


### PR DESCRIPTION
add `data_dir: "{{ galaxy_root }}/cache"` because otherwise all of the cache directories spawn within `/mnt/galaxy`

Addresses #156 