### PR TITLE
uncomment qld mounts and add to aarnet test object store

### DIFF
--- a/files/galaxy/config/aarnet_test_object_store_conf.xml
+++ b/files/galaxy/config/aarnet_test_object_store_conf.xml
@@ -4,10 +4,13 @@
         <backend id="NFS" type="disk" order="0">
             <files_dir path="/mnt/user-data-0" />
         </backend>
-        <!-- <backend id="GPFS" type="disk" order="1">
-            <files_dir path="/mnt/galaxy/files" />
+        <!-- <backend id="NFS" type="disk" order="1">
+            <files_dir path="/mnt/user-data" />
+        </backend> -->
+        <!-- <backend id="GPFS" type="disk" order="2">
+            <files_dir path="/mnt/files" />
         </backend>
-        <backend id="NFS" type="disk" order="2">
+        <backend id="NFS" type="disk" order="3">
             <files_dir path="/mnt/files2" />
         </backend> -->
     </backends>

--- a/group_vars/aarnet_workers.yml
+++ b/group_vars/aarnet_workers.yml
@@ -29,14 +29,14 @@ shared_mounts:
       src: "{{ hostvars['aarnet-job-nfs']['internal_ip'] }}:/mnt/tmp"
       fstype: nfs
       state: mounted
-    # - path: /mnt/files
-    #   src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
-    #   fstype: nfs
-    #   state: mounted
-    # - path: /mnt/files2
-    #   src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
-    #   fstype: nfs
-    #   state: mounted
+    - path: /mnt/files
+      src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
+      fstype: nfs
+      state: mounted
+    - path: /mnt/files2
+      src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
+      fstype: nfs
+      state: mounted
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -55,14 +55,14 @@ shared_mounts:
       src: "{{ hostvars['aarnet-job-nfs']['internal_ip'] }}:/mnt/tmp"
       fstype: nfs
       state: mounted
-    # - path: /mnt/files
-    #   src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
-    #   fstype: nfs
-    #   state: mounted
-    # - path: /mnt/files2
-    #   src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
-    #   fstype: nfs
-    #   state: mounted
+    - path: /mnt/files
+      src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
+      fstype: nfs
+      state: mounted
+    - path: /mnt/files2
+      src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
+      fstype: nfs
+      state: mounted
 
 galaxy_db_user_password: "{{ vault_aarnet_db_user_password }}"  # ** check that this is set
 


### PR DESCRIPTION
Uncomment variables to mount qld filesystems at aarent.

At pawsey /mnt/files has been symlinked to /mnt/galaxy/files because that was the file path in qld.  The database does not store file paths, only dataset ids so setting the path as /mnt/files in object store should be OK.  This is commented out in the object store.  If we wanted to test file access from the galaxy application we'd need to load a backup of the database and uncomment this.