### PR TITLE
bind /etc/passwd in docker

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -203,14 +203,14 @@ tools:
     cores: 3
     params:
       docker_enabled: true
-      docker_volumes: '$defaults,/etc/passwd'
+      docker_volumes: '$defaults,/etc/passwd:ro'
       docker_memory: '{mem}G'
       docker_sudo: false
   cactus_export:
     cores: 1
     params:
       docker_enabled: true
-      docker_volumes: '$defaults,/etc/passwd'
+      docker_volumes: '$defaults,/etc/passwd:ro'
       docker_memory: '{mem}G'
       docker_sudo: false
 

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -203,14 +203,14 @@ tools:
     cores: 3
     params:
       docker_enabled: true
-      docker_volumes: '$defaults'
+      docker_volumes: '$defaults,/etc/passwd'
       docker_memory: '{mem}G'
       docker_sudo: false
   cactus_export:
     cores: 1
     params:
       docker_enabled: true
-      docker_volumes: '$defaults'
+      docker_volumes: '$defaults,/etc/passwd'
       docker_memory: '{mem}G'
       docker_sudo: false
 


### PR DESCRIPTION
Hi @cat-bro 

This was [suggested by the developers](https://github.com/ComparativeGenomicsToolkit/cactus/issues/677#issuecomment-1063211195) as a workaround to the issue running Cactus with docker on dev.

I *think* Singularity mounts `/etc/passwd` by default but Docker doesn't.

Not sure if this is the right way to do it in TPV.

Thanks!