### PR TITLE
use real path to links.xml

### DIFF
--- a/files/galaxy/config/local_tool_conf_dev.xml
+++ b/files/galaxy/config/local_tool_conf_dev.xml
@@ -4,6 +4,6 @@
         <tool file="/mnt/galaxy/local_tools/alphafold/alphafold.xml" />
         <tool file="/mnt/galaxy/local_tools/wtdbg2/wtdbg2.xml" />
         <tool file="/mnt/galaxy/local_tools/ipa/ipa.xml" />
-        <tool file="/mnt/galaxy/local_tools/links/links.xml" />
+        <tool file="/home/tom/galaxy-local-tools/tools/links/links.xml" />
     </section>
 </toolbox>


### PR DESCRIPTION
Singularity doesn't seem to like the symlink

```bash
FATAL:   container creation failed: mount /mnt/galaxy/local_tools/links->/mnt/galaxy/local_tools/links error: while mounting /mnt/galaxy/local_tools/links: mount source /mnt/galaxy/local_tools/links doesn't exist
```