### PR TITLE
add symlink from /tmp to /mnt/tmpdisk on high-mem pulsars

### DIFF
--- a/pulsar-high-mem1_playbook.yml
+++ b/pulsar-high-mem1_playbook.yml
@@ -23,3 +23,28 @@
     #- pulsar-post-tasks
     - slurm-post-tasks
     # - slg.galaxy_stats
+  post_tasks:
+    - name: Create worker tmpdir on /mnt
+      file:
+          path: /mnt/tmpdisk
+          state: directory
+          owner: root
+          group: root
+          mode: '1777'
+    - name: stat links
+      stat:
+          path: /tmp
+      register: links
+    - name: remove old tmp
+      file:
+          path: /tmp
+          state: absent
+      when: links.stat.islnk is defined and not links.stat.islnk
+    - name: Link /tmp to /mnt/tmpdisk
+      file:
+          src: /mnt/tmpdisk
+          dest: /tmp
+          state: link
+      become: yes
+      become_user: root
+      when: links.stat.islnk is defined and not links.stat.islnk

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -23,3 +23,28 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     # - slg.galaxy_stats
+  post_tasks:
+    - name: Create worker tmpdir on /mnt
+      file:
+          path: /mnt/tmpdisk
+          state: directory
+          owner: root
+          group: root
+          mode: '1777'
+    - name: stat links
+      stat:
+          path: /tmp
+      register: links
+    - name: remove old tmp
+      file:
+          path: /tmp
+          state: absent
+      when: links.stat.islnk is defined and not links.stat.islnk
+    - name: Link /tmp to /mnt/tmpdisk
+      file:
+          src: /mnt/tmpdisk
+          dest: /tmp
+          state: link
+      become: yes
+      become_user: root
+      when: links.stat.islnk is defined and not links.stat.islnk

--- a/pulsar-qld-high-mem_playbook.yml
+++ b/pulsar-qld-high-mem_playbook.yml
@@ -23,3 +23,28 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     # - slg.galaxy_stats
+  post_tasks:
+    - name: Create worker tmpdir on /mnt
+      file:
+          path: /mnt/tmpdisk
+          state: directory
+          owner: root
+          group: root
+          mode: '1777'
+    - name: stat links
+      stat:
+          path: /tmp
+      register: links
+    - name: remove old tmp
+      file:
+          path: /tmp
+          state: absent
+      when: links.stat.islnk is defined and not links.stat.islnk
+    - name: Link /tmp to /mnt/tmpdisk
+      file:
+          src: /mnt/tmpdisk
+          dest: /tmp
+          state: link
+      become: yes
+      become_user: root
+      when: links.stat.islnk is defined and not links.stat.islnk


### PR DESCRIPTION
A bwa_mem job has failed with 'no space left on device' on qld high mem pulsar 2.  I've copied the code to make symlinks between /tmp and /mnt/tmpdisk on the high mem pulsars