### PR TITLE
switch to new volume in object store when user-data reaches 95%

### DIFF
--- a/files/galaxy/config/object_store_conf.xml
+++ b/files/galaxy/config/object_store_conf.xml
@@ -2,12 +2,15 @@
 <object_store type="hierarchical">
     <backends>
         <backend id="NFS" type="disk" order="0">
+            <files_dir path="/mnt/user-data-2" />
+        </backend>
+        <backend id="NFS" type="disk" order="1">
             <files_dir path="/mnt/user-data" />
         </backend>
-        <backend id="GPFS" type="disk" order="1">
+        <backend id="GPFS" type="disk" order="2">
             <files_dir path="/mnt/galaxy/files" />
         </backend>
-        <backend id="NFS" type="disk" order="2">
+        <backend id="NFS" type="disk" order="3">
             <files_dir path="/mnt/files2" />
         </backend>
     </backends>

--- a/group_vars/pawsey_workers.yml
+++ b/group_vars/pawsey_workers.yml
@@ -21,6 +21,10 @@ shared_mounts:
       src: "{{ hostvars['pawsey-user-nfs']['internal_ip'] }}:/mnt/user-data"
       fstype: nfs
       state: mounted
+    - path: /mnt/user-data-2
+      src: "{{ hostvars['pawsey-user-nfs']['internal_ip'] }}:/user-data-2"
+      fstype: nfs
+      state: mounted
     - path: /mnt/tmp
       src: "{{ hostvars['pawsey-job-nfs']['internal_ip'] }}:/mnt/tmp"
       fstype: nfs

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -47,6 +47,10 @@ shared_mounts:
       src: "{{ hostvars['pawsey-user-nfs']['internal_ip'] }}:/mnt/user-data"
       fstype: nfs
       state: mounted
+    - path: /mnt/user-data-2
+      src: "{{ hostvars['pawsey-user-nfs']['internal_ip'] }}:/user-data-2"
+      fstype: nfs
+      state: mounted
     - path: /mnt/tmp
       src: "{{ hostvars['pawsey-job-nfs']['internal_ip'] }}:/mnt/tmp"
       fstype: nfs
@@ -75,7 +79,7 @@ galaxy_tmp_dir: /mnt/tmp
 
 galaxy_handler_count: 5   ############# europe uses 5, this could be host specific
 
-galaxy_file_path: /mnt/user-data
+galaxy_file_path: /mnt/user-data-2
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"


### PR DESCRIPTION
Switch to using /mnt/user-data-2 on pawsey

Before merging:
Run the pawsey-user-nfs playbook
Delete or modify the normal and noqld object store copies in /mnt/galaxy/config

Immediately after running this, reload nginx on pawsey.