### PR TITLE
set client_max_body_size to 25g

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -49,7 +49,7 @@ nginx_enable_default_server: false
 nginx_ssl_servers:
   - galaxy
 nginx_conf_http:
-  client_max_body_size: 30g
+  client_max_body_size: 25g
 nginx_ssl_role: usegalaxy_eu.certbot
 nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-nginx.pem


### PR DESCRIPTION
This was at 30g but pawsey does not have enough space