### PR TITLE
put mem in all rules for tools with high mem rules

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -535,14 +535,17 @@ tools:
       cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/flye/flye/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.15 <= input_size < 1
       cores: 8
+      mem: cores * 3.8
     - match: 1 <= input_size < 10
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 10
       cores: 120
       mem: 1922
@@ -551,12 +554,14 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/bgruening/racon/racon/.*:
     cores: 1
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.05 <= input_size < 5
       cores: 8
+      mem: cores * 3.8
     - match: input_size >= 5
       cores: 120
       mem: 1922
@@ -751,12 +756,14 @@ tools:
       cores: 4
   toolshed.g2.bx.psu.edu/repos/iuc/khmer_abundance_distribution_single/khmer_abundance_distribution_single/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.1 <= input_size < 0.5
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 0.5
       cores: 120
       mem: 1922
@@ -779,12 +786,14 @@ tools:
       - pulsar-paw
   toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/.*:
     cores: 1
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.5 <= input_size < 5
       cores: 8
+      mem: cores * 3.8
     - match: input_size >= 5
       cores: 120
       mem: 1922
@@ -817,14 +826,17 @@ tools:
       cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/minimap2/minimap2/.*:
     cores: 4
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.5 <= input_size < 5
       cores: 8
+      mem: cores * 3.8
     - match: 5 <= input_size < 20
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 20
       cores: 120
       mem: 1922
@@ -838,12 +850,14 @@ tools:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_seq/.*:
     cores: 1
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 10 <= input_size < 20
       cores: 4
+      mem: cores * 3.8
     - match: input_size >= 20
       cores: 120
       mem: 1922
@@ -961,6 +975,7 @@ tools:
       - high-mem
   toolshed.g2.bx.psu.edu/repos/bgruening/hifiasm/hifiasm/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
@@ -973,14 +988,17 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.25 <= input_size < 1
       cores: 4
+      mem: cores * 3.8
     - match: 1 <= input_size < 20
       cores: 8
+      mem: cores * 3.8
     - match: input_size >= 20
       cores: 120
       mem: 1922
@@ -989,12 +1007,14 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.002 <= input_size < 5
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 5
       cores: 126
       mem: 3845
@@ -1003,12 +1023,14 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.05 <= input_size < 0.3
       cores: 8
+      mem: cores * 3.8
     - match: input_size >= 0.3
       cores: 120
       mem: 1922
@@ -1017,6 +1039,7 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/mothur_cluster_split/mothur_cluster_split/.*:
     cores: 1
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
@@ -1036,6 +1059,7 @@ tools:
       - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/.*:
     cores: 1
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
@@ -1048,12 +1072,14 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/raven/raven/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.002 <= input_size < 5
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 5
       cores: 126
       mem: 1922
@@ -1062,12 +1088,14 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/raxml/raxml/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.0005 <= input_size < 0.1
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 0.1
       cores: 120
       mem: 1922
@@ -1076,12 +1104,14 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/shasta/shasta/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.002 <= input_size < 5
       cores: 16
+      mem: cores * 3.8
     - match: input_size >= 5
       cores: 126
       mem: 1922
@@ -1090,6 +1120,7 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
     cores: 8
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
@@ -1105,12 +1136,14 @@ tools:
         backend. Please use another server for your job.
   toolshed.g2.bx.psu.edu/repos/nml/spades/spades/.*:
     cores: 2
+    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar
     rules:
     - match: 0.015 <= input_size < 2
       cores: 4
+      mem: cores * 3.8
     - match: 2 <= input_size < 20
       cores: 120
       mem: 1922


### PR DESCRIPTION
There is a bug where some tools are getting mem values for a different rule.  This change sets mem for all of the lesser rules where there is a high-mem rule in the list of rules.  It may or may not patch it from our end.