### PR TITLE
prefer pulsar for repenrich

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -38,7 +38,10 @@ tools:
   testtoolshed.g2.bx.psu.edu/repos/simon-gladman/phyloseq_ordination_plot/phyloseq_ordinate/.*:
     cores: 16
   toolshed.g2.bx.psu.edu/repos/artbio/repenrich/repenrich/.*:
-    cores: 7
+    cores: 8
+    scheduling:
+      prefer:
+        - pulsar
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/.*:
     cores: 9
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/.*:


### PR DESCRIPTION
repenrich should be ok on mel2 and mel3 pulsars.  The environment was pre-installed with tbb=2020.2 and all of the tests pass.

TODO: make a pr to fix the conda recipe for bowtie=1.2.0 in bioconda to use tbb <= 2020.2
