### PR TITLE
update roles for galaxy, pulsar, gxadmin and nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ roles/usegalaxy_eu.galaxy_systemd/
 roles/insspb.hostname
 roles/galaxyproject.pulsar
 roles/dj-wasabi.telegraf
-roles/usegalaxy_eu.gxadmin
+roles/galaxyproject.gxadmin
 roles/usegalaxy_eu.tiaas2
 roles/usegalaxy_eu.gie_proxy
 roles/geerlingguy.docker

--- a/aarnet_playbook.yml
+++ b/aarnet_playbook.yml
@@ -34,7 +34,7 @@
     - galaxyproject.slurm
     - galaxyproject.cvmfs
     - dj-wasabi.telegraf
-    - usegalaxy_eu.gxadmin
+    - galaxyproject.gxadmin
     - geerlingguy.docker
     - usegalaxy_eu.gie_proxy
     - pg-post-tasks

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -31,7 +31,7 @@
     - geerlingguy.nfs
     - galaxyproject.slurm
     - galaxyproject.cvmfs
-    - usegalaxy_eu.gxadmin
+    - galaxyproject.gxadmin
     - pg-post-tasks
     - remote-pulsar-cron
     - usegalaxy_eu.tiaas2

--- a/pawsey_playbook.yml
+++ b/pawsey_playbook.yml
@@ -33,7 +33,7 @@
     - geerlingguy.nfs
     - galaxyproject.slurm
     - galaxyproject.cvmfs
-    - usegalaxy_eu.gxadmin
+    - galaxyproject.gxadmin
     - geerlingguy.docker
     - usegalaxy_eu.gie_proxy
     - pg-post-tasks

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 - name: galaxyproject.galaxy
-  version: 0.9.11
+  version: 0.9.16
 - name: galaxyproject.nginx
-  version: 0.6.4
+  version: 0.7.0
 - name: galaxyproject.postgresql
   version: 1.0.3
 - name: natefoo.postgresql_objects
@@ -24,11 +24,11 @@
 #- src: galaxyproject.repos - Waiting for a new release with Ubuntu >= 18.04
 #  version: 0.0.1
 - src: galaxyproject.pulsar
-  version: 1.0.6
+  version: 1.0.8
 - src: dj-wasabi.telegraf
   version: 0.13.0
-- src: usegalaxy_eu.gxadmin
-  version: 0.0.5
+- src: galaxyproject.gxadmin
+  version: 0.0.8
 - src: usegalaxy_eu.tiaas2
   version: 0.0.1
 - src: geerlingguy.docker

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -31,7 +31,7 @@
     - geerlingguy.nfs
     - galaxyproject.slurm
     - galaxyproject.cvmfs
-    - usegalaxy_eu.gxadmin
+    - galaxyproject.gxadmin
     - geerlingguy.docker
     - usegalaxy_eu.gie_proxy
     - pg-post-tasks


### PR DESCRIPTION
Update galaxyproject roles to their latest version.  The latest ansible-pulsar role requires ansible version 2.10 or later.  This will not be ready to merge ansible users (and the build server) have updated ansible.

I haven't seen any changes that I think will affect the current playbooks except the ansible 2.10 requirement of ansible-pulsar

links to diffs between versions.

https://github.com/galaxyproject/ansible-galaxy/compare/0.9.11...galaxyproject:0.9.16
https://github.com/galaxyproject/ansible-pulsar/compare/1.0.6...galaxyproject:1.0.8
https://github.com/galaxyproject/ansible-nginx/compare/0.6.4...galaxyproject:0.7.0
https://github.com/galaxyproject/ansible-gxadmin/compare/0.0.5...galaxyproject:0.0.8