### PR TITLE
send abricate to pulsar-mel2

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/dynamic_rules/tool_destinations.yml
@@ -432,7 +432,7 @@ tools:
               lower_bound: 5 MB
               upper_bound: 20 MB
               destination: pulsar-mel_mid
-        default_destination: pulsar-mel3_mid
+        default_destination: pulsar-mel_big
     snippy:
         rules:
             - rule_type: file_size


### PR DESCRIPTION
the abricate env is broken on pulsar-mel3, it can't be rebuilt at the moment because of bioconda