### PR TITLE
send busco v3 jobs to slurm only

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -1039,7 +1039,12 @@ tools:
       scheduling:
         accept:
         - high-mem
-  toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/.*:
+  toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.*:  # send busco 3 to slurm
+    cores: 2
+    rules:
+    - match: 0.05 <= input_size
+      cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/[^3].*:
     cores: 2
     scheduling:
       accept:


### PR DESCRIPTION
send old busco versions to slurm.

TODO: there is probably a way to fix this in galaxy https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tools/__init__.py#L219 because it seems to be broken because of a missing file in the working directory on pulsar