### PR TITLE
send minimap to pulsar-mel2 and slurm9

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -908,7 +908,18 @@ tools:
     kraken2_build_database:
         default_destination: slurm_16slots
     minimap2:
-        default_destination: pulsar-mel3_big
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 500 MB
+              destination: pulsar-mel_mid
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 500 MB
+              upper_bound: 5 GB
+              destination: pulsar-mel_big
+        default_destination: slurm_9slots
     kallisto_quant:
         rules:
             - rule_type: file_size


### PR DESCRIPTION
Due to queues for pulsar-mel3_big..

Up to 500Mb to pulsar-mel_mid, 500Mb to 5G to pulsar-mel_big, default dest slurm_9slots

