### PR TITLE
mount custom-indices at /mnt/custom-indices on pawsey and workers

### DIFF
--- a/group_vars/pawsey_workers.yml
+++ b/group_vars/pawsey_workers.yml
@@ -17,6 +17,10 @@ shared_mounts:
       src: "{{ hostvars['pawsey-misc-nfs']['internal_ip'] }}:/mnt/tools-indices"
       fstype: nfs
       state: mounted
+    - path: /mnt/custom-indices
+      src: "{{ hostvars['pawsey-misc-nfs']['internal_ip'] }}:/custom-indices"
+      fstype: nfs
+      state: mounted
     - path: /mnt/user-data
       src: "{{ hostvars['pawsey-user-nfs']['internal_ip'] }}:/mnt/user-data"
       fstype: nfs

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -43,6 +43,10 @@ shared_mounts:
       src: "{{ hostvars['pawsey-misc-nfs']['internal_ip'] }}:/mnt/tools-indices"
       fstype: nfs
       state: mounted
+    - path: /mnt/custom-indices
+      src: "{{ hostvars['pawsey-misc-nfs']['internal_ip'] }}:/custom-indices"
+      fstype: nfs
+      state: mounted
     - path: /mnt/user-data
       src: "{{ hostvars['pawsey-user-nfs']['internal_ip'] }}:/mnt/user-data"
       fstype: nfs


### PR DESCRIPTION
have custom-indices as a separate volume next to tools-indices on pawsey and the workers.

The next step is to refactor the pulsar mounts, find/replace text in /mnt/tools-indices/tool-data and change the custom-indices path in galaxyservers.yml.
