### PR TITLE
add CR_CPU_Memory to all slurm configs

### DIFF
--- a/group_vars/pulsar-nci-test/pulsar-nci-test_slurm.yml
+++ b/group_vars/pulsar-nci-test/pulsar-nci-test_slurm.yml
@@ -42,6 +42,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
+++ b/group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
@@ -66,6 +66,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
@@ -61,6 +61,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/group_vars/pulsar_paw/pulsar-paw_slurm.yml
+++ b/group_vars/pulsar_paw/pulsar-paw_slurm.yml
@@ -56,6 +56,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/group_vars/staging_pulsar_slurm.yml
+++ b/group_vars/staging_pulsar_slurm.yml
@@ -28,6 +28,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/group_vars/staging_slurm.yml
+++ b/group_vars/staging_slurm.yml
@@ -44,6 +44,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -75,6 +75,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -75,6 +75,6 @@ slurm_config:
     FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key

--- a/host_vars/pulsar_eu_gpu.yml
+++ b/host_vars/pulsar_eu_gpu.yml
@@ -24,6 +24,6 @@ slurm_config:
     #FastSchedule: 2
     SchedulerType: sched/backfill
     SelectType: select/cons_res
-    SelectTypeParameters: CR_CPU,CR_LLN
+    SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key


### PR DESCRIPTION
CR_CPU_Memory is already being used for the main cluster and qld high mems.

Add it to remaining slurm configs:
```
group_vars/pulsar-nci-test/pulsar-nci-test_slurm.yml
group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
group_vars/pulsar_paw/pulsar-paw_slurm.yml
group_vars/staging_pulsar_slurm.yml
group_vars/staging_slurm.yml
host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
host_vars/pulsar_eu_gpu.yml
```