### PR TITLE
.config folder in home directories should be owned by users

### DIFF
--- a/roles/pg-post-tasks/tasks/main.yml
+++ b/roles/pg-post-tasks/tasks/main.yml
@@ -8,6 +8,8 @@
       file:
         path: "/home/{{ item }}/.config"
         state: directory
+        group: "{{ item }}"
+        owner: "{{ item }}"
       with_items: "{{ (machine_users | map(attribute='name') | list) + ['ubuntu'] }}"
     - name: Ensure that all users + ubuntu have a copy of gxadmin-local.sh
       copy: 


### PR DESCRIPTION
/home/<username/.config is owned by root which is a bug