### PR TITLE
skip update labels on staging

### DIFF
--- a/jenkins/update_labels/update_tool_labels.sh
+++ b/jenkins/update_labels/update_tool_labels.sh
@@ -17,6 +17,7 @@ fi
 
 echo "secret" > .vault_pass.txt  # ansible needs .vault_pass.txt to exist
 
-ansible-playbook -i hosts jenkins/update_labels/update_tool_labels_playbook.yml --extra-vars "ansible_user=jenkins_bot update_labels_hostname=staging_galaxy_server"
+# skip labels on staging to check whether updated tools without labels added will remain in the tool search index
+# ansible-playbook -i hosts jenkins/update_labels/update_tool_labels_playbook.yml --extra-vars "ansible_user=jenkins_bot update_labels_hostname=staging_galaxy_server"
 
 ansible-playbook -i hosts jenkins/update_labels/update_tool_labels_playbook.yml --extra-vars "ansible_user=jenkins_bot update_labels_hostname=pawsey_galaxy_server"


### PR DESCRIPTION
There is an issue where newly updated tools stop showing up in the tool search until the next restart.  It's not clear whether this is because the tools have new versions, or whether it is because the tools are also being given labels in shed_tool_conf.xml.

Skip labelling on staging so that these can be compared after the next jenkins update run.