### PR TITLE
revert busco high mem rule

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -363,11 +363,11 @@ tools:
               lower_bound: 0
               upper_bound: 50 MB
               destination: pulsar-mel_small
-            - rule_type: file_size
-              nice_value: 0
-              lower_bound: 50 MB
-              upper_bound: 300 MB
-              destination: pulsar-mel3_mid
+            # - rule_type: file_size
+            #   nice_value: 0
+            #   lower_bound: 50 MB
+            #   upper_bound: 300 MB
+            #   destination: pulsar-mel3_mid
             - rule_type: file_size
               nice_value: -5
               lower_bound: 0
@@ -375,7 +375,7 @@ tools:
               destination: pulsar-high-mem1_mid
               users:
                 - anna.syme@unimelb.edu.au
-        default_destination: pulsar-qld-high-mem2_mid
+        default_destination: pulsar-mel_big
     fastqc:
         rules:
           - rule_type: file_size


### PR DESCRIPTION
the qld pulsar is running the wrong version of busco (5.21 instead of 5.22).  It turns out that pulsar-mel3 is as well.  pulsar-mel2 uses the correct version.  pulsar-mel2 and pulsar-mel3 have the same conda version as one another (4.9.2)