### PR TITLE
added CR_CPU_Memory to dev slurm so galaxy mem env works

### DIFF
--- a/group_vars/dev_slurm.yml
+++ b/group_vars/dev_slurm.yml
@@ -44,6 +44,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key


### PR DESCRIPTION
This should fix the mem env var problem. Can you run this on dev, dev workers and queue please?