### PR TITLE
send more large fastqc jobs to pulsar-mel2

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -360,11 +360,11 @@ tools:
           - rule_type: file_size
             nice_value: 0
             lower_bound: 2 GB
-            upper_bound: 5 GB
+            upper_bound: 7 GB
             destination: pulsar-mel_big
           - rule_type: file_size
             nice_value: 0
-            lower_bound: 5 GB
+            lower_bound: 7 GB
             upper_bound: Infinity
             destination: pulsar-mel3_mid
         default_destination: slurm_3slots


### PR DESCRIPTION
large fastqc job are split between pulsar-mel2 and pulsar-mel3 but more of these could run on mel2