### PR TITLE
Miniconda and mamba for galaxy

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -130,11 +130,14 @@ bashrc_env: |
   export SACCT_FORMAT="jobid%8,partition%9,jobname%30,alloccpus,elapsed,totalcpu,END,state,MaxRSS,ReqMem,NodeList"
 
 # miniconda
-global_miniconda_version: '4.10.3'
+# miniconda installs the latest version of conda by default
+# installing mamba will also install the latest version of conda
 miniconda_channels:
   - conda-forge
   - bioconda
   - defaults
+miniconda_base_env_packages:
+  - mamba
 
 # Monitoring
 influx_url: stats.usegalaxy.org.au

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -59,7 +59,6 @@ nginx_upload_limit_rate: 0 # for nginx template: rate in bytes per second.  0 me
 
 # miniconda
 miniconda_prefix: "{{ galaxy_conda_prefix }}"
-miniconda_version: "{{ host_miniconda_version|d(global_miniconda_version) }}"
 
 # Galaxy
 

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -86,6 +86,7 @@ galaxy_mutable_config_dir: "{{ galaxy_root }}/var"
 galaxy_mutable_data_dir: "{{ galaxy_root }}"
 galaxy_config_dir: "{{ galaxy_root }}/config"
 galaxy_conda_prefix: "{{ galaxy_tools_indices_dir }}/tool_dependencies/_conda"
+galaxy_conda_exec: mamba
 
 
 #########################################
@@ -196,9 +197,11 @@ group_galaxy_config:
       - type: tool_shed_packages
       - type: galaxy_packages
       - type: conda
+        exec: "{{ galaxy_conda_prefix }}/bin/{{ galaxy_conda_exec|d('conda') }}"
       - type: galaxy_packages
         versionless: true
       - type: conda
+        exec: "{{ galaxy_conda_prefix }}/bin/{{ galaxy_conda_exec|d('conda') }}"
         versionless: true
 
     # amqp_internal_connection: 'pyamqp://galaxy_internal:more_queues@localhost:5672/galaxy_internal' # this needs configuration

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -110,7 +110,6 @@ pulsar_yaml_config:
 
 pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
 miniconda_prefix: "{{ pulsar_conda_prefix }}"
-miniconda_version: "{{ global_miniconda_version }}"
 
 # for pulsar-post-tasks
 pulsar_tools_indices_dir: /mnt/tools-indices

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -111,8 +111,6 @@ pulsar_yaml_config:
 pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
 miniconda_prefix: "{{ pulsar_conda_prefix }}"
 miniconda_version: "{{ global_miniconda_version }}"
-miniconda_base_env_packages:
-  - mamba
 
 # for pulsar-post-tasks
 pulsar_tools_indices_dir: /mnt/tools-indices

--- a/pawsey_playbook.yml
+++ b/pawsey_playbook.yml
@@ -34,6 +34,9 @@
       become_user: postgres
     - geerlingguy.pip
     - galaxyproject.galaxy
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: galaxy
     - usegalaxy_eu.galaxy_systemd
     - nginx-upload-module
     - galaxyproject.nginx

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -31,6 +31,9 @@
       become_user: postgres
     - geerlingguy.pip
     - galaxyproject.galaxy
+    - role: galaxyproject.miniconda
+      become: true
+      become_user: galaxy
     - usegalaxy_eu.galaxy_systemd
     - nginx-upload-module
     - galaxyproject.nginx


### PR DESCRIPTION
I've tried this out on my VM.  cuffdiff does not resolve with conda but installs in a minute and a half with mamba.

In the past I've been setting the miniconda_version variable to anchor the conda version but this will not work when installing mamba into the base environment.  conda is in mamba's recipe so the latest conda is installed when mamba is installed.