### PR TITLE
fix pulsar cron job for empty lists

### DIFF
--- a/roles/remote-pulsar-cron/templates/remove_pulsar_jwds.py.j2
+++ b/roles/remote-pulsar-cron/templates/remove_pulsar_jwds.py.j2
@@ -46,6 +46,13 @@ def get_current_time():
     return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
 
+def log_nothing_to_remove(keep_error_days, dry_run):
+    with open(log_file, 'a+') as log_handle:
+        dry_run_text = ' [dry run]' if dry_run else ''
+        log_handle.write(f'{get_current_time()}: Running delete jwds script for {pulsar_name} keep_error_days {keep_error_days}{dry_run_text}\n')
+        log_handle.write('No job working directories to remove.\n\n')
+
+
 def main():
     parser = argparse.ArgumentParser(description='Write a script to remove job working dirs that can be removed on pulsar')
     parser.add_argument(
@@ -65,6 +72,10 @@ def main():
     job_ids = sanitize_subprocess_output_list(f'ssh -i {ssh_key} {remote_user}@{pulsar_ip_address} \"ls {pulsar_staging_dir}\"')
     job_ids = [jid for jid in job_ids if is_job_id(jid)] # filter out anything that may not be a job working directory
 
+    if not job_ids:
+        log_nothing_to_remove(keep_error_days, dry_run)
+        return
+
     def get_job_query(state, save_days=None):
         query = f'psql -t -d {connection_string} -c \"select j.id from job j where j.state = \'{state}\' and j.id in ({", ".join(job_ids)})'
         if save_days:
@@ -78,6 +89,10 @@ def main():
         error_job_ids = sanitize_subprocess_output_list(get_job_query(state='error', save_days=keep_error_days))
     else:
         error_job_ids = []
+
+    if len(ok_job_ids + deleted_job_ids + error_job_ids) == 0:
+        log_nothing_to_remove(keep_error_days, dry_run)
+        return
 
     with open(rm_jwds_script, 'w') as handle:
         handle.write('#!/bin/bash\n\n')
@@ -102,8 +117,8 @@ def main():
         print(job_query_result)
 
     with open(log_file, 'a+') as log_handle:
-        dry_run = ' [dry run]' if dry_run else ''
-        log_handle.write(f'{get_current_time()}: Running delete jwds script for {pulsar_name} keep_error_days {keep_error_days}{dry_run}\n')
+        dry_run_text = ' [dry run]' if dry_run else ''
+        log_handle.write(f'{get_current_time()}: Running delete jwds script for {pulsar_name} keep_error_days {keep_error_days}{dry_run_text}\n')
         log_handle.write(job_query_result)
 
         log_handle.write('Copying script to remote pulsar\n')


### PR DESCRIPTION
The script throws an error when there is nothing to remove.  Exit early and log 'nothing to remove' instead.