### PR TITLE
kraken2 and shovill to pulsar, pulsar-training-large tags for some tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -290,6 +290,11 @@ tools:
     - match: input_size >= 0.1
       cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
+    scheduling:
+      accept:
+        - pulsar
+      reject:
+        - pulsar-QLD
     cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/limma_voom/limma_voom/.*:
     cores: 7
@@ -487,11 +492,14 @@ tools:
     - match: input_size >= 0.5
       cores: 9
   toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/.*:
+    scheduling:
+      accept:
+        - pulsar
     rules:
     - match: 0.015 <= input_size < 2
-      cores: 7
+      cores: 8
     - match: 2 <= input_size < 10
-      cores: 9
+      cores: 10
     - match: input_size >= 10
       fail: Too much data, shoudn't run
   toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/.*:

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -297,6 +297,13 @@ tools:
       reject:
         - pulsar-QLD
     cores: 16
+    rules:
+    - match: |
+        user_limit = 2
+        helpers.concurrent_job_count_for_tool(app, tool, user) >= user_limit
+      execute: |
+        from galaxy.jobs.mapper import JobNotReadyException
+        raise JobNotReadyException()
   toolshed.g2.bx.psu.edu/repos/iuc/limma_voom/limma_voom/.*:
     cores: 7
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/.*:
@@ -736,7 +743,6 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-training-large
     rules:
     - match: 0.005 <= input_size < 0.02
       cores: 4
@@ -939,7 +945,6 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-training-large
   toolshed.g2.bx.psu.edu/repos/iuc/trycycler_consensus/trycycler_consensus/.*:
     cores: 1
     scheduling:
@@ -977,7 +982,6 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-training-large
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/.*:
     cores: 2
     scheduling:

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -293,6 +293,7 @@ tools:
     scheduling:
       accept:
         - pulsar
+        - pulsar-training-large
       reject:
         - pulsar-QLD
     cores: 16
@@ -708,6 +709,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: 0.001 <= input_size < 1
       cores: 8
@@ -734,6 +736,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: 0.005 <= input_size < 0.02
       cores: 4
@@ -771,6 +774,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: input_size >= 5e-06
       cores: 120
@@ -867,6 +871,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: input_size >= 5
       cores: 16
@@ -875,6 +880,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: 0.001 < input_size <= 5
       cores: 16
@@ -905,6 +911,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
   toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_seq/.*:
     cores: 1
     scheduling:
@@ -970,6 +977,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
   toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/.*:
     cores: 2
     scheduling:
@@ -993,6 +1001,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: 0.05 <= input_size < 1
       cores: 8
@@ -1180,6 +1189,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: 0.1 <= input_size < 30
       cores: 60
@@ -1195,6 +1205,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-training-large
     rules:
     - match: 0.005 <= input_size < 2
       cores: 8


### PR DESCRIPTION
kraken2 can go to pulsar but not pulsar-QLD yet because it needs ref data

pulsar-friendly tools such as rna_star can go to 8-core training destinations (pulsar-training-large tag)