### PR TITLE
upload module for pawsey

### DIFF
--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -63,6 +63,11 @@ galaxy_tmp_dir: /mnt/tmp
 
 galaxy_handler_count: 5   ############# europe uses 5, this could be host specific
 
+galaxy_file_path: /mnt/user-data
+nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
+nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
+nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
+
 host_galaxy_config:  # renamed from __galaxy_config
   uwsgi:
     mule:
@@ -77,13 +82,17 @@ host_galaxy_config:  # renamed from __galaxy_config
     brand: "Australia"
     database_connection: "postgres://galaxy:{{ vault_pawsey_db_user_password }}@{{ hostvars['pawsey-db']['internal_ip'] }}:5432/galaxy"
     id_secret: "{{ vault_pawsey_id_secret }}"
-    file_path: /mnt/user-data
+    file_path: "{{ galaxy_file_path }}"
     object_store_config_file: "{{ galaxy_config_dir }}/object_store_conf.xml"
     smtp_server: localhost
     ga_code: "{{ vault_pawsey_ga_code }}"
     galaxy_infrastructure_url: 'https://usegalaxy.org.au'
     enable_oidc: false
-
+    # nginx upload module
+    nginx_upload_store: "{{ nginx_upload_store_dir }}"
+    nginx_upload_path: '/_upload'
+    nginx_upload_job_files_store: "{{ nginx_upload_job_files_store_dir }}"
+    nginx_upload_job_files_path: '/_job_files'
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/pawsey_playbook.yml
+++ b/pawsey_playbook.yml
@@ -45,6 +45,7 @@
     - geerlingguy.pip
     - galaxyproject.galaxy
     - usegalaxy_eu.galaxy_systemd
+    - nginx-upload-module
     - galaxyproject.nginx
     - geerlingguy.nfs
     - galaxyproject.slurm


### PR DESCRIPTION
@Slugger70 this puts the upload store in /mnt/user-data because of the recommendation in https://docs.galaxyproject.org/en/master/admin/nginx.html#receiving-files-with-nginx "create a directory in which to store uploads (ideally, for performance reasons, on the same filesystem as Galaxy’s datasets)" but we could potentially be putting this somewhere else.  Initially when I was trying this out on dev I was using another volume mounted from the galaxy server.
