### PR TITLE
use interactive_tools.yml in tpv

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/interactive_tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/interactive_tools.yml
@@ -20,16 +20,16 @@ tools:
     inherits: interactive_tool
   interactive_tool_rstudio:
     inherits: interactive_tool
-  #   rules:
-  #     - match: |
-  #         not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
-  #       fail: "Interactive tool rstudio not available for user"  # TODO: update placeholder text
+    rules:
+      - match: |
+          not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
+        fail: "Interactive tool rstudio not available for user"  # TODO: update placeholder text
   interactive_tool_jupyter_notebook:
     inherits: interactive_tool
-  #   rules:
-  #     - match: |
-  #         not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
-  #       fail: "Interactive tool jupyter not available for user"  # TODO: update placeholder text
+    rules:
+      - match: |
+          not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
+        fail: "Interactive tool jupyter not available for user"  # TODO: update placeholder text
   interactive_tool_phinch:
     inherits: interactive_tool
   interactive_tool_cellxgene:

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/interactive_tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/interactive_tools.yml
@@ -22,13 +22,17 @@ tools:
     inherits: interactive_tool
     rules:
       - match: |
-          not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
+          not user or not any(
+            [True for r in user.all_roles() if not r.deleted and (r.name == 'trusted_for_ITs' or r.name.startswith('training'))]
+          )
         fail: "Interactive tool rstudio not available for user"  # TODO: update placeholder text
   interactive_tool_jupyter_notebook:
     inherits: interactive_tool
     rules:
       - match: |
-          not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
+          not user or not any(
+            [True for r in user.all_roles() if not r.deleted and (r.name == 'trusted_for_ITs' or r.name.startswith('training'))]
+          )
         fail: "Interactive tool jupyter not available for user"  # TODO: update placeholder text
   interactive_tool_phinch:
     inherits: interactive_tool

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/interactive_tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/interactive_tools.yml
@@ -20,16 +20,16 @@ tools:
     inherits: interactive_tool
   interactive_tool_rstudio:
     inherits: interactive_tool
-    rules:
-      - match: |
-          not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
-        fail: "Interactive tool rstudio not available for user"  # TODO: update placeholder text
+  #   rules:
+  #     - match: |
+  #         not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
+  #       fail: "Interactive tool rstudio not available for user"  # TODO: update placeholder text
   interactive_tool_jupyter_notebook:
     inherits: interactive_tool
-    rules:
-      - match: |
-          not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
-        fail: "Interactive tool jupyter not available for user"  # TODO: update placeholder text
+  #   rules:
+  #     - match: |
+  #         not user or not 'trusted_for_ITs' in [role.name for role in user.all_roles() if not role.deleted]
+  #       fail: "Interactive tool jupyter not available for user"  # TODO: update placeholder text
   interactive_tool_phinch:
     inherits: interactive_tool
   interactive_tool_cellxgene:

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -190,6 +190,8 @@ group_galaxy_config:
     build_sites_config_file: "{{ galaxy_config_dir }}/build_sites.yml"
     enable_old_display_applications: true
 
+    tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_interactive_tools
+
     dependency_resolvers:
       - type: tool_shed_packages
       - type: galaxy_packages

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -190,8 +190,6 @@ group_galaxy_config:
     build_sites_config_file: "{{ galaxy_config_dir }}/build_sites.yml"
     enable_old_display_applications: true
 
-    tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_interactive_tools
-
     dependency_resolvers:
       - type: tool_shed_packages
       - type: galaxy_packages

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -146,7 +146,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     watch_job_rules: true  # important for total perspective vortex
     enable_mulled_containers: true
     enable_beta_containers_interface: true
-    # tool_filters: ga_filters:hide_test_tools  # filter code cannot be copied to galaxy on the first run of the playbook, uncomment this after
+    # tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_interactive_tools  # filter code cannot be copied to galaxy on the first run of the playbook, uncomment this after
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -91,7 +91,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     enable_beta_containers_interface: true
     watch_job_rules: true  # important for total perspective vortex
     sentry_dsn: "{{ vault_sentry_dsn_dev }}"
-    tool_filters: ga_filters:hide_test_tools
+    tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_interactive_tools
 
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -149,7 +149,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     watch_job_rules: true  # important for total perspective vortex
     enable_mulled_containers: true
     enable_beta_containers_interface: true
-    tool_filters: ga_filters:hide_test_tools
+    tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_interactive_tools
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -86,7 +86,7 @@ galaxy_dynamic_job_rules:
   - total_perspective_vortex/destinations.yml
   - total_perspective_vortex/users.yml
   - total_perspective_vortex/roles.yml
-  # - total_perspective_vortex/interactive_tools.yml # leave these as mapped from job_conf for now
+  - total_perspective_vortex/interactive_tools.yml
   # - total_perspective_vortex/default_tool.yml.j2 # a future version of galaxyproject.galaxy will allow listing templates here
   - dynamic_rules/destination_mapper.py
   - dynamic_rules/tool_destinations.yml

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -88,7 +88,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     watch_job_rules: true  # important for total perspective vortex
     enable_mulled_containers: true
     enable_beta_containers_interface: true
-    tool_filters: ga_filters:hide_test_tools
+    tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_interactive_tools
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/pawsey_update_job_conf_playbook.yml
+++ b/pawsey_update_job_conf_playbook.yml
@@ -14,6 +14,7 @@
         - users.yml
         - roles.yml
         - destinations.yml
+        - interactive_tools.yml
     - tpv_templates:
         - default_tool.yml.j2
   handlers:

--- a/templates/galaxy/config/pawsey_job_conf.yml.j2
+++ b/templates/galaxy/config/pawsey_job_conf.yml.j2
@@ -143,6 +143,7 @@ execution:
       vortex_config_files:
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/default_tool.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/tools.yml"
+        - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/interactive_tools.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/users.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/roles.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/destinations.yml"
@@ -153,17 +154,6 @@ execution:
     dynamic_dtd:
       runner: dynamic
       type: dtd
-    interactive_pulsar:
-      runner: pulsar_embedded
-      docker_enabled: true
-      docker_volumes: $defaults
-      docker_sudo: false
-      docker_net: bridge
-      docker_auto_rm: true
-      docker_set_user: ''
-      require_container: true
-      container_monitor_result: callback
-      submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760 --partition=interactive_tools"
     slurm:
       runner: slurm
       nativeSpecification: --nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=124160 --partition=main
@@ -277,17 +267,6 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=62000
       transport: curl
-tools:
-- id: interactive_tool_ethercalc
-  environment: interactive_pulsar
-- id: interactive_tool_rstudio
-  environment: interactive_pulsar
-- id: interactive_tool_jupyter_notebook
-  environment: interactive_pulsar
-- id: interactive_tool_phinch
-  environment: interactive_pulsar
-- id: interactive_tool_cellxgene
-  environment: interactive_pulsar
 limits:
 - type: anonymous_user_concurrent_jobs
   value: 1
@@ -349,4 +328,3 @@ limits:
 - type: user_total_concurrent_jobs
   id: pulsar-QLD
   value: 5
-

--- a/templates/galaxy/config/tool_conf_interactive.xml.j2
+++ b/templates/galaxy/config/tool_conf_interactive.xml.j2
@@ -4,6 +4,6 @@
         <tool file="interactive/interactivetool_rstudio.xml" />
         <tool file="interactive/interactivetool_jupyter_notebook.xml" />
         <tool file="interactive/interactivetool_phinch.xml" />
-        <!-- <tool file="interactive/interactivetool_cellxgene.xml" /> -->
+        <tool file="interactive/interactivetool_cellxgene.xml" />
     </section>
 </toolbox>

--- a/templates/galaxy/config/tool_conf_interactive.xml.j2
+++ b/templates/galaxy/config/tool_conf_interactive.xml.j2
@@ -1,9 +1,9 @@
 <toolbox monitor="true">
     <section id="interactivetools" name="Interactive Tools">
         <tool file="interactive/interactivetool_ethercalc.xml" />
-        <!-- <tool file="interactive/interactivetool_rstudio.xml" /> -->
-        <!-- <tool file="interactive/interactivetool_jupyter_notebook.xml" /> -->
+        <tool file="interactive/interactivetool_rstudio.xml" />
+        <tool file="interactive/interactivetool_jupyter_notebook.xml" />
         <tool file="interactive/interactivetool_phinch.xml" />
-        <tool file="interactive/interactivetool_cellxgene.xml" />
+        <!-- <tool file="interactive/interactivetool_cellxgene.xml" /> -->
     </section>
 </toolbox>

--- a/templates/galaxy/toolbox/filters/ga_filters.py.j2
+++ b/templates/galaxy/toolbox/filters/ga_filters.py.j2
@@ -1,11 +1,23 @@
 test_tool_users = ["{{ test_tool_users | join('", "') }}"]
 test_tool_label = "test"
 
+restricted_ITs = ["interactive_tool_rstudio", "interactive_tool_jupyter_notebook"]
+IT_roles = ["trusted_for_ITs"]
+
 def hide_test_tools(context, tool):
     """
     hide tools with 'test' tag from all but selected_users
     """
     if hasattr(tool, 'labels') and test_tool_label in tool.labels:
         user = context.trans.user
-        return user and user.email in test_tool_users
+        return user is not None and user.email in test_tool_users
+    return True
+
+def restrict_interactive_tools(context, tool):
+    """
+    Show restricted interactive tools to users with specified roles
+    """
+    if hasattr(tool, 'id') and tool.id in restricted_ITs:
+        user = context.trans.user
+        return user is not None and len([r for r in user.all_roles() if not r.deleted and r.name in IT_roles]) > 0
     return True

--- a/templates/galaxy/toolbox/filters/ga_filters.py.j2
+++ b/templates/galaxy/toolbox/filters/ga_filters.py.j2
@@ -19,5 +19,7 @@ def restrict_interactive_tools(context, tool):
     """
     if hasattr(tool, 'id') and tool.id in restricted_ITs:
         user = context.trans.user
-        return user is not None and len([r for r in user.all_roles() if not r.deleted and r.name in IT_roles]) > 0
+        return user is not None and any(
+            [True for r in user.all_roles() if not r.deleted and (r.name in IT_roles or r.name.startswith('training'))]
+        )
     return True


### PR DESCRIPTION
2 ITs are disabled (jupyter and rstudio).  Having interactive tools go through tpv would make it possible to reenable them for some users.

Also added a toolbox filter to hide the tools from users that cannot access them.   Both the filter and TPV only allow the tools for users with the trusted_for_ITs role but this could be extended to include the training-smorgasbord role or all training roles. [Updated: this now includes all training roles]

rstudio and jupyter are uncommented in the tool_conf_interactive.