### PR TITLE
Docker and galaxy updates for docker enabled tools

### DIFF
--- a/dev-workers_playbook.yml
+++ b/dev-workers_playbook.yml
@@ -21,6 +21,7 @@
       - galaxyproject.cvmfs
       - geerlingguy.docker
       - dj-wasabi.telegraf
+      - acl-on-startup
   post_tasks:
       - name: restart munge
         systemd:
@@ -53,10 +54,4 @@
             become_user: root
             when: links.stat.islnk is defined and not links.stat.islnk
         when: attached_volumes is defined
-      - name: set acl for galaxy user on docker.sock
-        acl:
-            path: /var/run/docker.sock
-            entity: "{{ galaxy_user.name }}"
-            etype: user
-            permissions: rw
-            state: present
+

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -41,6 +41,13 @@ tools:
     scheduling:
       prefer:
         - pulsar
+  toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
+    cores: 16
+    params:
+      docker_enabled: true
+      docker_volumes: '$defaults'
+      docker_memory: '{mem}'
+      docker_sudo: false
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/.*:
     cores: 9
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/.*:

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
@@ -20,6 +20,12 @@ tools:
     cores: 1
   toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/.*:
     cores: 2
+  toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
+    params:
+      docker_enabled: true
+      docker_volumes: '$defaults'
+      docker_memory: '{mem}'
+      docker_sudo: false
 
 destinations:
   slurm:

--- a/group_vars/dev_workers.yml
+++ b/group_vars/dev_workers.yml
@@ -20,3 +20,5 @@ shared_mounts:
 docker_install_compose: false
 docker_users:
   - "{{ galaxy_user.name }}"
+docker_daemon_options:
+  data-root: /mnt/docker-data

--- a/group_vars/pawsey_workers.yml
+++ b/group_vars/pawsey_workers.yml
@@ -54,3 +54,5 @@ cvmfs_quota_limit: 20000
 docker_install_compose: false
 docker_users:
   - "{{ galaxy_user.name }}"
+docker_daemon_options:
+  data-root: /mnt/docker-data

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -140,6 +140,8 @@ host_galaxy_config:  # renamed from __galaxy_config
     nginx_upload_job_files_path: '/_job_files'
     job_config_file: "{{ galaxy_config_dir }}/job_conf.yml"
     watch_job_rules: true  # important for total perspective vortex
+    enable_mulled_containers: true
+    enable_beta_containers_interface: true
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -83,6 +83,8 @@ host_galaxy_config:  # renamed from __galaxy_config
     nginx_upload_job_files_store: "{{ nginx_upload_job_files_store_dir }}"
     nginx_upload_job_files_path: '/_job_files'
     watch_job_rules: true  # important for total perspective vortex
+    enable_mulled_containers: true
+    enable_beta_containers_interface: true
 
 #Galaxy Job Conf
 galaxy_jobconf:

--- a/pawsey-workers_playbook.yml
+++ b/pawsey-workers_playbook.yml
@@ -21,6 +21,7 @@
       - galaxyproject.cvmfs
       - dj-wasabi.telegraf
       - geerlingguy.docker
+      - acl-on-startup
   post_tasks:
       - name: restart munge
         systemd:
@@ -53,10 +54,4 @@
             become_user: root
             when: links.stat.islnk is defined and not links.stat.islnk
         when: attached_volumes is defined
-      - name: add FACL for docker.sock
-        acl:
-          path: /var/run/docker.sock
-          entity: "{{ galaxy_user.name }}"
-          etype: user
-          permissions: rw
-          state: present
+

--- a/requirements.yml
+++ b/requirements.yml
@@ -32,7 +32,7 @@
 - src: usegalaxy_eu.tiaas2
   version: 0.0.9
 - src: geerlingguy.docker
-  version: 2.6.0
+  version: 4.1.3
 - src: usegalaxy_eu.gie_proxy
   version: 0.0.2
 - name: galaxyproject.miniconda

--- a/roles/acl-on-startup/README.md
+++ b/roles/acl-on-startup/README.md
@@ -1,0 +1,4 @@
+A hack so that when we reboot the workers, setfacl is automatically run.
+
+Thanks very much to stackoverflow user Q23
+https://unix.stackexchange.com/questions/372244/how-can-i-make-acl-settings-on-run-media-persistent

--- a/roles/acl-on-startup/defaults/main.yml
+++ b/roles/acl-on-startup/defaults/main.yml
@@ -1,0 +1,1 @@
+acl_job_runner_user: galaxy

--- a/roles/acl-on-startup/tasks/main.yml
+++ b/roles/acl-on-startup/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Template .service file
+  template:
+    src: start-acl.service.j2
+    dest: /etc/systemd/system/start-acl.service
+- name: Enable service
+  systemd:
+    name: start-acl
+    enabled: true  # will start on reboot
+    state: started  # will start now if not running

--- a/roles/acl-on-startup/templates/start-acl.service.j2
+++ b/roles/acl-on-startup/templates/start-acl.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+ Description=ACL Hack
+ Requires=local-fs.target
+ After=local-fs.target
+
+[Service]
+ ExecStart=/usr/bin/setfacl -R -m u:{{ acl_job_runner_user }}:rw /var/run/docker.sock
+
+[Install]
+ WantedBy=multi-user.target

--- a/staging-workers_playbook.yml
+++ b/staging-workers_playbook.yml
@@ -16,6 +16,8 @@
       - galaxyproject.slurm
       - galaxyproject.cvmfs
       - dj-wasabi.telegraf
+      - geerlingguy.docker
+      - acl-on-startup
   post_tasks:
       - name: restart munge
         systemd:


### PR DESCRIPTION
Update the geerlingguy.docker version from 2.6.0 to 4.1.3.  The new one has an option `docker_daemon_options` that we can use to move the images/containers/docker things off the root disk.

Add `enable_mulled_containers: true` and `enable_beta_containers_interface: true` to galaxy.yml on staging and production

Add a role acl-on-startup that copies start-acl.service to /etc/systemd/system and enables it.  This is a "hack" thanks to stackoverflow user Q23 https://unix.stackexchange.com/questions/372244/how-can-i-make-acl-settings-on-run-media-persistent

Add bionano_scaffold to vortex config to run on 16 cores on slurm