### PR TITLE
Update to release 21.09

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -52,12 +52,6 @@
     - dj-wasabi.telegraf
     - login-override
   post_tasks:
-    - name: Clone Galaxy-Owncloud-Integration
-      git:
-        repo: https://github.com/usegalaxy-au/Galaxy-Owncloud-Integration
-        dest: "{{ galaxy_server_dir }}/tools/Galaxy-Owncloud-Integration"
-        update: no
-      when: use_cloudstor_conf|d(false) == true
     - name: Clone galaxy-local-tools
       git:
         repo: https://github.com/usegalaxy-au/galaxy-local-tools

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -63,7 +63,7 @@ miniconda_version: "{{ global_miniconda_version|d(host_miniconda_version) }}"
 
 # Galaxy
 
-tool_config_files:
+galaxy_tool_config_files:
   - "{{ galaxy_config_dir }}/tool_conf.xml"
   - "{{ galaxy_config_dir }}/nagios_tool_conf.xml"
   - "{{ galaxy_config_dir }}/local_tool_conf.xml"
@@ -166,7 +166,6 @@ group_galaxy_config:
 
     job_config_file: "{{ galaxy_config_dir }}/job_conf.xml"
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
-    tool_config_file: "{{ tool_config_files | join(',') }}"
     user_preferences_extra_conf_path: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
     file_sources_config_file: "{{ galaxy_config_dir }}/file_sources_conf.yml"
 

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -63,15 +63,11 @@ miniconda_version: "{{ global_miniconda_version|d(host_miniconda_version) }}"
 
 # Galaxy
 
-# Variables that will differ based on the value of use_cloudstor_conf
-default_settings:
-  tool_config_files: "{{ galaxy_config_dir }}/tool_conf.xml,{{ galaxy_config_dir }}/nagios_tool_conf.xml,{{ galaxy_config_dir }}/local_tool_conf.xml"
-
-cloudstor_settings:
-  tool_config_files: "{{ galaxy_config_dir }}/tool_conf.xml,{{ galaxy_config_dir }}/nagios_tool_conf.xml,{{ galaxy_config_dir }}/cloudstor_tool_conf.xml,{{ galaxy_config_dir }}/local_tool_conf.xml"
-
-tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }}"
-# end variables dependent on use_cloudstor_conf
+tool_config_files:
+  - "{{ galaxy_config_dir }}/tool_conf.xml"
+  - "{{ galaxy_config_dir }}/nagios_tool_conf.xml"
+  - "{{ galaxy_config_dir }}/local_tool_conf.xml"
+  - "{{ galaxy_config_dir }}/tool_conf_interactive.xml"
 
 galaxy_create_user: true
 galaxy_separate_privileges: true
@@ -170,7 +166,7 @@ group_galaxy_config:
 
     job_config_file: "{{ galaxy_config_dir }}/job_conf.xml"
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
-    tool_config_file: "{{ tool_config_files }}"
+    tool_config_file: "{{ tool_config_files | join(',') }}"
     user_preferences_extra_conf_path: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
     file_sources_config_file: "{{ galaxy_config_dir }}/file_sources_conf.yml"
 
@@ -196,6 +192,16 @@ group_galaxy_config:
     enable_old_display_applications: true
 
     tool_filters: ga_filters:hide_test_tools
+
+    dependency_resolvers:
+      - type: tool_shed_packages
+      - type: galaxy_packages
+      - type: conda
+      - type: galaxy_packages
+        versionless: true
+      - type: conda
+        versionless: true
+
     # amqp_internal_connection: 'pyamqp://galaxy_internal:more_queues@localhost:5672/galaxy_internal' # this needs configuration
 
     # data_manager_config_file: /mnt/galaxy-app/config/data_manager_conf.xml.sample  # should we be templating these?
@@ -260,8 +266,6 @@ group_galaxy_config_files:
     dest: "{{ galaxy_config_dir }}/tool_conf.xml"
   - src: "{{ galaxy_config_file_src_dir }}/config/nagios_tool_conf.xml"
     dest: "{{ galaxy_config_dir }}/nagios_tool_conf.xml"
-  - src: "{{ galaxy_config_file_src_dir }}/config/cloudstor_tool_conf.xml"
-    dest: "{{ galaxy_config_dir }}/cloudstor_tool_conf.xml"
   - src: "{{ galaxy_config_file_src_dir }}/config/local_tool_conf.xml"
     dest: "{{ galaxy_config_dir }}/local_tool_conf.xml"
   - src: "{{ galaxy_config_file_src_dir }}/config/user_preferences_extra_conf.yml"

--- a/host_vars/DR.usegalaxy.org.au.yml
+++ b/host_vars/DR.usegalaxy.org.au.yml
@@ -84,9 +84,6 @@ nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
 
-# ITs tool conf overrides.  TODO: simplify this
-tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }},{{ galaxy_config_dir }}/tool_conf_interactive.xml"
-
 host_galaxy_config_files:
   # - src: "{{ galaxy_config_file_src_dir }}/config/object_store_conf.xml"
   #   dest: "{{ galaxy_config_dir }}/object_store_conf.xml"

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -88,9 +88,6 @@ nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
 
-# ITs tool conf overrides.  TODO: simplify this
-tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }},{{ galaxy_config_dir }}/tool_conf_interactive.xml"
-
 host_galaxy_config_files:
   - src: "{{ galaxy_config_file_src_dir }}/config/aarnet_object_store_conf.xml"
     dest: "{{ galaxy_config_dir }}/object_store_conf.xml"

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -40,16 +40,10 @@ galaxy_tmp_dir: "{{ galaxy_root }}/tmp"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_21.09
 
-# Do not use extra tool_conf file for cloudstor tool
-use_cloudstor_conf: false
-
 galaxy_file_path: "{{ galaxy_root }}/data"
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
-
-# ITs tool conf overrides.
-tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }},{{ galaxy_config_dir }}/tool_conf_interactive.xml"
 
 host_galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/oidc_backends_config.xml.j2"
@@ -88,14 +82,6 @@ host_galaxy_config:  # renamed from __galaxy_config
     enable_mulled_containers: true
     enable_beta_containers_interface: true
     watch_job_rules: true  # important for total perspective vortex
-    dependency_resolvers:
-      - type: tool_shed_packages
-      - type: galaxy_packages
-      - type: conda
-      - type: galaxy_packages
-        versionless: true
-      - type: conda
-        versionless: true
 
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -26,12 +26,8 @@ nginx_ssl_servers:
   #gie proxy hostname
 interactive_tools_server_name: "usegalaxy.org.au"
 
-# galaxy_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_repo: https://github.com/usegalaxy-au/galaxy.git  # usegalaxy-au fork of galaxy
-galaxy_commit_id: release_21.05_cloudstor
-
-# Use extra tool_conf file and user prefs for cloudstor tool
-use_cloudstor_conf: true
+galaxy_repo: https://github.com/galaxyproject/galaxy.git
+galaxy_commit_id: release_21.09
 
 # Mounts for various connections:
 shared_mounts:
@@ -89,9 +85,6 @@ nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
 nginx_upload_store_set_cleanup_cron_job: true
 
-# ITs tool conf overrides.
-tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }},{{ galaxy_config_dir }}/tool_conf_interactive.xml"
-
 host_galaxy_config_files:
   - src: "{{ galaxy_config_file_src_dir }}/config/object_store_conf.xml"
     dest: "{{ galaxy_config_dir }}/object_store_conf.xml"
@@ -130,7 +123,6 @@ host_galaxy_config:  # renamed from __galaxy_config
     nginx_upload_job_files_store: "{{ nginx_upload_job_files_store_dir }}"
     nginx_upload_job_files_path: '/_job_files'
     job_config_file: "{{ galaxy_config_dir }}/job_conf.yml"
-    dependency_resolvers_config_file: "{{ galaxy_server_dir }}/config/dependency_resolvers_conf.xml.sample"  # remove for 21.09
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -28,12 +28,8 @@ nfs_exports:
     - "{{ galaxy_root }}  *(rw,async,no_root_squash,no_subtree_check)"
 
 # ansible-galaxy
-# galaxy_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_repo: https://github.com/usegalaxy-au/galaxy.git  # usegalaxy-au fork of galaxy
-galaxy_commit_id: release_21.05_cloudstor
-
-# Use cloudstor branch and extra tool_conf file and user prefs for cloudstor tool
-use_cloudstor_conf: true
+galaxy_repo: https://github.com/galaxyproject/galaxy.git
+galaxy_commit_id: release_21.09
 
 galaxy_dynamic_job_rules_src_dir: files/galaxy/dynamic_job_rules/staging
 galaxy_dynamic_job_rules_dir: "{{ galaxy_root }}/dynamic_job_rules"
@@ -49,9 +45,6 @@ galaxy_file_path: "{{ galaxy_root }}/data"
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
-
-# ITs tool conf overrides.
-tool_config_files: "{{ cloudstor_settings['tool_config_files'] if use_cloudstor_conf|d(false) == true else default_settings['tool_config_files'] }},{{ galaxy_config_dir }}/tool_conf_interactive.xml"
 
 host_galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/oidc_backends_config.xml.j2"
@@ -81,7 +74,6 @@ host_galaxy_config:  # renamed from __galaxy_config
     nginx_upload_path: '/_upload'
     nginx_upload_job_files_store: "{{ nginx_upload_job_files_store_dir }}"
     nginx_upload_job_files_path: '/_job_files'
-    dependency_resolvers_config_file: "{{ galaxy_server_dir }}/config/dependency_resolvers_conf.xml.sample"  # remove for 21.09
 
 #Galaxy Job Conf
 galaxy_jobconf:

--- a/pawsey_playbook.yml
+++ b/pawsey_playbook.yml
@@ -42,12 +42,6 @@
     - usegalaxy_eu.tiaas2
     # - slg.galaxy_stats
   post_tasks:
-    - name: Clone Galaxy-Owncloud-Integration
-      git:
-        repo: https://github.com/usegalaxy-au/Galaxy-Owncloud-Integration
-        dest: "{{ galaxy_server_dir }}/tools/Galaxy-Owncloud-Integration"
-        update: no
-      when: use_cloudstor_conf|d(false) == true
     - name: Clone galaxy-local-tools
       git:
         repo: https://github.com/usegalaxy-au/galaxy-local-tools

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -38,12 +38,6 @@
     - dj-wasabi.telegraf
     - pg-post-tasks
   post_tasks:
-    - name: Clone Galaxy-Owncloud-Integration
-      git:
-        repo: https://github.com/usegalaxy-au/Galaxy-Owncloud-Integration
-        dest: "{{ galaxy_server_dir }}/tools/Galaxy-Owncloud-Integration"
-        update: no
-      when: use_cloudstor_conf|d(false) == true
     - name: Clone galaxy-local-tools
       git:
         repo: https://github.com/usegalaxy-au/galaxy-local-tools


### PR DESCRIPTION
move staging and production to 21.09, move dependency_resolvers configuration from host_vars/dev into group_vars/galaxyservers.

Not having cloudstor conf simplifies tool_config a fair bit.  We can use the list variable from ansible_galaxy:

```
galaxy_tool_config_files:
  - "{{ galaxy_config_dir }}/tool_conf.xml"
  - "{{ galaxy_config_dir }}/nagios_tool_conf.xml"
  - "{{ galaxy_config_dir }}/local_tool_conf.xml"
  - "{{ galaxy_config_dir }}/tool_conf_interactive.xml"
```

which is comma-joined into the `tool_config_file` setting in galaxy.yml