### PR TITLE
add another worker to mel3

### DIFF
--- a/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
@@ -44,7 +44,7 @@ slurm_nodes:
 
 slurm_partitions:
     - name: main
-      nodes: "pulsar-mel3-w1,pulsar-mel3-w2,pulsar-mel3-w3,pulsar-mel3-w4,,pulsar-mel3-w6"
+      nodes: "pulsar-mel3-w1,pulsar-mel3-w2,pulsar-mel3-w3,pulsar-mel3-w4,pulsar-mel3-w5,pulsar-mel3-w6"
       Default: YES
       MaxTime: INFINITE
       State: UP

--- a/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
@@ -36,10 +36,15 @@ slurm_nodes:
       CPUs: 32
       RealMemory: 125812
       State: UNKNOWN
+    - name: pulsar-mel3-w6
+      NodeAddr: "{{ hostvars['pulsar-mel3-w6']['ansible_ssh_host'] }}"
+      CPUs: 16
+      RealMemory: 64419
+      State: UNKNOWN
 
 slurm_partitions:
     - name: main
-      nodes: "pulsar-mel3-w1,pulsar-mel3-w2,pulsar-mel3-w3,pulsar-mel3-w4,pulsar-mel3-w5"
+      nodes: "pulsar-mel3-w1,pulsar-mel3-w2,pulsar-mel3-w3,pulsar-mel3-w4,,pulsar-mel3-w6"
       Default: YES
       MaxTime: INFINITE
       State: UP

--- a/hosts
+++ b/hosts
@@ -146,6 +146,7 @@ pulsar-mel3-w2 ansible_ssh_host=115.146.84.238
 pulsar-mel3-w3 ansible_ssh_host=115.146.87.129
 pulsar-mel3-w4 ansible_ssh_host=115.146.86.181
 pulsar-mel3-w5 ansible_ssh_host=115.146.86.108
+pulsar-mel3-w6 ansible_ssh_host=115.146.86.64
 
 [pulsar_nci_test_head]
 pulsar-nci-test ansible_ssh_host=130.56.246.138 internal_ip=10.0.2.29

--- a/terraform/pulsar-mel3/pulsar-mel3-initial.tf
+++ b/terraform/pulsar-mel3/pulsar-mel3-initial.tf
@@ -1,7 +1,7 @@
 # Pulsar-mel3
 resource "openstack_compute_instance_v2" "pulsar-mel3" {
   name            = "pulsar-mel3"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "r3.large"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -11,7 +11,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3" {
 #Workers
 resource "openstack_compute_instance_v2" "pulsar-mel3-w1" {
   name            = "pulsar-mel2-w1"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "r3.xlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -20,7 +20,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w1" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w2" {
   name            = "pulsar-mel3-w2"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "r3.xlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -29,7 +29,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w2" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w3" {
   name            = "pulsar-mel3-w3"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "c3.xxlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -38,7 +38,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w3" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w4" {
   name            = "pulsar-mel3-w4"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "c3.xxlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -47,7 +47,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w4" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w5" {
   name            = "pulsar-mel3-w5"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "r3.xxlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -56,7 +56,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w5" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w6" {
   name            = "pulsar-mel3-w6"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_id        = "8faa45cc-2c97-40db-a12d-648c303cd567"
   flavor_name     = "r3.xlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]

--- a/terraform/pulsar-mel3/pulsar-mel3-initial.tf
+++ b/terraform/pulsar-mel3/pulsar-mel3-initial.tf
@@ -1,7 +1,7 @@
 # Pulsar-mel3
 resource "openstack_compute_instance_v2" "pulsar-mel3" {
   name            = "pulsar-mel3"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
   flavor_name     = "r3.large"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -11,7 +11,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3" {
 #Workers
 resource "openstack_compute_instance_v2" "pulsar-mel3-w1" {
   name            = "pulsar-mel2-w1"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
   flavor_name     = "r3.xlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -20,7 +20,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w1" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w2" {
   name            = "pulsar-mel3-w2"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
   flavor_name     = "r3.xlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -29,7 +29,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w2" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w3" {
   name            = "pulsar-mel3-w3"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
   flavor_name     = "c3.xxlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -38,7 +38,7 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w3" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w4" {
   name            = "pulsar-mel3-w4"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
   flavor_name     = "c3.xxlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
@@ -47,8 +47,17 @@ resource "openstack_compute_instance_v2" "pulsar-mel3-w4" {
 
 resource "openstack_compute_instance_v2" "pulsar-mel3-w5" {
   name            = "pulsar-mel3-w5"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64 [v9]"
   flavor_name     = "r3.xxlarge"
+  key_pair        = "galaxy-australia"
+  security_groups = ["SSH", "default"]
+  availability_zone = "melbourne-qh2"
+}
+
+resource "openstack_compute_instance_v2" "pulsar-mel3-w6" {
+  name            = "pulsar-mel3-w6"
+  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  flavor_name     = "r3.xlarge"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
   availability_zone = "melbourne-qh2"
@@ -98,6 +107,13 @@ resource "openstack_blockstorage_volume_v2" "pulsar-mel3-w5-volume" {
   size        = 200
 }
 
+resource "openstack_blockstorage_volume_v2" "pulsar-mel3-w6-volume" {
+  availability_zone = "melbourne-qh2"
+  name        = "pulsar-mel3-w6-volume"
+  description = "Pulsar-mel3 w6 volume"
+  size        = 200
+}
+
 # Attachment between application/web server and volume
 resource "openstack_compute_volume_attach_v2" "attach-mel3-volume-to-mel3" {
   instance_id = "${openstack_compute_instance_v2.pulsar-mel3.id}"
@@ -127,4 +143,9 @@ resource "openstack_compute_volume_attach_v2" "attach-mel3-w4-volume-to-mel3-w4"
 resource "openstack_compute_volume_attach_v2" "attach-mel3-w5-volume-to-mel3-w5" {
   instance_id = "${openstack_compute_instance_v2.pulsar-mel3-w5.id}"
   volume_id   = "${openstack_blockstorage_volume_v2.pulsar-mel3-w5-volume.id}"
+}
+
+resource "openstack_compute_volume_attach_v2" "attach-mel3-w6-volume-to-mel3-w6" {
+  instance_id = "${openstack_compute_instance_v2.pulsar-mel3-w6.id}"
+  volume_id   = "${openstack_blockstorage_volume_v2.pulsar-mel3-w6-volume.id}"
 }


### PR DESCRIPTION
the image names of the existing VMs needed to be changed to match their image ids, otherwise terraform wanted to replace them