### PR TITLE
change circos scheduling to require pulsar

### DIFF
--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/usegalaxy-au/total-perspective-vortex pyyaml
+        pip install git+https://github.com/usegalaxy-au/total-perspective-vortex pyyaml galaxy-data
     # Run check files script
     - name: Check vortex destination ids against job conf environment ids
       env:

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -724,7 +724,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/circos/circos/.*:
     cores: 2
     scheduling:
-      accept:
+      require:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/gecko/gecko/.*:
     cores: 2


### PR DESCRIPTION
There's a long standing bug with circos on slurm.  Before tpv it was running on pulsar-mel2 to avoid this.  It's ok on pulsar-mel3 as well.