### PR TITLE
update aarnet-db playbook

### DIFF
--- a/aarnet-db_playbook.yml
+++ b/aarnet-db_playbook.yml
@@ -15,17 +15,52 @@
             name: python3-psycopg2
             state: present
         become: true
-      - name: give /data 777 so postgres can create data_directory
-        file:
-          path: /data
-          state: directory
-          mode: 0777
   roles:
       - common
       - insspb.hostname
       - geerlingguy.pip
       - galaxyproject.postgresql
-      - role: natefoo.postgresql_objects
-        become: true
-        become_user: postgres
       - dj-wasabi.telegraf
+  post_tasks:
+    - name: stat data directory
+      stat:
+        path: "{{ postgresql_pgdata }}"
+      register: data_dir
+    - name: move the data directory
+      block:
+        - name: get postgresql version string
+          shell: pg_config --version
+          register: version_string
+        - name: set postgresql_version_major
+          set_fact:
+            postgresql_version_major: "{{ version_string | regex_findall('PostgreSQL ([0-9]+).') | first }}"
+        - name: stop postgres
+          service:
+            name: postgresql
+            state: stopped
+        - name: create data directory
+          file:
+            path: "{{ postgresql_pgdata }}"
+            state: directory
+            mode: 0700
+            owner: postgres    
+            group: postgres
+        - name: Run initdB
+          command:
+            cmd: "/usr/lib/postgresql/{{ postgresql_version_major }}/bin/initdb -D {{ postgresql_pgdata }}"
+          become: true
+          become_user: postgres
+        - name: Start postgresql with -D data_directory
+          command:
+            cmd: "/usr/lib/postgresql/{{ postgresql_version_major }}/bin/pg_ctl -D {{ postgresql_pgdata }} start"
+          become: true
+          become_user: postgres
+        - name: override postgresql_objects_privileges since there are not any tables yet
+          set_fact:
+            postgresql_objects_privileges: []
+      when: not data_dir.stat.exists
+    - name: run postgresql objects role
+      import_role:
+        name: natefoo.postgresql_objects
+      become: true
+      become_user: postgres


### PR DESCRIPTION
Update aarnet-db playbook with a block of post-tasks that will create and initialise the data_directory after the galaxyproject.postgresql task has run, when it does not exist yet.