### PR TITLE
Send larger bwa_mem jobs to pulsar-mel3

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -448,8 +448,8 @@ tools:
               nice_value: 0
               lower_bound: 1 GB
               upper_bound: 10 GB
-              destination: slurm_5slots
-        default_destination: slurm_7slots
+              destination: pulsar-mel3_mid
+        default_destination: pulsar-mel3_mid
     bowtie2:
         rules:
             - rule_type: file_size


### PR DESCRIPTION
This could ease slurm bottlenecks but there is also a risk that it could create bottlenecks on pulsar-mel3, it's difficult to tell.