### PR TITLE
do not send busco jobs to mel3

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -1044,6 +1044,8 @@ tools:
     scheduling:
       accept:
       - pulsar
+      reject:
+      - pulsar-mel3
     rules:
     - match: 0.05 <= input_size < 0.3
       cores: 8


### PR DESCRIPTION
multiple versions of busco are failing on pulsar-mel3.  Set scheduling for busco to reject the pulsar-mel3 tag for the time being