### PR TITLE
aarnet testing object store and var changes

### DIFF
--- a/files/galaxy/config/aarnet_object_store_conf.xml
+++ b/files/galaxy/config/aarnet_object_store_conf.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<object_store type="hierarchical">
+    <backends>
+        <backend id="aarnetNFS3" type="disk" order="0">
+            <files_dir path="/mnt/user-data-3/test" />
+        </backend>
+        <!--
+            <backend id="perthNFS1" type="disk" order="1">
+                <files_dir path="/mnt/user-data" />
+            </backend>
+            <backend id="perthNFS2" type="disk" order="2">
+                <files_dir path="/mnt/user-data-2" />
+            </backend>
+        -->
+        <backend id="GPFS" type="disk" order="3">
+            <files_dir path="/mnt/galaxy/files" />
+        </backend>
+        <backend id="NFS" type="disk" order="4">
+            <files_dir path="/mnt/files2" />
+        </backend>
+    </backends>
+</object_store>
+

--- a/files/galaxy/dynamic_job_rules/aarnet/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/aarnet/dynamic_rules/tool_destinations.yml
@@ -2,14 +2,14 @@
 tools:
     upload1:
         default_destination: slurm_1slot_upload
-    fastqc:
-        rules:
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 0
-            upper_bound: 1 MB
-            destination: pulsar-nci-test_small
-        default_destination: pulsar-nci-test_mid
+    # fastqc:
+    #     rules:
+    #       - rule_type: file_size
+    #         nice_value: 0
+    #         lower_bound: 0
+    #         upper_bound: 1 MB
+    #         destination: pulsar-nci-test_small
+    #     default_destination: pulsar-nci-test_mid
 
 default_destination: slurm_2slots
 

--- a/group_vars/aarnet_workers.yml
+++ b/group_vars/aarnet_workers.yml
@@ -17,14 +17,14 @@ shared_mounts:
       src: "{{ hostvars['aarnet-misc-nfs']['internal_ip'] }}:/mnt/tools-indices"
       fstype: nfs
       state: mounted
-    - path: /mnt/user-data
-      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data"
-      fstype: nfs
-      state: mounted
-    - path: /mnt/user-data-2
-      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data-2"
-      fstype: nfs
-      state: mounted
+    # - path: /mnt/user-data
+    #   src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data"
+    #   fstype: nfs
+    #   state: mounted
+    # - path: /mnt/user-data-2
+    #   src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data-2"
+    #   fstype: nfs
+    #   state: mounted
     - path: /mnt/user-data-3
       src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/aarnet/user-data-3"
       fstype: nfs

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -43,14 +43,14 @@ shared_mounts:
       src: "{{ hostvars['aarnet-misc-nfs']['internal_ip'] }}:/mnt/tools-indices"
       fstype: nfs
       state: mounted
-    - path: /mnt/user-data
-      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data"
-      fstype: nfs
-      state: mounted
-    - path: /mnt/user-data-2
-      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data-2"
-      fstype: nfs
-      state: mounted
+    # - path: /mnt/user-data
+    #   src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data"
+    #   fstype: nfs
+    #   state: mounted
+    # - path: /mnt/user-data-2
+    #   src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/perth/user-data-2"
+    #   fstype: nfs
+    #   state: mounted
     - path: /mnt/user-data-3
       src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/aarnet/user-data-3"
       fstype: nfs
@@ -83,7 +83,7 @@ galaxy_tmp_dir: /mnt/tmp
 
 galaxy_handler_count: 5
 
-galaxy_file_path: /mnt/user-data-2
+galaxy_file_path: /mnt/user-data-3/test
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
@@ -92,7 +92,7 @@ nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
 tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }},{{ galaxy_config_dir }}/tool_conf_interactive.xml"
 
 host_galaxy_config_files:
-  - src: "{{ galaxy_config_file_src_dir }}/config/object_store_conf.xml"
+  - src: "{{ galaxy_config_file_src_dir }}/config/aarnet_object_store_conf.xml"
     dest: "{{ galaxy_config_dir }}/object_store_conf.xml"
 
 host_galaxy_config:  # renamed from __galaxy_config

--- a/host_vars/aarnet_job_conf.yml
+++ b/host_vars/aarnet_job_conf.yml
@@ -15,17 +15,17 @@ galaxy_jobconf:
         load: "galaxy.jobs.runners.slurm:SlurmJobRunner"
       - id: pulsar_rest
         load: "galaxy.jobs.runners.pulsar:PulsarRESTJobRunner"
-      - id: pulsar_nci_test_runner
-        load: galaxy.jobs.runners.pulsar:PulsarMQJobRunner
-        params:
-            amqp_url: "pyamqp://galaxy_nci_test:{{ vault_rabbitmq_password_galaxy_nci_test }}@aarnet-queue.usegalaxy.org.au:5671//pulsar/galaxy_nci_test?ssl=1"
-            galaxy_url: "https://aarnet.usegalaxy.org.au"
-            manager: _default_
-            amqp_acknowledge: True
-            amqp_ack_republish_time: 1200
-            amqp_consumer_timeout: 2.0
-            amqp_publish_retry: True
-            amqp_publish_retry_max_retries: 60
+      # - id: pulsar_nci_test_runner
+      #   load: galaxy.jobs.runners.pulsar:PulsarMQJobRunner
+      #   params:
+      #       amqp_url: "pyamqp://galaxy_nci_test:{{ vault_rabbitmq_password_galaxy_nci_test }}@aarnet-queue.usegalaxy.org.au:5671//pulsar/galaxy_nci_test?ssl=1"
+      #       galaxy_url: "https://aarnet.usegalaxy.org.au"
+      #       manager: _default_
+      #       amqp_acknowledge: True
+      #       amqp_ack_republish_time: 1200
+      #       amqp_consumer_timeout: 2.0
+      #       amqp_publish_retry: True
+      #       amqp_publish_retry_max_retries: 60
       # - id: pulsar_mel2_runner
       #   load: "galaxy.jobs.runners.pulsar:PulsarMQJobRunner"
       #   params:
@@ -164,39 +164,39 @@ galaxy_jobconf:
           require_container: true
           container_monitor_result: callback
           submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760 --partition=interactive_tools"
-      - id: pulsar-nci-test_small
-        runner: pulsar_nci_test_runner
-        params:
-              jobs_directory: /mnt/pulsar/files/staging
-              transport: curl
-              remote_metadata: "false"
-              default_file_action: remote_transfer
-              dependency_resolution: remote
-              rewrite_parameters: "true"
-              persistence_directory: /mnt/pulsar/files/persisted_data
-              submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2"
-      - id: pulsar-nci-test_mid
-        runner: pulsar_nci_test_runner
-        params:
-              jobs_directory: /mnt/pulsar/files/staging
-              transport: curl
-              remote_metadata: "false"
-              default_file_action: remote_transfer
-              dependency_resolution: remote
-              rewrite_parameters: "true"
-              persistence_directory: /mnt/pulsar/files/persisted_data
-              submit_native_specification: "--nodes=1 --ntasks=8 --ntasks-per-node=8"
-      - id: pulsar-nci-test_big
-        runner: pulsar_nci_test_runner
-        params:
-              jobs_directory: /mnt/pulsar/files/staging
-              transport: curl
-              remote_metadata: "false"
-              default_file_action: remote_transfer
-              dependency_resolution: remote
-              rewrite_parameters: "true"
-              persistence_directory: /mnt/pulsar/files/persisted_data
-              submit_native_specification: "--nodes=1 --ntasks=16 --ntasks-per-node=16"
+      # - id: pulsar-nci-test_small
+      #   runner: pulsar_nci_test_runner
+      #   params:
+      #         jobs_directory: /mnt/pulsar/files/staging
+      #         transport: curl
+      #         remote_metadata: "false"
+      #         default_file_action: remote_transfer
+      #         dependency_resolution: remote
+      #         rewrite_parameters: "true"
+      #         persistence_directory: /mnt/pulsar/files/persisted_data
+      #         submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2"
+      # - id: pulsar-nci-test_mid
+      #   runner: pulsar_nci_test_runner
+      #   params:
+      #         jobs_directory: /mnt/pulsar/files/staging
+      #         transport: curl
+      #         remote_metadata: "false"
+      #         default_file_action: remote_transfer
+      #         dependency_resolution: remote
+      #         rewrite_parameters: "true"
+      #         persistence_directory: /mnt/pulsar/files/persisted_data
+      #         submit_native_specification: "--nodes=1 --ntasks=8 --ntasks-per-node=8"
+      # - id: pulsar-nci-test_big
+      #   runner: pulsar_nci_test_runner
+      #   params:
+      #         jobs_directory: /mnt/pulsar/files/staging
+      #         transport: curl
+      #         remote_metadata: "false"
+      #         default_file_action: remote_transfer
+      #         dependency_resolution: remote
+      #         rewrite_parameters: "true"
+      #         persistence_directory: /mnt/pulsar/files/persisted_data
+      #         submit_native_specification: "--nodes=1 --ntasks=16 --ntasks-per-node=16"
       # Pulsar mel destinations
       # - id: pulsar-mel_small
       #   runner: pulsar_mel2_runner


### PR DESCRIPTION
`galaxy_file_path: /mnt/user-data-3/test` + separate object store file for aarnet.

job_conf has all pulsars commented out.  pulsar-nci-test could be enabled but there seems no need to switch it away from dev before Monday.

Maybe leave this open for now.

