### PR TITLE
delete some rules in tool_destinations.yml

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -9,12 +9,7 @@ tools:
             lower_bound: 0
             upper_bound: 10 MB
             destination: slurm_1slot
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 10 MB
-            upper_bound: Infinity
-            destination: slurm_5slots
-        default_destination: slurm_1slot
+        default_destination: slurm_5slots
     scanpy_cluster_reduce_dimension:
         rules:
           - rule_type: file_size
@@ -22,11 +17,6 @@ tools:
             lower_bound: 0
             upper_bound: 500 MB
             destination: slurm_1slot
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 500 MB
-            upper_bound: Infinity
-            destination: slurm_5slots
         default_destination: slurm_5slots
     scanpy_inspect:
         rules:
@@ -35,11 +25,6 @@ tools:
             lower_bound: 0
             upper_bound: 500 MB
             destination: slurm_1slot
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 500 MB
-            upper_bound: Infinity
-            destination: slurm_5slots
         default_destination: slurm_5slots
     scanpy_filter:
         rules:
@@ -48,11 +33,6 @@ tools:
             lower_bound: 0
             upper_bound: 500 MB
             destination: slurm_1slot
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 500 MB
-            upper_bound: Infinity
-            destination: slurm_3slots
         default_destination: slurm_3slots
     scanpy_normalize:
         rules:
@@ -61,11 +41,6 @@ tools:
             lower_bound: 0
             upper_bound: 1 GB
             destination: slurm_1slot
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 1 GB
-            upper_bound: Infinity
-            destination: slurm_2slots
         default_destination: slurm_2slots
     scanpy_remove_confounders:
         rules:
@@ -79,12 +54,7 @@ tools:
             lower_bound: 50 MB
             upper_bound: 500 MB
             destination: slurm_5slots
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 500 MB
-            upper_bound: Infinity
-            destination: slurm_9slots
-        default_destination: slurm_5slots
+        default_destination: slurm_9slots
     shovill:
         rules:
           - rule_type: file_size
@@ -139,7 +109,7 @@ tools:
             nice_value: 0
             lower_bound: 0
             upper_bound: 50 MB
-            destination: slurm_1slot
+            destination: pulsar-mel3_small
           - rule_type: file_size
             nice_value: 0
             lower_bound: 50 MB
@@ -222,52 +192,16 @@ tools:
     trinity_align_and_estimate_abundance:
         default_destination: pulsar-mel3_big_trinity
     ggplot2_point:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 20 MB
-              destination: slurm_1slot
         default_destination: slurm_1slot
     datamash_ops:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 20 MB
-              destination: slurm_1slot
         default_destination: slurm_1slot
     Grouping1:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 20 MB
-              destination: slurm_1slot
         default_destination: slurm_1slot
     tp_sorted_uniq:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 20 MB
-              destination: slurm_1slot
         default_destination: slurm_1slot
     Cut1:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 20 MB
-              destination: slurm_1slot
         default_destination: slurm_1slot
     Remove beginning1:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 20 MB
-              destination: slurm_1slot
         default_destination: slurm_1slot
     cshl_fastq_quality_filter:
         rules:
@@ -330,12 +264,7 @@ tools:
             lower_bound: 1 MB
             upper_bound: 1 GB
             destination: pulsar-mel3_mid
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 1 GB
-            upper_bound: 20 GB
-            destination: pulsar-mel3_big
-        default_destination: slurm_5slots
+        default_destination: pulsar-mel3_big
     hyphy_gard:
         rules:
           - rule_type: file_size
@@ -492,12 +421,7 @@ tools:
             lower_bound: 2 GB
             upper_bound: 7 GB
             destination: pulsar-mel_big
-          - rule_type: file_size
-            nice_value: 0
-            lower_bound: 7 GB
-            upper_bound: Infinity
-            destination: pulsar-mel3_mid
-        default_destination: slurm_3slots
+        default_destination: pulsar-mel3_mid
     iuc_pear:
         rules:
             - rule_type: file_size
@@ -510,12 +434,7 @@ tools:
               lower_bound: 15 MB
               upper_bound: 1 GB
               destination: slurm_5slots
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 1 GB
-              upper_bound: Infinity
-              destination: slurm_7slots
-        default_destination: slurm_5slots
+        default_destination: slurm_7slots
     trimmomatic:
         rules:
             - rule_type: file_size
@@ -541,7 +460,7 @@ tools:
               lower_bound: 5 MB
               upper_bound: 20 MB
               destination: pulsar-mel_mid
-        default_destination: slurm_3slots
+        default_destination: pulsar-mel3_mid
     snippy:
         rules:
             - rule_type: file_size
@@ -562,11 +481,6 @@ tools:
               lower_bound: 250 MB
               upper_bound: 1 GB
               destination: pulsar-mel_mid
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 1 GB
-              upper_bound: 10 GB
-              destination: pulsar-mel3_mid
         default_destination: pulsar-mel3_mid
     bwa_mem:
         rules:
@@ -580,12 +494,7 @@ tools:
               lower_bound: 250 MB
               upper_bound: 1 GB
               destination: pulsar-mel_mid
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 1 GB
-              upper_bound: 10 GB
-              destination: pulsar-mel3_mid
-        default_destination: slurm_7slots
+        default_destination: pulsar-mel3_mid
     bowtie2:
         rules:
             - rule_type: file_size
@@ -598,12 +507,7 @@ tools:
               lower_bound: 100 MB
               upper_bound: 5 GB
               destination: pulsar-mel_big
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 5 GB
-              upper_bound: Infinity
-              destination: pulsar-mel3_mid
-        default_destination: slurm_5slots
+        default_destination: pulsar-mel3_mid
     hisat2:
         rules:
             - rule_type: file_size
@@ -621,12 +525,7 @@ tools:
               lower_bound: 5 GB
               upper_bound: 20 GB
               destination: pulsar-mel3_mid
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 20 GB
-              upper_bound: Infinity
-              destination: slurm_16slots
-        default_destination: slurm_5slots
+        default_destination: pulsar-mel3_big
     tophat2:
         rules:
             - rule_type: file_size
@@ -634,17 +533,7 @@ tools:
               lower_bound: 0
               upper_bound: 500 MB
               destination: slurm_1slot
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 500 MB
-              upper_bound: 20 GB
-              destination: pulsar-mel3_mid
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 20 GB
-              upper_bound: Infinity
-              destination: slurm_7slots
-        default_destination: slurm_5slots
+        default_destination: pulsar-mel3_mid
     freebayes:
         rules:
             - rule_type: file_size
@@ -681,11 +570,6 @@ tools:
               lower_bound: 500 MB
               upper_bound: 10 GB
               destination: slurm_5slots
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 10 GB
-              upper_bound: Infinity
-              destination: slurm_7slots
         default_destination: slurm_7slots
     lofreq_call:
         default_destination: slurm_5slots
@@ -740,18 +624,7 @@ tools:
               destination: slurm_5slots
         default_destination: slurm_2slots
     fastq_groomer:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 100 MB
-              destination: slurm_1slot
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 100 MB
-              upper_bound: 20 GB
-              destination: pulsar-mel3_small
-        default_destination: slurm_2slots
+        default_destination: pulsar-mel3_small
     iqtree:
         rules:
             - rule_type: file_size
@@ -775,12 +648,6 @@ tools:
     Extract genomic DNA 1:
         default_destination: slurm_3slots
     snpEff:
-        rules:
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 0
-              upper_bound: 100 MB
-              destination: slurm_3slots
         default_destination: slurm_3slots
     snpSift_annotate:
         default_destination: slurm_3slots
@@ -803,12 +670,7 @@ tools:
               lower_bound: 0
               upper_bound: 500 MB
               destination: slurm_1slot
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 500 MB
-              upper_bound: 10 GB
-              destination: pulsar-mel3_small
-        default_destination: slurm_2slots
+        default_destination: pulsar-mel3_small
     cuffmerge:
         rules:
             - rule_type: file_size
@@ -816,11 +678,6 @@ tools:
               lower_bound: 0
               upper_bound: 100 MB
               destination: slurm_1slot
-            - rule_type: file_size
-              nice_value: 10
-              lower_bound: 100 MB
-              upper_bound: Infinity
-              destination: slurm_3slots
         default_destination: slurm_3slots
     cufflinks:
         rules:
@@ -830,15 +687,10 @@ tools:
               upper_bound: 100 MB
               destination: slurm_1slot
             - rule_type: file_size
-              nice_value: 10
+              nice_value: 0
               lower_bound: 100 MB
               upper_bound: 4 GB
               destination: slurm_3slots
-            - rule_type: file_size
-              nice_value: 10
-              lower_bound: 4 GB
-              upper_bound: Infinity
-              destination: slurm_5slots
         default_destination: slurm_5slots
     velveth:
         default_destination: slurm_2slots
@@ -862,12 +714,7 @@ tools:
               lower_bound: 20 MB
               upper_bound: 1 GB
               destination: slurm_1slot
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 1 GB
-              upper_bound: 20 GB
-              destination: pulsar-mel3_mid
-        default_destination: slurm_5slots
+        default_destination: pulsar-mel3_mid
     fastq_paired_end_deinterlacer:
         rules:
             - rule_type: file_size
@@ -875,12 +722,7 @@ tools:
               lower_bound: 0
               upper_bound: 1 GB
               destination: slurm_1slot
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 1 GB
-              upper_bound: 20 GB
-              destination: pulsar-mel3_mid
-        default_destination: slurm_5slots
+        default_destination: pulsar-mel3_mid
     deeptools_compute_matrix:
         default_destination: slurm_9slots
     deeptools_plot_heatmap:
@@ -942,36 +784,6 @@ tools:
     macs2_callpeak:
         default_destination: slurm_9slots
     macs2_bdgdiff:
-        default_destination: slurm_5slots
-    gatk2_variant_recalibrator:
-        default_destination: slurm_5slots
-    gatk2_print_reads:
-        default_destination: slurm_5slots
-    gatk2_indel_realigner:
-        default_destination: slurm_5slots
-    gatk2_variant_eval:
-        default_destination: slurm_5slots
-    gatk2_haplotype_caller:
-        default_destination: slurm_5slots
-    gatk2_variant_validate:
-        default_destination: slurm_5slots
-    gatk2_reduce_reads:
-        default_destination: slurm_5slots
-    gatk2_realigner_target_creator:
-        default_destination: slurm_5slots
-    gatk2_depth_of_coverage:
-        default_destination: slurm_5slots
-    gatk2_variant_apply_recalibration:
-        default_destination: slurm_5slots
-    gatk2_variant_filtration:
-        default_destination: slurm_5slots
-    gatk2_base_recalibrator:
-        default_destination: slurm_5slots
-    gatk2_variant_combine:
-        default_destination: slurm_5slots
-    gatk2_variant_select:
-        default_destination: slurm_5slots
-    gatk2_variant_annotator:
         default_destination: slurm_5slots
     ncbi_blastn_wrapper:
         rules:
@@ -1125,12 +937,7 @@ tools:
               lower_bound: 200 MB
               upper_bound: 2 GB
               destination: pulsar-mel3_mid
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 2 GB
-              upper_bound: 60 GB
-              destination: pulsar-mel3_big
-        default_destination: slurm_16slots
+        default_destination: pulsar-mel3_big
     megahit:
         rules:
             - rule_type: file_size
@@ -1667,12 +1474,7 @@ tools:
               lower_bound: 2 MB
               upper_bound: 5 GB
               destination: pulsar-mel3_big
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 5 GB
-              upper_bound: Infinity
-              destination: pulsar-high-mem1_big
-        default_destination: pulsar-mel3_big
+        default_destination: pulsar-high-mem1_big
     shasta:
         rules:
             - rule_type: file_size
@@ -1685,12 +1487,7 @@ tools:
               lower_bound: 2 MB
               upper_bound: 5 GB
               destination: pulsar-mel3_big
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 5 GB
-              upper_bound: Infinity
-              destination: pulsar-high-mem2_big
-        default_destination: pulsar-mel3_big
+        default_destination: pulsar-high-mem2_big
     raven:
         rules:
             - rule_type: file_size
@@ -1703,12 +1500,7 @@ tools:
               lower_bound: 2 MB
               upper_bound: 5 GB
               destination: pulsar-mel3_big
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 5 GB
-              upper_bound: Infinity
-              destination: pulsar-high-mem2_big
-        default_destination: pulsar-mel3_big
+        default_destination: pulsar-high-mem2_big
     gmx_sim:
         rules:
             - rule_type: file_size


### PR DESCRIPTION
Refactor of tool_destinations.yml to remove double definitions of rules, i.e. if there is an X-Infinity rule and a default rule, use the default rule.  There are a couple of changes (slurm -> pulsar) where it seems sensible, for example very large hisat2 jobs were defaulting to slurm_16slots and will now go to pulsar-mel3_big.