### PR TITLE
Dev upload store working branch

### DIFF
--- a/aarnet-dev_playbook.yml
+++ b/aarnet-dev_playbook.yml
@@ -43,6 +43,7 @@
     - geerlingguy.pip
     - galaxyproject.galaxy
     - usegalaxy_eu.galaxy_systemd
+    - nginx-upload-module
     - galaxyproject.nginx
     - geerlingguy.nfs
     - galaxyproject.slurm

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -8,26 +8,13 @@
       - group_vars/dev_slurm.yml
       - host_vars/dev.usegalaxy.org.au.yml
   pre_tasks:
-    - name: Attach volume to instance
-      # If this script is being run for the first time, review the value of galaxyserver_attached_volume_device in group_vars
-      block: # TODO: This is pretty generic code for attaching a volume to a device and should probably live in another file to be reused
-        - name: Detect attached volume
-          parted:
-            device: "{{ galaxyserver_attached_volume_device }}"
-            unit: GiB
-          register: volume_info
-        - name: Create a filesystem on volume
-          filesystem:
-            fstype: "{{ galaxyserver_attached_volume_fstype }}"
-            dev: "{{ galaxyserver_attached_volume_device }}"
-          when: volume_info.disk is defined and volume_info.disk.dev is defined and volume_info.disk.dev == galaxyserver_attached_volume_device
-        - name: Mount volume
-          mount:
-            path: "{{ galaxyserver_attached_volume_path }}"
-            src: "{{ galaxyserver_attached_volume_device }}"
-            fstype: "{{ galaxyserver_attached_volume_fstype }}"
-            state: mounted
-      when: galaxyserver_attached_volume_device is defined
+      - name: Attach main volume to instance
+        include_role:
+          name: set-up-volume
+        vars:
+          attached_volume_device: "{{ galaxyserver_attached_volume_device }}"
+          attached_volume_fstype: "{{ galaxyserver_attached_volume_fstype }}"
+          attached_volume_path: "{{ galaxyserver_attached_volume_path }}"
   handlers:
     - name: Restart Galaxy
       systemd:
@@ -43,6 +30,7 @@
     - geerlingguy.pip
     - galaxyproject.galaxy
     - usegalaxy_eu.galaxy_systemd
+    - nginx-upload-module
     - galaxyproject.nginx
     - geerlingguy.nfs
     - galaxyproject.slurm
@@ -64,3 +52,4 @@
       command: exportfs -ra
       become: yes
       become_user: root
+

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -54,6 +54,7 @@ nginx_ssl_role: usegalaxy_eu.certbot
 nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-nginx.pem
 create_nginx_htpasswd: true
+nginx_conf_user: galaxy  # the nginx-with-dynamic-module role uses this (though it is a var for galaxyproject.nginx)
 
 # Galaxy
 
@@ -68,6 +69,7 @@ cloudstor_settings:
 
 tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }}"
 user_prefs_extra_config_file: "{{ cloudstor_settings['user_prefs_extra_config_file'] if use_cloudstor_conf|d(false) == true else default_settings['user_prefs_extra_config_file'] }}"
+# end variables dependent on use_cloudstor_conf
 
 galaxy_create_user: true
 galaxy_separate_privileges: true
@@ -81,6 +83,7 @@ galaxy_force_checkout: true
 galaxy_australia_website: "https://usegalaxy-au.github.io"
 
 galaxy_server_dir: "{{ galaxy_root }}/galaxy-app"
+galaxy_venv_dir: "{{ galaxy_root }}/venv" # set this explicitly as it can fail when host/group variables are used out of the context of the galaxy role
 galaxy_mutable_config_dir: "{{ galaxy_root }}/var"
 galaxy_mutable_data_dir: "{{ galaxy_root }}"
 galaxy_config_dir: "{{ galaxy_root }}/config"
@@ -185,16 +188,16 @@ group_galaxy_config:
     statsd_port: 8125
     statsd_prefix: galaxy-aust
     
+    display_servers: hgw1.cse.ucsc.edu,hgw2.cse.ucsc.edu,hgw3.cse.ucsc.edu,hgw4.cse.ucsc.edu,hgw5.cse.ucsc.edu,hgw6.cse.ucsc.edu,hgw7.cse.ucsc.edu,hgw8.cse.ucsc.edu,lowepub.cse.ucsc.edu
+    builds_file_path: /cvmfs/data.galaxyproject.org/managed/location/builds.txt
+    build_sites_config_file: "{{ galaxy_config_dir }}/build_sites.yml"
+    enable_old_display_applications: true
 
     # amqp_internal_connection: 'pyamqp://galaxy_internal:more_queues@localhost:5672/galaxy_internal' # this needs configuration
 
     # data_manager_config_file: /mnt/galaxy-app/config/data_manager_conf.xml.sample  # should we be templating these?
     
     # migrated_tools_config: /mnt/galaxy/var/migrated_tools_conf.xml
-    display_servers: hgw1.cse.ucsc.edu,hgw2.cse.ucsc.edu,hgw3.cse.ucsc.edu,hgw4.cse.ucsc.edu,hgw5.cse.ucsc.edu,hgw6.cse.ucsc.edu,hgw7.cse.ucsc.edu,hgw8.cse.ucsc.edu,lowepub.cse.ucsc.edu
-    builds_file_path: /cvmfs/data.galaxyproject.org/managed/location/builds.txt
-    build_sites_config_file: "{{ galaxy_config_dir }}/build_sites.yml"
-    enable_old_display_applications: true
     # datatypes_config_file: /mnt/galaxy-app/config/datatypes_conf.xml
 
     # interactive_environment_plugins_directory: config/plugins/interactive_environments
@@ -219,15 +222,6 @@ group_galaxy_config:
     # len_file_path: /mnt/galaxy-app/tool-data/len
     #
     
-    #########################################
-    # Commented out by Simon - 22/03/2021.
-    # Requires more testing before being used in production - team meeting 22/03/2021.
-    # Once it's added to production it's no longer an issue.
-    # 
-    #########################################
-    #enable_oidc: true
-    #oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"
-    #oidc_backends_config_file: "{{ galaxy_config_dir }}/oidc_backends_config.xml"
 
 galaxy_config_template_src_dir: templates/galaxy
 galaxy_config_templates:
@@ -237,8 +231,8 @@ galaxy_config_templates:
     dest: "{{ galaxy_config_dir}}/job_conf.xml"
   - src: "{{ galaxy_config_template_src_dir }}/config/reports.yml.j2"
     dest: "{{ galaxy_config_dir }}/reports.yml"
-  #- src: "{{ galaxy_config_template_src_dir }}/config/oidc_backends_config.xml.j2"
-  #  dest: "{{ galaxy_config_dir}}/oidc_backends_config.xml"
+  - src: "{{ galaxy_config_template_src_dir }}/config/oidc_backends_config.xml.j2"
+    dest: "{{ galaxy_config_dir}}/oidc_backends_config.xml"
 
 galaxy_config_file_src_dir: files/galaxy
 galaxy_config_files:
@@ -256,8 +250,8 @@ galaxy_config_files:
     dest: "{{ galaxy_config['galaxy']['user_preferences_extra_conf_path'] }}"
   - src: "{{ galaxy_config_file_src_dir }}/config/build_sites.yml"
     dest: "{{ galaxy_config_dir }}/build_sites.yml"
-  #- src: "{{ galaxy_config_file_src_dir }}/config/oidc_config.xml"
-  #  dest: "{{ galaxy_config_dir}}/oidc_config.xml"
+  - src: "{{ galaxy_config_file_src_dir }}/config/oidc_config.xml"
+    dest: "{{ galaxy_config_dir}}/oidc_config.xml"
 
 # galaxy_config is the combination of group_galaxy_config and host_galaxy_config.  For any variable
 # defined in both group_galaxy_config and host_galaxy_config the value from host_galaxy_config will

--- a/host_vars/aarnet-dev.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-dev.usegalaxy.org.au.yml
@@ -48,17 +48,28 @@ galaxy_commit_id: release_21.01_cloudstor
 # Use cloudstor branch and extra tool_conf file and user prefs for cloudstor tool
 use_cloudstor_conf: true
 
+galaxy_file_path: "{{ galaxy_root }}/data"
+nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
+nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
+nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
+
 host_galaxy_config:  # renamed from __galaxy_config
   galaxy:
     admin_users: "{{ machine_users | selectattr('email', 'defined') | map(attribute='email') | join(',') }}" # everyone is an admin on dev
     brand: "AARNet Dev"
     database_connection: "postgres://galaxy:{{ galaxy_db_user_password }}@{{ hostvars['aarnet-dev-db']['internal_ip'] }}:5432/galaxy"
     id_secret: "{{ vault_aarnet_dev_id_secret }}"
-    file_path: "{{ galaxy_root }}/data"
+    file_path: "{{ galaxy_file_path }}"
     galaxy_infrastructure_url: 'https://aarnet-dev.usegalaxy.org.au'
+    enable_oidc: false
     #IT overide stuff
     interactivetools_enable: true
     interactivetools_map: "{{ gie_proxy_sessions_path }}"
+    # nginx upload module
+    nginx_upload_store: "{{ nginx_upload_store_dir }}"
+    nginx_upload_path: '/_upload'
+    nginx_upload_job_files_store: "{{ nginx_upload_job_files_store_dir }}"
+    nginx_upload_job_files_path: '/_job_files'
 
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -24,14 +24,26 @@ galaxy_commit_id: release_21.01_cloudstor
 # Use cloudstor branch and extra tool_conf file and user prefs for cloudstor tool
 use_cloudstor_conf: true
 
+galaxy_file_path: "{{ galaxy_root }}/data"
+nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
+nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
+nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
+
 host_galaxy_config:  # renamed from __galaxy_config
   galaxy:
     admin_users: "{{ machine_users | selectattr('email', 'defined') | map(attribute='email') | join(',') }}" # everyone is an admin on dev
     brand: "Australia Dev"
     database_connection: "postgres://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
     id_secret: "{{ vault_dev_id_secret }}"
-    file_path: "{{ galaxy_root }}/data"
+    file_path: "{{ galaxy_file_path }}"
     galaxy_infrastructure_url: 'https://dev.usegalaxy.org.au'
+    enable_oidc: true
+    oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"
+    oidc_backends_config_file: "{{ galaxy_config_dir }}/oidc_backends_config.xml"
+    nginx_upload_store: "{{ nginx_upload_store_dir }}"
+    nginx_upload_path: '/_upload'
+    nginx_upload_job_files_store: "{{ nginx_upload_job_files_store_dir }}"
+    nginx_upload_job_files_path: '/_job_files'
 
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -82,6 +82,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     smtp_server: localhost
     ga_code: "{{ vault_pawsey_ga_code }}"
     galaxy_infrastructure_url: 'https://usegalaxy.org.au'
+    enable_oidc: false
 
 
 # cvmfs
@@ -117,8 +118,14 @@ tiaas_other_config: |
     TIAAS_SEND_EMAIL_TO = "help@genome.edu.au"
     TIAAS_SEND_EMAIL_FROM = "tiaas-no-reply@usegalaxy.org.au"
 
-# Custos/AAF specific settings
-#custos_client_id: "{{ vault_custos_client_id_pawsey }}"
-#custos_client_secret: "{{ vault_custos_client_secret_pawsey }}"
-#aaf_client_id: "{{ vault_aaf_client_id_pawsey }}"
-#aaf_client_secret: "{{ vault_aaf_client_secret_pawsey }}"
+# # Custos/AAF specific settings
+# custos_client_id: "{{ vault_custos_client_id_pawsey }}"
+# custos_client_secret: "{{ vault_custos_client_secret_pawsey }}"
+# aaf_client_id: "{{ vault_aaf_client_id_pawsey }}"
+# aaf_client_secret: "{{ vault_aaf_client_secret_pawsey }}"
+
+# Custos/AAF placeholder setting settings DELETE WHEN ABOVE SETTINGS ARE ENABLED
+custos_client_id: "potato"
+custos_client_secret: "zucchini"
+aaf_client_id: "tomato"
+aaf_client_secret: "pumpkin"

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -118,14 +118,8 @@ tiaas_other_config: |
     TIAAS_SEND_EMAIL_TO = "help@genome.edu.au"
     TIAAS_SEND_EMAIL_FROM = "tiaas-no-reply@usegalaxy.org.au"
 
-# # Custos/AAF specific settings
-# custos_client_id: "{{ vault_custos_client_id_pawsey }}"
-# custos_client_secret: "{{ vault_custos_client_secret_pawsey }}"
-# aaf_client_id: "{{ vault_aaf_client_id_pawsey }}"
-# aaf_client_secret: "{{ vault_aaf_client_secret_pawsey }}"
-
-# Custos/AAF placeholder setting settings DELETE WHEN ABOVE SETTINGS ARE ENABLED
-custos_client_id: "potato"
-custos_client_secret: "zucchini"
-aaf_client_id: "tomato"
-aaf_client_secret: "pumpkin"
+# Custos/AAF specific settings
+custos_client_id: "{{ vault_custos_client_id_pawsey }}"
+custos_client_secret: "{{ vault_custos_client_secret_pawsey }}"
+aaf_client_id: "{{ vault_aaf_client_id_pawsey }}"
+aaf_client_secret: "{{ vault_aaf_client_secret_pawsey }}"

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -37,6 +37,9 @@ host_galaxy_config:  # renamed from __galaxy_config
     id_secret: "{{ vault_staging_id_secret }}"
     file_path: "{{ galaxy_root }}/data"
     galaxy_infrastructure_url: 'https://staging.usegalaxy.org.au'
+    enable_oidc: true
+    oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"
+    oidc_backends_config_file: "{{ galaxy_config_dir }}/oidc_backends_config.xml"
 
 #Galaxy Job Conf
 galaxy_jobconf:

--- a/roles/nginx-upload-module/README.md
+++ b/roles/nginx-upload-module/README.md
@@ -1,0 +1,28 @@
+## nginx-upload-module role
+
+Ansible role for building nginx_upload_module from module source code and adding it to nginx modules-enabled
+
+**Author: Catherine Bromhead 2021**
+
+### Prerequisites
+
+Ubuntu operating system
+galaxy user on system
+
+### Role Variables
+
+**nginx_upload_store_dir** Path to nginx upload store
+**nginx_upload_job_files_store_dir** Path to nginx job files store
+
+**nginx_build_module_dir** Temporary directory for building upload module.  This will be removed when build process is complete.
+default: /var/ansible
+**nginx_module_source_url** Source code for nginx upload module
+default: https://github.com/fdintino/nginx-upload-module/archive/refs/tags/2.3.0.tar.gz
+
+#### default variables shared with galaxyproject.nginx role
+**nginx_flavor** Flavor of nginx installation e.g. full, core, extras, light
+default: full
+**nginx_conf_dir** Path to nginx configuration
+default: /etc/nginx
+
+

--- a/roles/nginx-upload-module/README.md
+++ b/roles/nginx-upload-module/README.md
@@ -2,6 +2,8 @@
 
 Ansible role for building nginx_upload_module from module source code and adding it to nginx modules-enabled
 
+This role is based on a blog post by Chris Oliver https://gorails.com/blog/how-to-compile-dynamic-nginx-modules
+
 **Author: Catherine Bromhead 2021**
 
 ### Prerequisites
@@ -24,5 +26,4 @@ default: https://github.com/fdintino/nginx-upload-module/archive/refs/tags/2.3.0
 default: full
 **nginx_conf_dir** Path to nginx configuration
 default: /etc/nginx
-
 

--- a/roles/nginx-upload-module/defaults/main.yml
+++ b/roles/nginx-upload-module/defaults/main.yml
@@ -1,0 +1,7 @@
+# build_module.yml variables
+nginx_build_module_dir: /var/ansible
+nginx_module_source_url: https://github.com/fdintino/nginx-upload-module/archive/refs/tags/2.3.0.tar.gz
+
+# default variables shared with galaxyproject.nginx role
+nginx_flavor: full
+nginx_conf_dir: /etc/nginx

--- a/roles/nginx-upload-module/tasks/build_module.yml
+++ b/roles/nginx-upload-module/tasks/build_module.yml
@@ -1,0 +1,83 @@
+---
+- name: Check whether upload_module conf file exists  # Assume that module is built and in place if this file exists
+  stat:
+    path: "{{ nginx_conf_dir }}/modules-enabled/50-mod-http-upload.conf"
+  register: stat_result
+
+- name: Build upload module if it is not already built
+  when: not stat_result.stat.exists
+  block:
+    - name: Register installed nginx version
+      shell: echo "$(nginx -v 2>&1 | cut -d '/' -f 2 | cut -d ' ' -f 1)"  # note this must use shell rather than command
+      register: nginx_version
+
+    - name: Make a directory for build operations
+      file:
+        path: "{{ nginx_build_module_dir }}"
+        state: directory
+
+    - name: Install the prerequisites
+      apt:
+        name: ['libperl-dev', 'libgeoip-dev', 'libgd-dev', 'libxslt-dev', 'libpcre3-dev']
+        state: present
+        update_cache: true
+
+    - name: Get configure arguments for nginx
+      shell: echo "$(nginx -V 2>&1 | grep 'configure arguments' )"  # note this must use shell rather than command
+      register: configure_arguments_line
+
+    - name: Get configure arguments excluding label and any --add_dynamic_module flags
+      set_fact:
+        configure_arguments: "{{ configure_arguments | default([]) + [item] }}"
+      with_items: "{{ configure_arguments_line.stdout.split()[2:] }}"
+      when: '"--add-dynamic-module" not in item'
+
+    - name: Download and unzip nginx source code
+      unarchive:
+        src: "https://nginx.org/download/nginx-{{ nginx_version.stdout }}.tar.gz"
+        dest: "{{ nginx_build_module_dir }}/"
+        list_files: true
+        remote_src: true
+      register: nginx_source_download
+
+    - name: Extract nginx_source_dir from nginx_source_download variable
+      set_fact:
+        nginx_source_dir: "{{ nginx_source_download.files | first | replace('/', '') }}"
+
+    - name: Download and unzip module source code
+      unarchive:
+        src: "{{ nginx_module_source_url }}"
+        dest: "{{ nginx_build_module_dir }}/"
+        list_files: true
+        remote_src: true
+      register: module_source_download
+
+    - name: Extract module_source_dir from module_source_download variable
+      set_fact:
+        module_source_dir: "{{ module_source_download.files | first | replace('/', '') }}"
+
+    - name: Invoke configure with configure_arguments and added module
+      command:
+        cmd: "./configure {{ configure_arguments | join(' ') }} --add-dynamic-module=../{{ module_source_dir}} "
+        chdir: "{{ nginx_build_module_dir }}/{{ nginx_source_dir }}"
+
+    - name: Build module
+      command:
+        cmd: make modules
+        chdir: "{{ nginx_build_module_dir }}/{{ nginx_source_dir }}"
+
+    - name: Move module to nginx modules dir
+      command:
+        cmd: mv objs/ngx_http_upload_module.so /usr/lib/nginx/modules
+        chdir: "{{ nginx_build_module_dir }}/{{ nginx_source_dir }}"
+
+    - name: Make nginx load the module
+      lineinfile:
+        create: true
+        line: 'load_module /usr/lib/nginx/modules/ngx_http_upload_module.so;'
+        path: "{{ nginx_conf_dir }}/modules-enabled/50-mod-http-upload.conf"
+
+    - name: Clean up
+      file:
+        path: "{{ nginx_build_module_dir }}"
+        state: absent

--- a/roles/nginx-upload-module/tasks/main.yml
+++ b/roles/nginx-upload-module/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Ensure that upload_store directories exist
+  file:
+      path: "{{ item }}"
+      state: directory
+      mode: '755'
+      owner: galaxy
+      group: galaxy
+  with_items:
+    - "{{ nginx_upload_store_dir }}"
+    - "{{ nginx_upload_job_files_store_dir }}"
+
+- name: Install nginx (APT)
+  apt:
+    pkg: nginx-{{ nginx_flavor }}
+
+- name: Ensure nginx_conf_user is the user in nginx conf
+  replace:
+      path: /etc/nginx/nginx.conf
+      regexp: '^user www-data;$'
+      replace: 'user {{ nginx_conf_user }};'
+
+# For nginx to run as the galaxy user, nginx directories that were owned by the nginx user (www-data) must now be owned by the galaxy user
+- name: Chown nginx log directories to galaxy
+  file:
+    path: /var/log/nginx
+    owner: galaxy
+    group: adm
+    recurse: true
+    state: directory
+
+- name: Chown nginx lib directories to galaxy
+  file:
+    path: /var/lib/nginx
+    owner: galaxy
+    group: galaxy
+    recurse: true
+    state: directory
+
+- name: Build and install upload module
+  import_tasks: build_module.yml
+

--- a/roles/set-up-volume/tasks/main.yml
+++ b/roles/set-up-volume/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Detect volume, create filesystem and mount volume
+  block:
+    - name: Detect attached volume
+      parted:
+        device: "{{ attached_volume_device }}"
+        unit: GiB
+      register: volume_info
+    - name: Create a filesystem on volume
+      filesystem:
+        fstype: "{{ attached_volume_fstype }}"
+        dev: "{{ attached_volume_device }}"
+      when: volume_info.disk is defined and volume_info.disk.dev is defined and volume_info.disk.dev == attached_volume_device
+    - name: Mount volume
+      mount:
+        path: "{{ attached_volume_path }}"
+        src: "{{ attached_volume_device }}"
+        fstype: "{{ attached_volume_fstype }}"
+        state: mounted
+  when: attached_volume_device is defined and attached_volume_fstype is defined and attached_volume_path is defined

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -90,4 +90,50 @@ server {
         uwsgi_param UWSGI_SCHEME $scheme;
         include uwsgi_params;
     }
+
+{% if galaxy_config['galaxy']['nginx_upload_store'] is defined %}
+
+    location /_upload {
+        upload_store {{ galaxy_config['galaxy']['nginx_upload_store'] }};
+        upload_limit_rate 32k;
+        upload_store_access user:rw group:r all:r;
+        upload_pass_form_field "";
+        upload_set_form_field "__${upload_field_name}__is_composite" "true";
+        upload_set_form_field "__${upload_field_name}__keys" "name path";
+        upload_set_form_field "${upload_field_name}_name" "$upload_file_name";
+        upload_set_form_field "${upload_field_name}_path" "$upload_tmp_path";
+        upload_pass_args on;
+        upload_pass /_upload_done;
+    }
+
+    location /_upload_done {
+        set $dst /api/tools;
+        if ($args ~ nginx_redir=([^&]+)) {
+                set $dst $1;
+        }
+        rewrite "" $dst;
+    }
+
+{% endif %}
+{% if galaxy_config['galaxy']['nginx_upload_job_files_store'] is defined %}
+
+    location /_job_files {
+        if ($request_method != POST) {
+                rewrite "" /api/jobs/$arg_job_id/files last;
+        }
+        upload_store {{ galaxy_config['galaxy']['nginx_upload_job_files_store'] }};
+        upload_limit_rate 32k;
+        upload_store_access user:rw group:r all:r;
+        upload_pass_form_field "";
+        upload_set_form_field "__${upload_field_name}_path" "$upload_tmp_path";
+        upload_pass_args on;
+        upload_pass /_upload_job_files_done;
+    }
+
+    location /_upload_job_files_done {
+        internal;
+        rewrite "" /api/jobs/$arg_job_id/files;
+    }
+
+{% endif %}
 }

--- a/terraform/dev/dev-initial.tf
+++ b/terraform/dev/dev-initial.tf
@@ -66,7 +66,7 @@ resource "openstack_compute_volume_attach_v2" "attach-dev-volume-to-dev" {
 resource "openstack_blockstorage_volume_v2" "dev-upload-store-volume" {
   availability_zone = "melbourne-qh2"
   name        = "dev-upload-store-volume"
-  description = "Galaxy Australia Dev volume"
+  description = "Galaxy Australia Dev volume for upload store"
   size        = 200
 }
 


### PR DESCRIPTION
This adds a role to install official nginx and add a task for building the module.  The build_module task is standalone and should be run on a non-production server.

Because nginx is installed in this role we need to skip the installation in the galaxyproject.nginx role so the requirement for the role has switched to a galaxy-au fork of the ansible-nginx.

Marking this as a draft for now.