### PR TITLE
hide old uploader in tool panel

### DIFF
--- a/files/galaxy/config/tool_conf.xml
+++ b/files/galaxy/config/tool_conf.xml
@@ -2,7 +2,7 @@
 <toolbox monitor="true">
     <label id="file_and_meta_tools" text="FILE AND META TOOLS"/>
     <section id="getext" name="Get Data">
-        <tool file="data_source/upload.xml"/>
+        <tool file="data_source/upload.xml" hidden="True"/>
         <tool file="data_source/ucsc_tablebrowser.xml"/>
         <!-- <tool file="data_source/ucsc_tablebrowser_test.xml" /> -->
         <tool file="data_source/ucsc_tablebrowser_archaea.xml"/>


### PR DESCRIPTION
The UI is broken for this.  Based on https://github.com/galaxyproject/galaxy/issues/11729: keep the tool in the tool_conf.xml but hide it