### PR TITLE
define the native spec twice so that wherever it goes, one of the keys is correct

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -8,6 +8,7 @@ tools:
     env: {}
     params:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={mem*1024}"
+      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={mem*1024}"
     scheduling:
       prefer:
       accept:


### PR DESCRIPTION
The native specification only has to be defined for the default tool and for anything that uses a different partition, i.e. the training role or maxquant.

Neither pulsar nor slurm has a problem with the extra parameter