### PR TITLE
send pulsar-mel_big jobs to mel3 temporarily

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -301,7 +301,7 @@ tools:
             nice_value: 0
             lower_bound: 1 MB
             upper_bound: 10 MB
-            destination: pulsar-mel_big
+            destination: pulsar-mel3_mid
           - rule_type: file_size
             nice_value: 0
             lower_bound: 10 MB
@@ -486,7 +486,7 @@ tools:
             nice_value: 0
             lower_bound: 2 GB
             upper_bound: 7 GB
-            destination: pulsar-mel_big
+            destination: pulsar-mel3_mid
           - rule_type: file_size
             nice_value: 0
             lower_bound: 7 GB
@@ -592,7 +592,7 @@ tools:
               nice_value: 0
               lower_bound: 100 MB
               upper_bound: 5 GB
-              destination: pulsar-mel_big
+              destination: pulsar-mel3_mid
             - rule_type: file_size
               nice_value: 0
               lower_bound: 5 GB
@@ -610,7 +610,7 @@ tools:
               nice_value: 0
               lower_bound: 500 MB
               upper_bound: 5 GB
-              destination: pulsar-mel_big
+              destination: pulsar-mel3_mid
             - rule_type: file_size
               nice_value: 0
               lower_bound: 5 GB
@@ -705,7 +705,7 @@ tools:
               nice_value: 0
               lower_bound: 200 MB
               upper_bound: 10 GB
-              destination: pulsar-mel_big
+              destination: pulsar-mel3_mid
         default_destination: slurm_9slots
     deseq2:
         default_destination: slurm_3slots
@@ -1019,7 +1019,7 @@ tools:
               nice_value: 0
               lower_bound: 500 MB
               upper_bound: 5 GB
-              destination: pulsar-mel_big
+              destination: pulsar-mel3_mid
             - rule_type: file_size
               nice_value: -5
               lower_bound: 0


### PR DESCRIPTION
there are a bunch of jobs for pulsar-mel_big that will not queue because pulsar failures last night have caused that destination to become full while nothing is running.  Temporarily send these jobs to pulsar-mel3_mid which is the same size.

with total perspective vortex we will never have to worry about this happening..