### PR TITLE
test tpv changes: remove default mem for quast

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -1059,7 +1059,6 @@ tools:
       - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/quast/quast/.*:
     cores: 1
-    mem: cores * 3.8
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
Test whether the vortex will reload

If it reloads, test the change that NG made to tpv yesterday that should save us from having to explicitly set mem of every rule for quast and other tools that have high mem rules.