### PR TITLE
upgrade tiaas role

### DIFF
--- a/host_vars/aarnet-db.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-db.usegalaxy.org.au.yml
@@ -73,7 +73,7 @@ postgresql_objects_privileges:
     privs: DELETE
   - database: galaxy
     roles: tiaas
-    objs: galaxy_user,galaxy_session,job,history,workflow,workflow_invocation
+    objs: galaxy_user,galaxy_session,job
     type: table
     privs: SELECT
   - database: galaxy
@@ -86,6 +86,11 @@ postgresql_objects_privileges:
     objs: role_id_seq,galaxy_group_id_seq,group_role_association_id_seq,user_group_association_id_seq
     type: sequence
     privs: USAGE,SELECT
+  - database: galaxy
+    roles: tiaas
+    objs: group_role_association
+    type: table
+    privs: DELETE
 # ***********
 postgresql_objects_databases:
   - name: galaxy

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -160,6 +160,11 @@ tiaas_other_config: |
     TIAAS_SEND_EMAIL_TO = "help@genome.edu.au"
     TIAAS_SEND_EMAIL_FROM = "tiaas-no-reply@usegalaxy.org.au"
 
+  # Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable
+tiaas_disassociate_training_roles:
+  hour: 9      # optional, defaults to 0
+  minute: 0    # optional, defaults to 0
+
 # # Custos/AAF specific settings
 # custos_client_id: "{{ vault_custos_client_id_prod }}"
 # custos_client_secret: "{{ vault_custos_client_secret_prod }}"

--- a/host_vars/dev-db.usegalaxy.org.au.yml
+++ b/host_vars/dev-db.usegalaxy.org.au.yml
@@ -32,7 +32,7 @@ postgresql_objects_privileges:
     privs: DELETE
   - database: galaxy
     roles: tiaas
-    objs: galaxy_user,galaxy_session,job,history,workflow,workflow_invocation
+    objs: galaxy_user,galaxy_session,job
     type: table
     privs: SELECT
   - database: galaxy
@@ -45,6 +45,11 @@ postgresql_objects_privileges:
     objs: role_id_seq,galaxy_group_id_seq,group_role_association_id_seq,user_group_association_id_seq
     type: sequence
     privs: USAGE,SELECT
+  - database: galaxy
+    roles: tiaas
+    objs: group_role_association
+    type: table
+    privs: DELETE
 postgresql_objects_databases:
   - name: galaxy
     owner: galaxy

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -222,6 +222,11 @@ tiaas_info:
   owner_site: "https://dev.usegalaxy.org.au"
   domain: "dev.usegalaxy.org.au"
 
+  # Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable
+tiaas_disassociate_training_roles:
+  hour: 9      # optional, defaults to 0
+  minute: 0    # optional, defaults to 0
+
 # Custos/AAF specific settings
 custos_client_id: "{{ vault_custos_client_id_dev }}"
 custos_client_secret: "{{ vault_custos_client_secret_dev }}"

--- a/host_vars/pawsey-db.usegalaxy.org.au.yml
+++ b/host_vars/pawsey-db.usegalaxy.org.au.yml
@@ -71,7 +71,7 @@ postgresql_objects_privileges:
     privs: DELETE
   - database: galaxy
     roles: tiaas
-    objs: galaxy_user,galaxy_session,job,history,workflow,workflow_invocation
+    objs: galaxy_user,galaxy_session,job
     type: table
     privs: SELECT
   - database: galaxy
@@ -84,6 +84,11 @@ postgresql_objects_privileges:
     objs: role_id_seq,galaxy_group_id_seq,group_role_association_id_seq,user_group_association_id_seq
     type: sequence
     privs: USAGE,SELECT
+  - database: galaxy
+    roles: tiaas
+    objs: group_role_association
+    type: table
+    privs: DELETE
 postgresql_objects_databases:
   - name: galaxy
     owner: galaxy

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -154,6 +154,11 @@ tiaas_other_config: |
     TIAAS_SEND_EMAIL_TO = "help@genome.edu.au"
     TIAAS_SEND_EMAIL_FROM = "tiaas-no-reply@usegalaxy.org.au"
 
+  # Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable
+tiaas_disassociate_training_roles:
+  hour: 9      # optional, defaults to 0
+  minute: 0    # optional, defaults to 0
+
 # # Custos/AAF specific settings
 # custos_client_id: "{{ vault_custos_client_id_prod }}"
 # custos_client_secret: "{{ vault_custos_client_secret_prod }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -30,7 +30,7 @@
 - src: galaxyproject.gxadmin
   version: 0.0.8
 - src: usegalaxy_eu.tiaas2
-  version: 0.0.1
+  version: 0.0.8
 - src: geerlingguy.docker
   version: 2.6.0
 - src: usegalaxy_eu.gie_proxy


### PR DESCRIPTION
It asks for fewer select permissions for the tiaas db user and an additional delete permission for group_role_association.  There is also `tiaas_disassociate_training_roles`:

```
# Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable
tiaas_disassociate_training_roles:
  hour: 0      # optional, defaults to 0
  minute: 0    # optional, defaults to 0
```

Looks like sets a daily cron job to delete sessions that have finished at an hour and minute that we can set, or have `tiaas_disassociate_training_roles: false` to not set the cron.

I've tentatively set these to `hour: 9` so that they clean up at 7pm