### PR TITLE
switch from 120 cores to 60 cores for busco, bwa_mem and quast

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -1024,8 +1024,8 @@ tools:
     - match: 1 <= input_size < 20
       cores: 8
     - match: input_size >= 20
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -1060,8 +1060,8 @@ tools:
     - match: 0.05 <= input_size < 0.3
       cores: 8
     - match: input_size >= 0.3
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -1093,8 +1093,8 @@ tools:
       - pulsar
     rules:
     - match: input_size >= 1
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem


### PR DESCRIPTION
these settings are from when we were sending all high-mem jobs to _mid or _big destinations.  Switch these to 1/4 of a high mem machine each.