### PR TITLE
Make all group names valid (use _ instead of -)

### DIFF
--- a/build-machines_playbook.yml
+++ b/build-machines_playbook.yml
@@ -1,4 +1,4 @@
-- hosts: build-machines
+- hosts: build_machines
   become: yes
   vars_files:
     - group_vars/VAULT

--- a/group_vars/pulsar-nci-test/pulsar-nci-test_slurm.yml
+++ b/group_vars/pulsar-nci-test/pulsar-nci-test_slurm.yml
@@ -1,8 +1,8 @@
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['pulsar-nci-test-head'] }}"
-worker_nodes: "{{ groups['pulsar-nci-test-workers'] }}"
+head_nodes: "{{ groups['pulsar_nci_test_head'] }}"
+worker_nodes: "{{ groups['pulsar_nci_test_workers'] }}"
 use_internal_ips: true
 
 # SLURM

--- a/group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
+++ b/group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
@@ -1,8 +1,8 @@
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['pulsar-mel2-head'] }}"
-worker_nodes: "{{ groups['pulsar-mel2-workers'] }}"
+head_nodes: "{{ groups['pulsar_mel2_head'] }}"
+worker_nodes: "{{ groups['pulsar_mel2_workers'] }}"
 
 # SLURM
 slurm_nodes:

--- a/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
@@ -1,8 +1,8 @@
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['pulsar-mel3-head'] }}"
-worker_nodes: "{{ groups['pulsar-mel3-workers'] }}"
+head_nodes: "{{ groups['pulsar_mel3_head'] }}"
+worker_nodes: "{{ groups['pulsar_mel3_workers'] }}"
 
 # SLURM
 slurm_nodes:

--- a/group_vars/pulsar_paw/pulsar-paw_slurm.yml
+++ b/group_vars/pulsar_paw/pulsar-paw_slurm.yml
@@ -1,8 +1,8 @@
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['pulsar-paw-head'] }}"
-worker_nodes: "{{ groups['pulsar-paw-workers'] }}"
+head_nodes: "{{ groups['pulsar_paw_head'] }}"
+worker_nodes: "{{ groups['pulsar_paw_workers'] }}"
 
 # SLURM
 slurm_nodes:

--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -40,7 +40,7 @@ telegraf_agent_output:
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['pulsar-high-mem1'] }}"
+head_nodes: "{{ groups['pulsar_high_mem1'] }}"
 
 # SLURM
 slurm_nodes:

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -40,7 +40,7 @@ telegraf_agent_output:
 
 auth_key_user: ubuntu
 
-head_nodes: "{{ groups['pulsar-high-mem2'] }}"
+head_nodes: "{{ groups['pulsar_high_mem2'] }}"
 
 # SLURM
 slurm_nodes:

--- a/hosts
+++ b/hosts
@@ -115,20 +115,20 @@ pawsey-w8 ansible_ssh_host=146.118.65.97 internal_ip=192.168.0.100
 
 # Pulsar servers
 
-[pulsar-paw-head]
+[pulsar_paw_head]
 pulsar-paw ansible_ssh_host=146.118.68.128 internal_ip=192.168.0.64
 
-[pulsar-paw-workers]
+[pulsar_paw_workers]
 pulsar-paw-w1 ansible_ssh_host=146.118.68.43 internal_ip=192.168.0.134
 pulsar-paw-w2 ansible_ssh_host=146.118.67.217 internal_ip=192.168.0.180
 pulsar-paw-w3 ansible_ssh_host=146.118.70.37 internal_ip=192.168.0.138
 pulsar-paw-w4 ansible_ssh_host=146.118.69.218 internal_ip=192.168.0.176
 pulsar-paw-w5 ansible_ssh_host=146.118.70.1 internal_ip=192.168.0.157
 
-[pulsar-mel2-head]
+[pulsar_mel2_head]
 pulsar-mel2 ansible_ssh_host=115.146.85.55
 
-[pulsar-mel2-workers]
+[pulsar_mel2_workers]
 pulsar-mel2-w1 ansible_ssh_host=115.146.86.24
 pulsar-mel2-w2 ansible_ssh_host=115.146.86.70
 pulsar-mel2-w3 ansible_ssh_host=115.146.87.226
@@ -137,39 +137,39 @@ pulsar-mel2-w5 ansible_ssh_host=115.146.85.102
 pulsar-mel2-w6 ansible_ssh_host=115.146.84.131
 pulsar-mel2-w7 ansible_ssh_host=115.146.86.132
 
-[pulsar-mel3-head]
+[pulsar_mel3_head]
 pulsar-mel3 ansible_ssh_host=115.146.85.19
 
-[pulsar-mel3-workers]
+[pulsar_mel3_workers]
 pulsar-mel3-w1 ansible_ssh_host=115.146.84.200
 pulsar-mel3-w2 ansible_ssh_host=115.146.84.238
 pulsar-mel3-w3 ansible_ssh_host=115.146.87.129
 pulsar-mel3-w4 ansible_ssh_host=115.146.86.181
 pulsar-mel3-w5 ansible_ssh_host=115.146.86.108
 
-[pulsar-nci-test-head]
+[pulsar_nci_test_head]
 pulsar-nci-test ansible_ssh_host=130.56.246.138 internal_ip=10.0.2.29
 
-[pulsar-nci-test-workers]
+[pulsar_nci_test_workers]
 pulsar-nci-test-w1 ansible_ssh_host=10.0.0.20 internal_ip=10.0.0.20
 pulsar-nci-test-w2 ansible_ssh_host=10.0.1.48 internal_ip=10.0.1.48
 
-[pulsar-high-mem1]
+[pulsar_high_mem1]
 pulsar-high-mem1 ansible_ssh_host=115.146.84.155
 
-[pulsar-high-mem2]
+[pulsar_high_mem2]
 pulsar-high-mem2 ansible_ssh_host=115.146.85.94
 
-[pulsar-qld-head]
+[pulsar_qld_head]
 pulsar-qld ansible_ssh_host=203.101.229.179
 
-[pulsar-qld-workers]
+[pulsar_qld_workers]
 pulsar-qld-w1 ansible_ssh_host=203.101.225.225
 pulsar-qld-w2 ansible_ssh_host=203.101.227.176
 pulsar-qld-w3 ansible_ssh_host=203.101.227.21
 pulsar-qld-w4 ansible_ssh_host=203.101.230.2
 
-[build-machines]
+[build_machines]
 nci-build ansible_ssh_host=130.56.246.156 internal_ip=10.0.0.249
 aarnet-backup ansible_ssh_host=138.44.80.55 internal_ip=192.168.199.190
 

--- a/pulsar-high-mem1_playbook.yml
+++ b/pulsar-high-mem1_playbook.yml
@@ -1,4 +1,4 @@
-- hosts: pulsar-high-mem1
+- hosts: pulsar_high_mem1
   become: true
   vars_files:
     - group_vars/all.yml

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -1,4 +1,4 @@
-- hosts: pulsar-high-mem2
+- hosts: pulsar_high_mem2
   become: true
   vars_files:
     - group_vars/all.yml

--- a/pulsar-mel2_worker_playbook.yml
+++ b/pulsar-mel2_worker_playbook.yml
@@ -1,5 +1,5 @@
 - name: Pulsar mel2 worker node install
-  hosts: pulsar-mel2-workers
+  hosts: pulsar_mel2_workers
   become: yes
   vars_files:
     - group_vars/all.yml

--- a/pulsar-mel3_worker_playbook.yml
+++ b/pulsar-mel3_worker_playbook.yml
@@ -1,5 +1,5 @@
 - name: Pulsar mel3 worker node install
-  hosts: pulsar-mel3-workers
+  hosts: pulsar_mel3_workers
   become: yes
   vars_files:
     - group_vars/all.yml

--- a/pulsar-nci-test_workers_playbook.yml
+++ b/pulsar-nci-test_workers_playbook.yml
@@ -1,5 +1,5 @@
 - name: Pulsar NCI Test worker node install
-  hosts: pulsar-nci-test-workers
+  hosts: pulsar_nci_test_workers
   become: yes
   vars_files:
     - group_vars/all.yml

--- a/pulsar-paw_worker_playbook.yml
+++ b/pulsar-paw_worker_playbook.yml
@@ -1,5 +1,5 @@
 - name: Pulsar PAW worker node install
-  hosts: pulsar-paw-workers
+  hosts: pulsar_paw_workers
   become: yes
   vars_files:
     - group_vars/all.yml


### PR DESCRIPTION
Address deprecation warning about group names.

Alternatively we could be setting `force_valid_group_names = ignore` in ansible.cfg.  I'm in favour of changing the group names because it's easy to do and we don't have to override the (new) default.
