### PR TITLE
Docker and singularity for dev pulsars

### DIFF
--- a/dev-pulsar_playbook.yml
+++ b/dev-pulsar_playbook.yml
@@ -20,6 +20,8 @@
     - insspb.hostname
     - geerlingguy.pip
     - galaxyproject.repos
+    - gantsign.golang
+    - cyverse-ansible.singularity
     - role: galaxyproject.miniconda
       become: true
       become_user: "{{ pulsar_user.name }}"
@@ -28,6 +30,8 @@
     - mariadb
     - galaxyproject.slurm
     - galaxyproject.cvmfs
+    - geerlingguy.docker
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
+    - acl-on-startup

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -3,16 +3,42 @@ tools:
     scheduling:
       prefer:
         - pulsar
+  slurm_singularity:
+    params:
+      singularity_enabled: True
+      singularity_volumes: '$defaults'
+      singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
+  pulsar_singularity:
+    inherits: slurm_singularity
+    scheduling:
+      require:
+        - pulsar
+    params:
+      singularity_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw'
+  slurm_docker:
+    params:
+      docker_enabled: true
+      docker_volumes: '$defaults'
+      docker_memory: '{mem}G'
+      docker_sudo: false  
+  pulsar_docker:
+    inherits: slurm_docker
+    scheduling:
+      require:
+        - pulsar
+    params:
+      docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw'
+      docker_set_user: '1000'
+
   upload1:
     cores: 1
 
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
+    inherits: pulsar_docker
+    cores: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/links/links/.*:
+    inherits: pulsar_singularity
     cores: 2
-    params:
-      docker_enabled: true
-      docker_volumes: '$defaults'
-      docker_memory: '{mem}'
-      docker_sudo: false
   toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/.*:
     inherits: pulsar_preferred
     cores: 2
@@ -188,12 +214,6 @@ tools:
       require:
         - pulsar
         - pulsar-nci-test
-    cores: 2
-    params:
-      singularity_enabled: True
-      singularity_volumes: '$defaults'
-      singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
-  links:
     cores: 2
     params:
       singularity_enabled: True

--- a/group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
+++ b/group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
@@ -37,7 +37,7 @@ docker_daemon_options:
   data-root: /mnt/docker-data
 
 # acl-on-startup role
-acl_job_runner_user: ubuntu
+acl_job_runner_user: "{{ pulsar_user.name }}"
 
 # Golang
 golang_gopath: '/var/workspace-go'

--- a/group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
+++ b/group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
@@ -3,6 +3,13 @@ slurm_roles: ['exec']
 add_hosts_head: yes
 use_internal_ips: true
 
+#Attached volume
+attached_volumes:
+  - device: /dev/vdb
+    path: /mnt
+    fstype: ext4
+    label: msdos
+
 shared_mounts:
     - path: /mnt/custom-indices
       src: pulsar-nci-test:/mnt/custom-indices
@@ -21,3 +28,20 @@ shared_mounts:
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 cvmfs_quota_limit: 20000
+
+# Docker
+docker_install_compose: false
+docker_users:
+  - "{{ pulsar_user.name }}"
+docker_daemon_options:
+  data-root: /mnt/docker-data
+
+# acl-on-startup role
+acl_job_runner_user: ubuntu
+
+# Golang
+golang_gopath: '/var/workspace-go'
+
+# Singularity target version
+singularity_version: "3.7.4"
+singularity_go_path: "{{ golang_install_dir }}"

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -120,4 +120,4 @@ add_utilisation_info: true
 stats_dir: /home/ubuntu/stats_collection
 
 # acl-on-startup role
-acl_job_runner_user: ubuntu
+acl_job_runner_user: "{{ pulsar_user.name }}"

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -118,3 +118,6 @@ pulsar_custom_indices_dir: /mnt/custom-indices
 sinfo_line_startswith: "p"
 add_utilisation_info: true
 stats_dir: /home/ubuntu/stats_collection
+
+# acl-on-startup role
+acl_job_runner_user: ubuntu

--- a/host_vars/dev-pulsar.usegalaxy.org.au.yml
+++ b/host_vars/dev-pulsar.usegalaxy.org.au.yml
@@ -28,7 +28,7 @@ docker_users:
   - "{{ pulsar_user.name }}"
 
 # acl-on-startup role
-acl_job_runner_user: ubuntu
+acl_job_runner_user: "{{ pulsar_user.name }}"
 
 # Golang
 golang_gopath: '/var/workspace-go'

--- a/host_vars/dev-pulsar.usegalaxy.org.au.yml
+++ b/host_vars/dev-pulsar.usegalaxy.org.au.yml
@@ -21,3 +21,18 @@ extra_keys:
   - id: ubuntu_maintenance_key
     type: public
     from: "{{ hostvars['dev']['ansible_ssh_host'] }}"
+
+# Docker
+docker_install_compose: false
+docker_users:
+  - "{{ pulsar_user.name }}"
+
+# acl-on-startup role
+acl_job_runner_user: ubuntu
+
+# Golang
+golang_gopath: '/var/workspace-go'
+
+# Singularity target version
+singularity_version: "3.7.4"
+singularity_go_path: "{{ golang_install_dir }}"

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -93,6 +93,20 @@ host_galaxy_config:  # renamed from __galaxy_config
     sentry_dsn: "{{ vault_sentry_dsn_dev }}"
     tool_filters: ga_filters:hide_test_tools
 
+    container_resolvers:
+      - type: explicit
+      - type: explicit_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+      - type: cached_mulled_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+      #   cache_directory: /cvmfs/singularity.galaxyproject.org/all  # from usa usegalaxy-playbook
+      #   cache_directory_cacher_type: dir_mtime
+      - type: mulled_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+      - type: build_mulled_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+        auto_install: false
+
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 
 # NFS stuff

--- a/host_vars/pulsar-nci-test/pulsar-nci-test.usegalaxy.org.au.yml
+++ b/host_vars/pulsar-nci-test/pulsar-nci-test.usegalaxy.org.au.yml
@@ -26,3 +26,15 @@ pulsar_rabbit_vhost: "/pulsar/galaxy_nci_test"
 
 # Use mamba as replacement for conda
 pulsar_conda_exec: "mamba"
+
+# Docker
+docker_install_compose: false
+docker_users:
+  - "{{ pulsar_user.name }}"
+
+# Golang
+golang_gopath: '/var/workspace-go'
+
+# Singularity target version
+singularity_version: "3.7.4"
+singularity_go_path: "{{ golang_install_dir }}"

--- a/pulsar-nci-test_playbook.yml
+++ b/pulsar-nci-test_playbook.yml
@@ -20,9 +20,13 @@
     - mariadb
     - galaxyproject.slurm
     - galaxyproject.cvmfs
+    - gantsign.golang
+    - cyverse-ansible.singularity
+    - geerlingguy.docker
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
+    - acl-on-startup
     # - slg.galaxy_stats
   post_tasks:
     - name: Reload exportfs

--- a/pulsar-nci-test_workers_playbook.yml
+++ b/pulsar-nci-test_workers_playbook.yml
@@ -7,16 +7,51 @@
     - group_vars/pulsar-nci-test/pulsar-nci-test_workers.yml
     - group_vars/pulsar-nci-test/pulsar-nci-test_slurm.yml
     - group_vars/VAULT
+  pre_tasks:
+    - name: Attach volume to instance
+      include_role:
+        name: attached-volumes
   roles:
       - common
       - insspb.hostname
       - galaxyproject.slurm
       - mounts
       - galaxyproject.repos
+      - gantsign.golang
+      - cyverse-ansible.singularity
       - galaxyproject.cvmfs
       - dj-wasabi.telegraf
+      - geerlingguy.docker
+      - acl-on-startup
   post_tasks:
       - name: Restart munge service
         service:
             name: munge
             state: restarted
+      - name: Move /tmp to vdc
+        block:
+          - name: Create worker tmpdir on vdb
+            file:
+                path: /mnt/tmpdisk
+                state: directory
+                owner: root
+                group: root
+                mode: '1777'
+          - name: stat links
+            stat:
+                path: /tmp
+            register: links
+          - name: remove old tmp
+            file:
+                path: /tmp
+                state: absent
+            when: links.stat.islnk is defined and not links.stat.islnk
+          - name: Link /tmp to /mnt/tmpdisk
+            file:
+                src: /mnt/tmpdisk
+                dest: /tmp
+                state: link
+            become: yes
+            become_user: root
+            when: links.stat.islnk is defined and not links.stat.islnk
+        when: attached_volumes is defined


### PR DESCRIPTION
- Add container_resolvers to host_vars/dev
- Add docker and singularity roles to dev-pulsar and pulsar-nci-test
- Set bionano_scaffold to run with docker on pulsar and links to run on singularity with pulsar

The tools set to run on pulsar with singularity or docker have `require: ['pulsar']` in tpv because the singularity_volumes will be different between slurm and pulsar.  The directory structures are different and jobs will fail on pulsar with '$defaults'.  My idea of a for-now solution is to set tools to run either only on slurm or only on pulsar if they use containers.

There is also a caveat that to run a singularity job on pulsar the container must be deleted from galaxy's local container cache.. 