### PR TITLE
raise RealMemory on pulsar-paw workers

### DIFF
--- a/group_vars/pulsar_paw/pulsar-paw_slurm.yml
+++ b/group_vars/pulsar_paw/pulsar-paw_slurm.yml
@@ -14,27 +14,27 @@ slurm_nodes:
     - name: pulsar-paw-w1
       NodeAddr: "{{ hostvars['pulsar-paw-w1']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 30500
+      RealMemory: 32208
       State: UNKNOWN
     - name: pulsar-paw-w2
       NodeAddr: "{{ hostvars['pulsar-paw-w2']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 30500
+      RealMemory: 32208
       State: UNKNOWN
     - name: pulsar-paw-w3
       NodeAddr: "{{ hostvars['pulsar-paw-w3']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 30500
+      RealMemory: 32208
       State: UNKNOWN
     - name: pulsar-paw-w4
       NodeAddr: "{{ hostvars['pulsar-paw-w4']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 30500
+      RealMemory: 32208
       State: UNKNOWN
     - name: pulsar-paw-w5
       NodeAddr: "{{ hostvars['pulsar-paw-w5']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 30500
+      RealMemory: 32208
       State: UNKNOWN
 
 slurm_partitions:


### PR DESCRIPTION
pulsar-paw worker VMs have the same MemTotal values as pulsar-mel2 workers so they could have the same RealMemory value in slurm.  At the moment pulsar-paw jobs have `cores: mem * 3.7` instead of 3.8 but they could be using 3.8, same as everywhere else.