### PR TITLE
more mem for cdhit_est

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -529,6 +529,13 @@ tools:
     - match: input_size >= 0.01
       cores: 5
 
+  toolshed.g2.bx.psu.edu/repos/bebatut/cdhit/cd_hit_est/.*:
+    scheduling:
+      accept:
+      - pulsar
+    rules:
+    - match: input_size >= 0.1
+      cores: 4
   toolshed.g2.bx.psu.edu/repos/bgruening/augustus/augustus/.*:
     cores: 2
     scheduling:


### PR DESCRIPTION
Some larger cdhit jobs have been failing with the error
```
Fatal Error:
not enough memory, please set -M option greater than 1266

Program halted !
```