### PR TITLE
update dev terraform

### DIFF
--- a/terraform/dev/dev-initial.tf
+++ b/terraform/dev/dev-initial.tf
@@ -1,59 +1,59 @@
 # dev database
 resource "openstack_compute_instance_v2" "dev-db" {
   name            = "dev-db"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
-  flavor_name     = "m3.small"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "uom.general.2c8g"  # 2 vcpu 8 ram, previously m3.small (2 vcpu 4 ram)
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-dev-db.name}"]
-  availability_zone = "melbourne-qh2"
+  availability_zone = "melbourne-qh2-uom"
 }
 
 # application server / web server
 resource "openstack_compute_instance_v2" "dev" {
   name            = "dev"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
-  flavor_name     = "m3.medium"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "uom.general.4c16g"  # previously m3.medium (4 vcpu 8 ram)
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "Web-Services", "${openstack_networking_secgroup_v2.galaxy-dev.name}", "${openstack_networking_secgroup_v2.galaxy-dev-db.name}"]
-  availability_zone = "melbourne-qh2"
+  availability_zone = "melbourne-qh2-uom"
 }
 
 # slurm / rabbitMQ
 resource "openstack_compute_instance_v2" "dev-queue" {
   name            = "dev-queue"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
-  flavor_name     = "m3.small"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "uom.general.2c8g"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "Web-Services", "rabbitmq", "${openstack_networking_secgroup_v2.galaxy-dev.name}"]
-  availability_zone = "melbourne-qh2"
+  availability_zone = "melbourne-qh2-uom"
 }
 
 # slurm worker
 resource "openstack_compute_instance_v2" "dev-w1" {
   name            = "dev-w1"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
-  flavor_name     = "m3.medium"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "uom.general.4c16g"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-dev.name}"]
-  availability_zone = "melbourne-qh2"
+  availability_zone = "melbourne-qh2-uom"
 }
 
 #pulsar test server
 resource "openstack_compute_instance_v2" "dev-pulsar" {
   name            = "dev-pulsar"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v3]"
-  flavor_name     = "m3.medium"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "uom.general.2c8g"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH"]
-  availability_zone = "melbourne-qh2"
+  availability_zone = "melbourne-qh2-uom"
 }
 
 # Volume for application/web server
 resource "openstack_blockstorage_volume_v2" "dev-volume" {
-  availability_zone = "melbourne-qh2"
+  availability_zone = "melbourne-qh2-uom"
   name        = "dev-volume"
   description = "Galaxy Australia Dev volume"
-  size        = 200
+  size        = 1000
 }
 
 # Attachment between application/web server and volume
@@ -62,16 +62,27 @@ resource "openstack_compute_volume_attach_v2" "attach-dev-volume-to-dev" {
   volume_id   = "${openstack_blockstorage_volume_v2.dev-volume.id}"
 }
 
-# Volume for upload store
-resource "openstack_blockstorage_volume_v2" "dev-upload-store-volume" {
-  availability_zone = "melbourne-qh2"
-  name        = "dev-upload-store-volume"
-  description = "Galaxy Australia Dev volume for upload store"
-  size        = 200
+# ftp
+resource "openstack_compute_instance_v2" "dev-ftp" {
+  name            = "dev-ftp"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "uom.general.2c8g"
+  key_pair        = "galaxy-australia"
+  security_groups = ["SSH", "Web-Services", "${openstack_networking_secgroup_v2.galaxy-dev.name}"]
+  availability_zone = "melbourne-qh2-uom"
+}
+
+# Volume for ftp
+resource "openstack_blockstorage_volume_v2" "dev-ftp-volume" {
+  availability_zone = "melbourne-qh2-uom"
+  name        = "dev-ftp-volume"
+  description = "Galaxy Australia Dev volume for ftp"
+  size        = 300
 }
 
 # Attachment between application/web server and upload store volume
-resource "openstack_compute_volume_attach_v2" "attach-dev-upload-store-volume-to-dev" {
-  instance_id = "${openstack_compute_instance_v2.dev.id}"
-  volume_id   = "${openstack_blockstorage_volume_v2.dev-upload-store-volume.id}"
+resource "openstack_compute_volume_attach_v2" "attach-dev-ftp-volume-to-dev-ftp" {
+  instance_id = "${openstack_compute_instance_v2.dev-ftp.id}"
+  volume_id   = "${openstack_blockstorage_volume_v2.dev-ftp-volume.id}"
 }
+


### PR DESCRIPTION
The new flavours we can use have 1 vcpu for every 4G of RAM.  The previous ones had 2 vcpus for 4G.  In each case we are doubling the RAM and staying with the same number of VCPUs as before.  The dev volume is 1000G (previously 200) and the dev-ftp volume is 300G.