### PR TITLE
send all mafft jobs to 2-core destinations

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -943,12 +943,6 @@ tools:
       accept:
       - pulsar
     rules:
-    - match: 0.0005 <= input_size < 0.5
-      cores: 60
-      mem: 961
-      scheduling:
-        accept:
-        - high-mem
     - match: input_size >= 0.5
       fail: Too much data, please don't use MAFFT for this.
   toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvetoptimiser/.*:


### PR DESCRIPTION
mafft has been moved to high-mem but it doesn't seem scale.