### PR TITLE
update pulsar-post-tasks to set permissions on new folder

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -98,7 +98,7 @@ pulsar_yaml_config:
   amqp_publish_retry_interval_max: 60
 
 # for pulsar-post-tasks
-galaxy_dir: /mnt/galaxy
+pulsar_tools_indices_dir: /mnt/tools-indices
 
 #Stats collection
 sinfo_line_startswith: "p"

--- a/pulsar-mel2_playbook.yml
+++ b/pulsar-mel2_playbook.yml
@@ -30,3 +30,6 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
+  post_tasks:
+    - name: Reload exportfs
+      command: exportfs -ra

--- a/pulsar-mel3_playbook.yml
+++ b/pulsar-mel3_playbook.yml
@@ -38,3 +38,5 @@
         state: link
         owner: ubuntu
         group: ubuntu
+    - name: Reload exportfs
+      command: exportfs -ra

--- a/pulsar-nci-test_playbook.yml
+++ b/pulsar-nci-test_playbook.yml
@@ -21,4 +21,7 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
+  post_tasks:
+    - name: Reload exportfs
+      command: exportfs -ra
     

--- a/pulsar-nci-training_playbook.yml
+++ b/pulsar-nci-training_playbook.yml
@@ -26,3 +26,6 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
+  post_tasks:
+    - name: Reload exportfs
+      command: exportfs -ra

--- a/pulsar-paw_playbook.yml
+++ b/pulsar-paw_playbook.yml
@@ -30,3 +30,6 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
+  post_tasks:
+    - name: Reload exportfs
+      command: exportfs -ra

--- a/roles/pulsar-post-tasks/tasks/main.yml
+++ b/roles/pulsar-post-tasks/tasks/main.yml
@@ -3,16 +3,16 @@
   package:
     name: slurm-drmaa1
     state: present
-- name: own the pulsar_root dirs as ubuntu
+- name: own the pulsar_root dir as ubuntu
   file:
       path: "{{ pulsar_root }}"
       owner: ubuntu
       group: ubuntu
       state: directory
       mode: 0755
-- name: own the galaxy_dir dirs as ubuntu
+- name: own the pulsar_tools_indices_dir as ubuntu
   file:
-      path: "{{ galaxy_dir }}"
+      path: "{{ pulsar_tools_indices_dir }}"
       owner: ubuntu
       group: ubuntu
       state: directory
@@ -21,5 +21,3 @@
   systemd:
     name: munge
     state: restarted
-- name: Reload exportfs
-  command: exportfs -ra

--- a/staging-pulsar_playbook.yml
+++ b/staging-pulsar_playbook.yml
@@ -25,3 +25,4 @@
     - galaxyproject.cvmfs
     - pulsar-post-tasks
     - slurm-post-tasks
+


### PR DESCRIPTION
remove exportfs command from pulsar-post-tasks because not all pulsars need it and it breaks on the high-mems