### PR TITLE
send khmer_abundance_distribution_single to pulsar-mel3 small and mid

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -1343,6 +1343,14 @@ tools:
         default_destination: slurm_7slots
     gffread:
         default_destination: slurm_9slots_1off
+    khmer_abundance_distribution_single:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 1 GB
+              destination: pulsar-mel3_small
+        default_destination: pulsar-mel3_mid
     #
     # Data managers
     #


### PR DESCRIPTION
currently running on slurm1slot and possibly running out of memory with inputs bigger than 3G
passes 2/2 tests on pulsar