### PR TITLE
change aarnet-misc volumes from 200 300 300 1000 to 1000 2000

### DIFF
--- a/terraform/aarnet-prod-pulumi/__main__.py
+++ b/terraform/aarnet-prod-pulumi/__main__.py
@@ -143,7 +143,7 @@ VM_CONFIG = {
         "flavor": "C4R16D40",
     },
     "aarnet-job-nfs": {"volume": [20000], "flavor": "C8R32D40"},
-    "aarnet-misc-nfs": {"volume": [200, 300, 300, 1000], "flavor": "C8R32D40"},
+    "aarnet-misc-nfs": {"volume": [1000, 2000], "flavor": "C8R32D40"},
     "aarnet-user-nfs": {"volume": [80000, 50000], "flavor": "C8R32D40"},
     "aarnet-db": {
         "ext-net": True,

--- a/terraform/aarnet-prod-pulumi/__main__.py
+++ b/terraform/aarnet-prod-pulumi/__main__.py
@@ -144,7 +144,7 @@ VM_CONFIG = {
     },
     "aarnet-job-nfs": {"volume": [20000], "flavor": "C8R32D40"},
     "aarnet-misc-nfs": {"volume": [1000, 2000], "flavor": "C8R32D40"},
-    "aarnet-user-nfs": {"volume": [80000, 50000], "flavor": "C8R32D40"},
+    "aarnet-user-nfs": {"volume": [150000], "flavor": "C8R32D40"},
     "aarnet-db": {
         "ext-net": True,
         "sec-groups": [db_sec_grp.id],


### PR DESCRIPTION
This is 1200 GB more than we previously had.  We have only been using the 1000 volume for /mnt/tools-indices and /mnt/ghost-galaxy-app.

This would be 1000 for shed_tools, tool_dependencies and singularity_cache
and 2000 for custom-indices (currently this size and half full on pawsey-misc-nfs)