### PR TITLE
add ipa to dev local tool conf

### DIFF
--- a/files/galaxy/config/local_tool_conf_dev.xml
+++ b/files/galaxy/config/local_tool_conf_dev.xml
@@ -3,5 +3,6 @@
     <section id="local_tools" name="Local Tools">
         <tool file="/mnt/galaxy/local_tools/alphafold/alphafold.xml" />
         <tool file="/mnt/galaxy/local_tools/wtdbg2/wtdbg2.xml" />
+        <tool file="/mnt/galaxy/local_tools/ipa/ipa.xml" />
     </section>
 </toolbox>


### PR DESCRIPTION
It's in `/mnt/galaxy/local_tools`, which is owned by root but if it had 777 permissions then non-sudo users could copy things to this.
