### PR TITLE
Add miniconda to pulsar playbooks, run with mamba if pulsar_conda_exec: mamba is set

### DIFF
--- a/dev-pulsar_playbook.yml
+++ b/dev-pulsar_playbook.yml
@@ -20,6 +20,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - geerlingguy.nfs
     - mariadb

--- a/group_vars/pulsar_nci_training/pulsar-nci-training.yml
+++ b/group_vars/pulsar_nci_training/pulsar-nci-training.yml
@@ -6,6 +6,9 @@ use_internal_ips: true
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 
+# Use mamba as replacement for conda
+pulsar_conda_exec: "mamba"
+
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au
 grafana_server_url: "https://{{ influx_url }}:8086"

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -84,9 +84,19 @@ pulsar_yaml_config:
           postprocess_action_interval_step: 4
           postprocess_action_interval_max: 120
           min_polling_interval: 15
-  dependency_resolvers_config_file: dependency_resolvers_conf.xml
-  conda_auto_init: True
-  conda_auto_install: True
+  dependency_resolution:
+    resolvers:
+      - type: conda
+        exec: "{{ pulsar_conda_prefix }}/bin/{{ pulsar_conda_exec|d('conda') }}"
+        auto_init: true
+        auto_install: true
+        prefix: "{{ pulsar_conda_prefix }}"
+      - type: conda
+        exec: "{{ pulsar_conda_prefix }}/bin/{{ pulsar_conda_exec|d('conda') }}"
+        auto_init: true
+        auto_install: true
+        prefix: "{{ pulsar_conda_prefix }}"
+        versionless: true
   staging_directory: "{{ pulsar_staging_dir }}"
   persistence_directory: "{{ pulsar_persistence_dir }}"
   message_queue_url: "pyamqp://{{ pulsar_rabbit_username }}:{{ rabbitmq_password_galaxy_au }}@{{ pulsar_queue_url }}:5671/{{ pulsar_rabbit_vhost }}?ssl=1"
@@ -96,6 +106,12 @@ pulsar_yaml_config:
   amqp_publish_retry_interval_start: 10
   amqp_publish_retry_interval_step: 10
   amqp_publish_retry_interval_max: 60
+
+pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
+miniconda_prefix: "{{ pulsar_conda_prefix }}"
+miniconda_version: "{{ global_miniconda_version }}"
+miniconda_base_env_packages:
+  - mamba
 
 # for pulsar-post-tasks
 pulsar_tools_indices_dir: /mnt/tools-indices

--- a/host_vars/dev-pulsar.usegalaxy.org.au.yml
+++ b/host_vars/dev-pulsar.usegalaxy.org.au.yml
@@ -15,6 +15,8 @@ pulsar_queue_url: "dev-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_au"
 pulsar_rabbit_vhost: "/pulsar/galaxy_au"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 extra_keys:
   - id: ubuntu_maintenance_key
     type: public

--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -49,6 +49,9 @@ auth_key_user: ubuntu
 
 head_nodes: "{{ groups['pulsar_high_mem1'] }}"
 
+# Use mamba as replacement for conda
+pulsar_conda_exec: "mamba"
+
 # SLURM
 slurm_nodes:
     - name: pulsar-high-mem1
@@ -84,46 +87,3 @@ extra_keys:
   - id: ubuntu_maintenance_key
     type: public
     from: "{{ hostvars['pawsey']['ansible_ssh_host'] }}"
-
-
-# for running conda with exec: mamba
-# everything below this line can be copied into pulsarservers.yml
-# pulsar playbooks will need galaxyproject.miniconda
-pulsar_yaml_config:
-  managers:
-      _default_:
-          type: queued_drmaa
-          preprocess_action_max_retries: 10
-          preprocess_action_interval_start: 2
-          preprocess_action_interval_step: 2
-          preprocess_action_interval_max: 60
-          postprocess_action_max_retries: 20
-          postprocess_action_interval_start: 2
-          postprocess_action_interval_step: 4
-          postprocess_action_interval_max: 120
-          min_polling_interval: 15
-  dependency_resolution:
-    resolvers:
-      - type: conda
-        exec: "{{ pulsar_conda_prefix }}/bin/mamba"
-        auto_init: true
-        auto_install: true
-        prefix: "{{ pulsar_conda_prefix }}"
-  staging_directory: "{{ pulsar_staging_dir }}"
-  persistence_directory: "{{ pulsar_persistence_dir }}"
-  message_queue_url: "pyamqp://{{ pulsar_rabbit_username }}:{{ rabbitmq_password_galaxy_au }}@{{ pulsar_queue_url }}:5671/{{ pulsar_rabbit_vhost }}?ssl=1"
-  min_polling_interval: 0.5
-  amqp_publish_retry: True
-  amqp_publish_retry_max_retries: 5
-  amqp_publish_retry_interval_start: 10
-  amqp_publish_retry_interval_step: 10
-  amqp_publish_retry_interval_max: 60
-
-pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
-miniconda_prefix: "{{ pulsar_conda_prefix }}"
-miniconda_version: "{{ global_miniconda_version }}"
-miniconda_base_env_packages:
-  - mamba
-
-
-

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -49,6 +49,9 @@ auth_key_user: ubuntu
 
 head_nodes: "{{ groups['pulsar_high_mem2'] }}"
 
+# Use mamba as replacement for conda
+pulsar_conda_exec: "mamba"
+
 # SLURM
 slurm_nodes:
     - name: pulsar-high-mem2

--- a/host_vars/pulsar-mel2/pulsar-mel2.genome.edu.au.yml
+++ b/host_vars/pulsar-mel2/pulsar-mel2.genome.edu.au.yml
@@ -22,6 +22,8 @@ pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_mel2"
 pulsar_rabbit_vhost: "/pulsar/galaxy_mel2"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 extra_keys:
   - id: ubuntu_maintenance_key
     type: public

--- a/host_vars/pulsar-mel3/pulsar-mel3.genome.edu.au.yml
+++ b/host_vars/pulsar-mel3/pulsar-mel3.genome.edu.au.yml
@@ -24,6 +24,8 @@ pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_mel3"
 pulsar_rabbit_vhost: "/pulsar/galaxy_mel3"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 #Attached volume
 attached_volumes:
   - device: /dev/vdb

--- a/host_vars/pulsar-nci-test/pulsar-nci-test.usegalaxy.org.au.yml
+++ b/host_vars/pulsar-nci-test/pulsar-nci-test.usegalaxy.org.au.yml
@@ -24,41 +24,5 @@ pulsar_queue_url: "dev-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_nci_test"
 pulsar_rabbit_vhost: "/pulsar/galaxy_nci_test"
 
-# for running conda with exec: mamba
-# everything below this line can be copied into pulsarservers.yml
-# pulsar playbooks will need galaxyproject.miniconda
-pulsar_yaml_config:
-  managers:
-      _default_:
-          type: queued_drmaa
-          preprocess_action_max_retries: 10
-          preprocess_action_interval_start: 2
-          preprocess_action_interval_step: 2
-          preprocess_action_interval_max: 60
-          postprocess_action_max_retries: 20
-          postprocess_action_interval_start: 2
-          postprocess_action_interval_step: 4
-          postprocess_action_interval_max: 120
-          min_polling_interval: 15
-  dependency_resolution:
-    resolvers:
-      - type: conda
-        exec: "{{ pulsar_conda_prefix }}/bin/mamba"
-        auto_init: true
-        auto_install: true
-        prefix: "{{ pulsar_conda_prefix }}"
-  staging_directory: "{{ pulsar_staging_dir }}"
-  persistence_directory: "{{ pulsar_persistence_dir }}"
-  message_queue_url: "pyamqp://{{ pulsar_rabbit_username }}:{{ rabbitmq_password_galaxy_au }}@{{ pulsar_queue_url }}:5671/{{ pulsar_rabbit_vhost }}?ssl=1"
-  min_polling_interval: 0.5
-  amqp_publish_retry: True
-  amqp_publish_retry_max_retries: 5
-  amqp_publish_retry_interval_start: 10
-  amqp_publish_retry_interval_step: 10
-  amqp_publish_retry_interval_max: 60
-
-pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
-miniconda_prefix: "{{ pulsar_conda_prefix }}"
-miniconda_version: "{{ global_miniconda_version }}"
-miniconda_base_env_packages:
-  - mamba
+# Use mamba as replacement for conda
+pulsar_conda_exec: "mamba"

--- a/host_vars/pulsar-paw/pulsar-paw.genome.edu.au.yml
+++ b/host_vars/pulsar-paw/pulsar-paw.genome.edu.au.yml
@@ -17,6 +17,8 @@ pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_paw"
 pulsar_rabbit_vhost: "/pulsar/galaxy_paw"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 attached_volumes:
   - device: /dev/vdc
     path: /mnt

--- a/host_vars/qld-pulsar-himem-0.yml
+++ b/host_vars/qld-pulsar-himem-0.yml
@@ -17,6 +17,8 @@ pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_qld_hm0"
 pulsar_rabbit_vhost: "/pulsar/galaxy_qld_hm0"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 attached_volumes:
   - device: /dev/vdb
     partition: 1

--- a/host_vars/qld-pulsar-himem-1.yml
+++ b/host_vars/qld-pulsar-himem-1.yml
@@ -17,6 +17,8 @@ pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_qld_hm1"
 pulsar_rabbit_vhost: "/pulsar/galaxy_qld_hm1"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 attached_volumes:
   - device: /dev/vdb
     partition: 1

--- a/host_vars/qld-pulsar-himem-2.yml
+++ b/host_vars/qld-pulsar-himem-2.yml
@@ -17,6 +17,8 @@ pulsar_queue_url: "pawsey-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_qld_hm2"
 pulsar_rabbit_vhost: "/pulsar/galaxy_qld_hm2"
 
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+
 attached_volumes:
   - device: /dev/vdb
     partition: 1

--- a/host_vars/staging-pulsar.usegalaxy.org.au.yml
+++ b/host_vars/staging-pulsar.usegalaxy.org.au.yml
@@ -14,3 +14,5 @@ rabbitmq_password_galaxy_au: "{{ vault_rabbitmq_password_galaxy_au_staging }}"
 pulsar_queue_url: "staging-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_au"
 pulsar_rabbit_vhost: "/pulsar/galaxy_au"
+
+pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -16,6 +16,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - mariadb
     - galaxyproject.slurm

--- a/pulsar-mel2_playbook.yml
+++ b/pulsar-mel2_playbook.yml
@@ -23,6 +23,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - geerlingguy.nfs
     - mariadb

--- a/pulsar-mel3_playbook.yml
+++ b/pulsar-mel3_playbook.yml
@@ -23,6 +23,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - geerlingguy.nfs
     - mariadb

--- a/pulsar-nci-training_playbook.yml
+++ b/pulsar-nci-training_playbook.yml
@@ -19,6 +19,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - geerlingguy.nfs
     - mariadb

--- a/pulsar-paw_playbook.yml
+++ b/pulsar-paw_playbook.yml
@@ -23,6 +23,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - geerlingguy.nfs
     - mariadb

--- a/pulsar-qld-high-mem_playbook.yml
+++ b/pulsar-qld-high-mem_playbook.yml
@@ -16,6 +16,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - mariadb
     - galaxyproject.slurm

--- a/requirements.yml
+++ b/requirements.yml
@@ -36,8 +36,7 @@
 - src: usegalaxy_eu.gie_proxy
   version: 0.0.2
 - name: galaxyproject.miniconda
-  src: https://github.com/cat-bro/ansible-miniconda.git
-  version: 43499526b66ed5242055731e4400472e89e03f14  # galaxyproject/ansible-miniconda + 1 commit
+  version: 0.3.0
 - name: usegalaxy_eu.influxdb
   version: v6.0.8
 - name: cloudalchemy.grafana

--- a/staging-pulsar_playbook.yml
+++ b/staging-pulsar_playbook.yml
@@ -19,6 +19,9 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: "{{ pulsar_user.name }}"
     - galaxyproject.pulsar
     - geerlingguy.nfs
     - mariadb


### PR DESCRIPTION
Add miniconda to all conda playbooks and the option of using mamba instead of conda.  This is opt-in: `pulsar_conda_exec: mamba` must be set somewhere or conda will be used.