### PR TITLE
reduce mem for destinations based on MemTotal

### DIFF
--- a/host_vars/pawsey_job_conf.yml
+++ b/host_vars/pawsey_job_conf.yml
@@ -332,7 +332,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=1004641"
+          submit_native_specification: "--nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=984345"
           transport: curl
       - id: pulsar-high-mem1_big
         runner: pulsar-high-mem1_runner
@@ -343,7 +343,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=126 --ntasks-per-node=126 --mem=4018565"
+          submit_native_specification: "--nodes=1 --ntasks=126 --ntasks-per-node=126 --mem=3937380"
           transport: curl
       # Pulsar-high-mem2 destinations
       - id: pulsar-high-mem2_mid
@@ -355,7 +355,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=63 --ntasks-per-node=63 --mem=1004641"
+          submit_native_specification: "--nodes=1 --ntasks=63 --ntasks-per-node=63 --mem=984315"
           transport: curl
       - id: pulsar-high-mem2_big
         runner: pulsar-high-mem2_runner
@@ -366,7 +366,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=126 --ntasks-per-node=126 --mem=2009282"
+          submit_native_specification: "--nodes=1 --ntasks=126 --ntasks-per-node=126 --mem=1968631"
           transport: curl
       # Pulsar QLD High Mem 0 Destinations
       - id: pulsar-qld-high-mem0_mid
@@ -378,7 +378,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=120 --ntasks-per-node=120 --mem=2009282"
+          submit_native_specification: "--nodes=1 --ntasks=120 --ntasks-per-node=120 --mem=1968677"
           transport: curl
       - id: pulsar-qld-high-mem0_big
         runner: pulsar-qld-high-mem0_runner
@@ -389,7 +389,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=4018565"
+          submit_native_specification: "--nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=3937354"
           transport: curl
       # Pulsar QLD High Mem 1 Destinations
       - id: pulsar-qld-high-mem1_mid
@@ -401,7 +401,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=120 --ntasks-per-node=120 --mem=2009282"
+          submit_native_specification: "--nodes=1 --ntasks=120 --ntasks-per-node=120 --mem=1968677"
           transport: curl
       - id: pulsar-qld-high-mem1_big
         runner: pulsar-qld-high-mem1_runner
@@ -412,7 +412,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=4018565"
+          submit_native_specification: "--nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=3937354"
           transport: curl
       # Pulsar QLD High Mem 2 Destinations
       - id: pulsar-qld-high-mem2_mid
@@ -424,7 +424,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=120 --ntasks-per-node=120 --mem=2009282"
+          submit_native_specification: "--nodes=1 --ntasks=120 --ntasks-per-node=120 --mem=1968677"
           transport: curl
       - id: pulsar-qld-high-mem2_big
         runner: pulsar-qld-high-mem2_runner
@@ -435,7 +435,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=4018565"
+          submit_native_specification: "--nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=3937354"
           transport: curl
       # Pulsar NCI Training Destinations
       - id: pulsar-nci-training_small
@@ -447,7 +447,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=4 --ntasks-per-node=4 --mem=12337"
+          submit_native_specification: "--nodes=1 --ntasks=4 --ntasks-per-node=4 --mem=12048"
           transport: curl
       - id: pulsar-nci-training_mid
         runner: pulsar-nci-training_runner
@@ -458,7 +458,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=24675"
+          submit_native_specification: "--nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=24097"
           transport: curl
       - id: pulsar-nci-training_big
         runner: pulsar-nci-training_runner
@@ -469,7 +469,7 @@ galaxy_jobconf:
           persistence_directory: /mnt/pulsar/files/persisted_data
           remote_metadata: false
           rewrite_parameters: true
-          submit_native_specification: "--nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=49350"
+          submit_native_specification: "--nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=48195"
           transport: curl
     limits:
       #General limits for user submission


### PR DESCRIPTION
With slurm memory fixed, tools have access to the $GALAXY_MEMORY_MB variable.  Canu will not run if this is greater than MemTotal in /proc/meminfo.  Reduce the max for all of the new pulsars to the MemTotal value