### PR TITLE
reduce mem per core for tools that go to pulsar-paw

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -757,6 +757,7 @@ tools:
       cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/.*:
     cores: 8
+    mem: cores * 3.7
     scheduling:
       accept:
       - pulsar
@@ -764,6 +765,7 @@ tools:
       - pulsar-paw
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/.*:
     cores: 8
+    mem: cores * 3.7
     scheduling:
       accept:
       - pulsar
@@ -771,6 +773,7 @@ tools:
       - pulsar-paw
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_variants/ivar_variants/.*:
     cores: 8
+    mem: cores * 3.7
     scheduling:
       accept:
       - pulsar
@@ -802,6 +805,7 @@ tools:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/.*:
     cores: 4
+    mem: cores * 3.7
     scheduling:
       accept:
       - pulsar
@@ -809,6 +813,7 @@ tools:
       - pulsar-paw
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/.*:
     cores: 4
+    mem: cores * 3.7
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
8-core jobs on pulsar-paw are failing.  The native specification is asking for more memory than the 30500MB allowed per node.  This value could probably be higher in the slurm config but for now this is a quicker fix.