### PR TITLE
send jellyfish to pulsar-mel2

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -1497,6 +1497,14 @@ tools:
               upper_bound: 500 MB
               destination: slurm_1slot
         default_destination: pulsar-mel3_mid
+    jellyfish:
+        rules:
+            - rule_type: file_size
+              nice_value: 0
+              lower_bound: 0
+              upper_bound: 100 MB
+              destination: pulsar-mel_small
+        default_destination: pulsar-mel_mid
     #
     # Data managers
     #


### PR DESCRIPTION
based on eu's tool destinations: they use 12G memory for jellyfish