### PR TITLE
remove offline tag for pulsar-high-mem1

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
@@ -38,7 +38,6 @@ destinations:
       require:
       - pulsar
       - high-mem
-      - offline
   pulsar-high-mem2:
     cores: 126
     mem: 1922.49


### PR DESCRIPTION
In the end I did get rid of conda on the machine and reinstall it.  This is now running with mamba as the conda exec file but it would be easy to switch this back to conda.  The envs for high mem tools are installed and tool test results look fine.