### PR TITLE
set default_destination for bwa_mem back to slurm_7slots

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -449,7 +449,7 @@ tools:
               lower_bound: 1 GB
               upper_bound: 10 GB
               destination: pulsar-mel3_mid
-        default_destination: pulsar-mel3_mid
+        default_destination: slurm_7slots
     bowtie2:
         rules:
             - rule_type: file_size


### PR DESCRIPTION
This will put pressure on the slurm queue but every single job with input size > 10G is failing