### PR TITLE
update rules for non-alphafold azure tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -67,19 +67,19 @@ tools:
           require:
             - pulsar-azure-0
         cores: 4
-        mem: 16
+        mem: 15
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=small"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=small"
+          nativeSpecification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
+          submit_native_specification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
       - match: user.email == "pulsar_azure_0@genome.edu.au" and input_size >= 10
         scheduling:
           require:
             - pulsar-azure-0
         cores: 16
-        mem: 64
+        mem: 60.8
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=medium"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=medium"
+          nativeSpecification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
+          submit_native_specification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
 
 
   toolshed.g2.bx.psu.edu/repos/bgruening/hifiasm/hifiasm/.*:
@@ -107,10 +107,10 @@ tools:
     rules:
       - match: user.email == "pulsar_azure_0@genome.edu.au"
         cores: 120
-        mem: 2000
+        mem: 1900
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=special"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=special"
+          nativeSpecification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
+          submit_native_specification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
 
   toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/.*:
     inherits: pulsar_preferred
@@ -169,19 +169,19 @@ tools:
           require:
             - pulsar-azure-0
         cores: 4
-        mem: 16
+        mem: 15
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=small"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=small"
+          nativeSpecification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
+          submit_native_specification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
       - match: user.email == "pulsar_azure_0@genome.edu.au" and input_size >= 0.1
         scheduling:
           require:
             - pulsar-azure-0
         cores: 32
-        mem: 128
+        mem: 121.6
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=large"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=large"
+          nativeSpecification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
+          submit_native_specification: "--nodes=2 --ntasks={cores} --ntasks-per-node={round(cores/2)} --mem={round(mem*1024)} --partition=small"
   
   toolshed.g2.bx.psu.edu/repos/lparsons/htseq_count/htseq_count/.*:
     scheduling:


### PR DESCRIPTION
the small, medium, large and special partitions need --nodes=2 --ntasks=X --ntasks-per-node=X/2 in the native specification.  They also have slightly less mem available than on the spreadsheet.