### PR TITLE
set pulsar-high-mem1 offline due to disk errors

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
@@ -36,6 +36,7 @@ destinations:
       accept:
       - pulsar-high-mem1
       require:
+      - offline
       - pulsar
       - high-mem
   pulsar-high-mem2:


### PR DESCRIPTION
A user reported bugs with raven jobs: `[bioparser::Parser::Store] error: buffer overflow`.  Identical raven jobs have completed successfully on other high mem pulsars with identical conda environments.  The syslog contains I/O errors and the majority of jobs are failing, needs investigation.