### PR TITLE
aarnet dev slurm dests to parallel production dests

### DIFF
--- a/files/galaxy/dynamic_job_rules/aarnet-dev/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/aarnet-dev/dynamic_rules/tool_destinations.yml
@@ -1,6 +1,6 @@
 tools:
   upload1:
-    default_destination: slurm_dest
+    default_destination: slurm_2slots
   fasta-stats:
     default_destination: pulsar_nci_test_small
   bwa_mem:
@@ -9,6 +9,6 @@ tools:
     default_destination: pulsar_nci_test_mid
   fastq_paired_end_interlacer:
     default_destination: pulsar_nci_test_mid
-default_destination: slurm_dest
+default_destination: slurm_2slots
 
 verbose: True

--- a/host_vars/aarnet-dev.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-dev.usegalaxy.org.au.yml
@@ -130,10 +130,30 @@ galaxy_jobconf:
         runner: dynamic
         params:
           type: dtd
-      - id: slurm_dest
+      - id: slurm_1slot
         runner: slurm
         params:
-            nativeSpecification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760"
+          nativeSpecification: "--nodes=1 --ntasks=1 --ntasks-per-node=1 --mem=3880"
+      - id: slurm_2slots
+        runner: slurm
+        params:
+          nativeSpecification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760"
+      - id: slurm_3slots
+        runner: slurm
+        params:
+          nativeSpecification: "--nodes=1 --ntasks=3 --ntasks-per-node=3 --mem=11640"
+      - id: slurm_5slots
+        runner: slurm
+        params:
+          nativeSpecification: "--nodes=1 --ntasks=5 --ntasks-per-node=5 --mem=19400"
+      - id: slurm_7slots
+        runner: slurm
+        params:
+          nativeSpecification: "--nodes=1 --ntasks=7 --ntasks-per-node=7 --mem=27160"
+      - id: slurm_8slots
+        runner: slurm
+        params:
+          nativeSpecification: "--nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=31040"
       # - id: pulsar_destination
       #   runner: pulsar_au_01
       #   params:


### PR DESCRIPTION
give aarnet-dev job conf some slurm destinations to parallel slurm dests on production.  8 slots is as high as we can go.  This could help with with a recent user tool issue with pilon.