### PR TITLE
add internal ssh keys to production pulsars and job-nfs

### DIFF
--- a/host_vars/pawsey-job-nfs.usegalaxy.org.au.yml
+++ b/host_vars/pawsey-job-nfs.usegalaxy.org.au.yml
@@ -7,3 +7,8 @@ galaxy_job_dir: /mnt/tmp
 
 nfs_exports:
   - "{{ galaxy_job_dir }} 192.168.0.0/24(rw,async,no_root_squash,no_subtree_check)"
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -227,3 +227,35 @@ rpc_pulsar_machines:
     keep_error_days: 7
     cron_hour: "17"
     cron_minute: "40"
+  # - pulsar_name: qld-pulsar-himem-0
+  #   pulsar_ip_address: "{{ hostvars['qld-pulsar-himem-0']['ansible_ssh_host'] }}"
+  #   ssh_key: /home/ubuntu/.ssh/ubuntu_maintenance_key
+  #   delete_jwds: true
+  #   keep_error_days: 7
+  #   cron_hour: "17"
+  #   cron_minute: "50"
+  # - pulsar_name: qld-pulsar-himem-1
+  #   pulsar_ip_address: "{{ hostvars['qld-pulsar-himem-1']['ansible_ssh_host'] }}"
+  #   ssh_key: /home/ubuntu/.ssh/ubuntu_maintenance_key
+  #   delete_jwds: true
+  #   keep_error_days: 7
+  #   cron_hour: "18"
+  #   cron_minute: "00"
+  # - pulsar_name: qld-pulsar-himem-2
+  #   pulsar_ip_address: "{{ hostvars['qld-pulsar-himem-2']['ansible_ssh_host'] }}"
+  #   ssh_key: /home/ubuntu/.ssh/ubuntu_maintenance_key
+  #   delete_jwds: true
+  #   keep_error_days: 7
+  #   cron_hour: "18"
+  #   cron_minute: "10"
+  # - pulsar_name: pulsar-nci-training
+  #   pulsar_ip_address: "{{ hostvars['pulsar-nci-training']['ansible_ssh_host'] }}"
+  #   ssh_key: /home/ubuntu/.ssh/ubuntu_maintenance_key
+  #   delete_jwds: true
+  #   keep_error_days: 7
+  #   cron_hour: "18"
+  #   cron_minute: "20"
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: private

--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -79,3 +79,8 @@ slurm_config:
     SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -79,3 +79,8 @@ slurm_config:
     SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/pulsar-mel2/pulsar-mel2.genome.edu.au.yml
+++ b/host_vars/pulsar-mel2/pulsar-mel2.genome.edu.au.yml
@@ -21,3 +21,8 @@ rabbitmq_password_galaxy_au: "{{ vault_rabbitmq_password_galaxy_mel2_prod }}"
 pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_mel2"
 pulsar_rabbit_vhost: "/pulsar/galaxy_mel2"
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/pulsar-mel3/pulsar-mel3.genome.edu.au.yml
+++ b/host_vars/pulsar-mel3/pulsar-mel3.genome.edu.au.yml
@@ -32,3 +32,8 @@ attached_volumes:
   - device: /dev/vdc
     path: /mnt/files
     fstype: ext4
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/pulsar-nci-training/pulsar-nci-training.usegalaxy.org.au.yml
+++ b/host_vars/pulsar-nci-training/pulsar-nci-training.usegalaxy.org.au.yml
@@ -23,3 +23,8 @@ rabbitmq_password_galaxy_au: "{{ vault_rabbitmq_password_galaxy_nci_training_pro
 pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_nci_training"
 pulsar_rabbit_vhost: "/pulsar/galaxy_nci_training"
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/pulsar-paw/pulsar-paw.genome.edu.au.yml
+++ b/host_vars/pulsar-paw/pulsar-paw.genome.edu.au.yml
@@ -21,3 +21,8 @@ attached_volumes:
   - device: /dev/vdc
     path: /mnt
     fstype: ext4
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/qld-pulsar-himem-0.yml
+++ b/host_vars/qld-pulsar-himem-0.yml
@@ -80,3 +80,8 @@ slurm_config:
     SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/qld-pulsar-himem-1.yml
+++ b/host_vars/qld-pulsar-himem-1.yml
@@ -80,3 +80,8 @@ slurm_config:
     SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/host_vars/qld-pulsar-himem-2.yml
+++ b/host_vars/qld-pulsar-himem-2.yml
@@ -80,3 +80,8 @@ slurm_config:
     SelectTypeParameters: CR_CPU_Memory,CR_LLN
 
 slurm_munge_key: files/keys/munge.key
+
+extra_keys:
+  - id: ubuntu_maintenance_key
+    type: public
+    from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"

--- a/pawsey_playbook.yml
+++ b/pawsey_playbook.yml
@@ -9,6 +9,7 @@
       - host_vars/pawsey.usegalaxy.org.au.yml
       - host_vars/pawsey_job_conf.yml
       - secret_group_vars/stats_server_vault
+      - secret_group_vars/ubuntu_maintenance_key
   pre_tasks:
     - name: Attach volume to instance
       include_role:


### PR DESCRIPTION
Pulsars would have a public key that would only accept ssh connections from pawsey.  pawsey would have the corresponding private key and this can replace the need for the more powerful keys to be used in maintenance tasks.  This also adds the public key to pawsey-job-nfs as this could be connected to for routine clearing of /mnt/tmp.