### PR TITLE
Change custom indices path on pulsars and in galaxyservers.yml

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -169,7 +169,7 @@ group_galaxy_config:
     user_preferences_extra_conf_path: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
     file_sources_config_file: "{{ galaxy_config_dir }}/file_sources_conf.yml"
 
-    galaxy_data_manager_data_path: "{{ galaxy_tools_indices_dir }}/custom-indices"
+    galaxy_data_manager_data_path: "{{ galaxy_custom_indices_dir }}"
     shed_tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data/shed_tool_data"
     tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data"
     tool_data_table_config_path: "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml"

--- a/group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
+++ b/group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
@@ -4,16 +4,16 @@ add_hosts_head: yes
 use_internal_ips: true
 
 shared_mounts:
-    - path: /mnt/tools-indices
-      src: pulsar-nci-test:/mnt/tools-indices
+    - path: /mnt/custom-indices
+      src: pulsar-nci-test:/mnt/custom-indices
       fstype: nfs
       state: mounted
     - path: /mnt/pulsar
       src: pulsar-nci-test:/mnt/pulsar
       fstype: nfs
       state: mounted
-    - path: /mnt/galaxy
-      src: pulsar-nci-test:/mnt/galaxy
+    - path: /mnt/tools-indices
+      src: pulsar-nci-test:/mnt/tools-indices
       fstype: nfs
       state: absent
 

--- a/group_vars/pulsar_QLD/pulsar-QLD_workers.yml
+++ b/group_vars/pulsar_QLD/pulsar-QLD_workers.yml
@@ -4,8 +4,8 @@ add_hosts_head: yes
 add_hosts_galaxy: yes
 
 shared_mounts:
-    - path: /mnt/tools-indices
-      src: pulsar-QLD:/mnt/tools-indices
+    - path: /mnt/custom-indices
+      src: pulsar-QLD:/mnt/custom-indices
       fstype: nfs
       state: mounted
     - path: /mnt/tmp
@@ -16,6 +16,10 @@ shared_mounts:
       src: pulsar-QLD:/mnt/pulsar
       fstype: nfs
       state: mounted
+    - path: /mnt/tools-indices
+      src: pulsar-nci-test:/mnt/tools-indices
+      fstype: nfs
+      state: absent
 
 
 # cvmfs

--- a/group_vars/pulsar_mel2/pulsar-mel2_workers.yml
+++ b/group_vars/pulsar_mel2/pulsar-mel2_workers.yml
@@ -3,16 +3,16 @@ slurm_roles: ['exec']
 add_hosts_head: yes
 
 shared_mounts:
-    - path: /mnt/tools-indices
-      src: pulsar-mel2:/mnt/tools-indices
+    - path: /mnt/custom-indices
+      src: pulsar-mel2:/mnt/custom-indices
       fstype: nfs
       state: mounted
     - path: /mnt/pulsar
       src: pulsar-mel2:/mnt/pulsar
       fstype: nfs
       state: mounted
-    - path: /mnt/galaxy
-      src: pulsar-mel2:/mnt/galaxy
+    - path: /mnt/tools-indices
+      src: pulsar-mel2:/mnt/tools-indices
       fstype: nfs
       state: absent
 

--- a/group_vars/pulsar_mel3/pulsar-mel3_workers.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_workers.yml
@@ -3,8 +3,8 @@ slurm_roles: ['exec']
 add_hosts_head: yes
 
 shared_mounts:
-    - path: /mnt/tools-indices
-      src: pulsar-mel3:/mnt/tools-indices
+    - path: /mnt/custom-indices
+      src: pulsar-mel3:/mnt/custom-indices
       fstype: nfs
       state: mounted
     - path: /mnt/pulsar
@@ -15,8 +15,8 @@ shared_mounts:
       src: pulsar-mel3:/mnt/files
       fstype: nfs
       state: mounted
-    - path: /mnt/galaxy
-      src: pulsar-mel3:/mnt/galaxy
+    - path: /mnt/tools-indices
+      src: pulsar-mel3:/mnt/tools-indices
       fstype: nfs
       state: absent
 

--- a/group_vars/pulsar_nci_training/pulsar-nci-training_workers.yml
+++ b/group_vars/pulsar_nci_training/pulsar-nci-training_workers.yml
@@ -4,16 +4,16 @@ add_hosts_head: yes
 use_internal_ips: true
 
 shared_mounts:
-    - path: /mnt/tools-indices
-      src: pulsar-nci-training:/mnt/tools-indices
+    - path: /mnt/custom-indices
+      src: pulsar-nci-training:/mnt/custom-indices
       fstype: nfs
       state: mounted
     - path: /mnt/pulsar
       src: pulsar-nci-training:/mnt/pulsar
       fstype: nfs
       state: mounted
-    - path: /mnt/galaxy
-      src: pulsar-nci-training:/mnt/galaxy
+    - path: /mnt/tools-indices
+      src: pulsar-nci-training:/mnt/tools-indices
       fstype: nfs
       state: absent
 

--- a/group_vars/pulsar_paw/pulsar-paw_workers.yml
+++ b/group_vars/pulsar_paw/pulsar-paw_workers.yml
@@ -3,16 +3,16 @@ slurm_roles: ['exec']
 add_hosts_head: yes
 
 shared_mounts:
-    - path: /mnt/tools-indices
-      src: pulsar-paw:/mnt/tools-indices
+    - path: /mnt/custom-indices
+      src: pulsar-paw:/mnt/custom-indices
       fstype: nfs
       state: mounted
     - path: /mnt/pulsar
       src: pulsar-paw:/mnt/pulsar
       fstype: nfs
       state: mounted
-    - path: /mnt/galaxy
-      src: pulsar-paw:/mnt/galaxy
+    - path: /mnt/tools-indices
+      src: pulsar-paw:/mnt/tools-indices
       fstype: nfs
       state: absent
 

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -37,7 +37,7 @@ slurmdbd_config:
 #NFS shares
 
 nfs_exports:
-    - "/mnt/tools-indices  *(rw,async,no_root_squash,no_subtree_check)"
+    - "{{ pulsar_custom_indices_dir }}  *(rw,async,no_root_squash,no_subtree_check)"
     - "/mnt/pulsar  *(rw,async,no_root_squash,no_subtree_check)"
 
 # Pulsar
@@ -112,7 +112,7 @@ pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
 miniconda_prefix: "{{ pulsar_conda_prefix }}"
 
 # for pulsar-post-tasks
-pulsar_tools_indices_dir: /mnt/tools-indices
+pulsar_custom_indices_dir: /mnt/custom-indices
 
 #Stats collection
 sinfo_line_startswith: "p"

--- a/host_vars/DR.usegalaxy.org.au.yml
+++ b/host_vars/DR.usegalaxy.org.au.yml
@@ -74,7 +74,8 @@ galaxy_dynamic_job_rules:
   - dynamic_rules/tool_destinations.yml
   - readme.txt
 
-galaxy_tools_indices_dir: /mnt/tools-indices     
+galaxy_tools_indices_dir: /mnt/tools-indices
+galaxy_custom_indices_dir: /mnt/custom-indices
 galaxy_tmp_dir: /mnt/tmp
 
 galaxy_handler_count: 5

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -79,6 +79,7 @@ galaxy_dynamic_job_rules:
   - readme.txt
 
 galaxy_tools_indices_dir: /mnt/tools-indices     
+galaxy_custom_indices_dir: /mnt/custom-indices     
 galaxy_tmp_dir: /mnt/tmp
 
 galaxy_handler_count: 5

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -42,6 +42,7 @@ galaxy_dynamic_job_rules:
   - readme.txt
 
 galaxy_tools_indices_dir: "{{ galaxy_root }}"
+galaxy_custom_indices_dir: "{{ galaxy_root }}/custom-indices" 
 galaxy_tmp_dir: "{{ galaxy_root }}/tmp"
 
 galaxy_repo: https://github.com/galaxyproject/galaxy.git

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -88,7 +88,8 @@ galaxy_dynamic_job_rules:
   - dynamic_rules/tool_destinations.yml
   - readme.txt
 
-galaxy_tools_indices_dir: /mnt/tools-indices     
+galaxy_tools_indices_dir: /mnt/tools-indices
+galaxy_custom_indices_dir: /mnt/custom-indices    
 galaxy_tmp_dir: /mnt/tmp     
 
 galaxy_handler_count: 5   ############# europe uses 5, this could be host specific

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -45,6 +45,7 @@ galaxy_dynamic_job_rules:
 
 galaxy_tools_indices_dir: "{{ galaxy_root }}"
 galaxy_tmp_dir: "{{ galaxy_root }}/tmp"
+galaxy_custom_indices_dir: "{{ galaxy_root }}/custom-indices"
 
 galaxy_file_path: "{{ galaxy_root }}/data"
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"

--- a/one-offs/move_pulsar_custom_indices.yml
+++ b/one-offs/move_pulsar_custom_indices.yml
@@ -1,0 +1,29 @@
+- hosts:
+    - pulsar-nci-test
+    - pulsar-mel2
+    - pulsar-mel3
+    - pulsar-paw
+    - qld-pulsar-himem-0
+    - qld-pulsar-himem-1
+    - qld-pulsar-himem-2
+    - pulsar-nci-training
+    - pulsar-QLD
+    - pulsar-high-mem1
+    - pulsar-high-mem2
+  become: true
+  become_user: ubuntu
+  pre_tasks:
+    - name: stat /mnt/tools-indices/custom-indices
+      stat:
+        path: /mnt/tools-indices/custom-indices
+      register: old_path
+    - name: stat /mnt/custom-indices
+      stat:
+        path: /mnt/custom-indices
+      register: new_path
+    - name: Move /mnt/tools-indices/custom-indices to /mnt/custom-indices
+      command:
+        cmd: mv /mnt/tools-indices/custom-indices /mnt/custom-indices
+      when: old_path.stat.exists and not new_path.stat.exists
+
+    

--- a/roles/pulsar-post-tasks/tasks/main.yml
+++ b/roles/pulsar-post-tasks/tasks/main.yml
@@ -11,9 +11,9 @@
       group: ubuntu
       state: directory
       mode: 0755
-- name: own the pulsar_tools_indices_dir as ubuntu
+- name: own the pulsar_custom_indices_dir as ubuntu
   file:
-      path: "{{ pulsar_tools_indices_dir }}"
+      path: "{{ pulsar_custom_indices_dir }}"
       owner: ubuntu
       group: ubuntu
       state: directory


### PR DESCRIPTION
- one-off playbook to move custom-indices down one level on pulsars
- mount custom-indices instead of tools-indices on pulsar workers
- galaxy_custom_indices_dir in galaxyservers for each galaxy host_vars file

staging and dev are not affected because they do not have any ref data

This depends on #658 being merged.
When switching over, before running the pawsey playbook I will need to run `find /mnt/galaxy/tools-indices/tool-data -type f -exec sed -i -e 's/tools-indices\/custom-indices/custom-indices/g' {} \;` to update the loc files