### PR TITLE
allow more jobs to queue on slurm so that tiaas jobs do not bounce

### DIFF
--- a/templates/galaxy/config/pawsey_job_conf.yml.j2
+++ b/templates/galaxy/config/pawsey_job_conf.yml.j2
@@ -296,7 +296,7 @@ limits:
 
 - type: destination_total_concurrent_jobs
   id: slurm
-  value: 40
+  value: 55
 - type: destination_user_concurrent_jobs
   id: slurm
   value: 5


### PR DESCRIPTION
@Slugger70 I'm 90% sure that this is the problem.  There are >40 jobs in queued+running and other jobs get assigned to slurm and remain in new state