### PR TITLE
Comment out local_canu in local_tool_conf.xml

### DIFF
--- a/files/galaxy/config/local_tool_conf.xml
+++ b/files/galaxy/config/local_tool_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <toolbox monitor="true">
     <section id="local_tools" name="Local Tools">
-        <tool file="galaxy-local-tools/tools/canu/canu.xml" labels="test"/>
+        <!-- <tool file="galaxy-local-tools/tools/canu/canu.xml" labels="test"/> -->
     </section>
 </toolbox>


### PR DESCRIPTION
The local canu wrapper is just an old version of canu with hardcoded GALAXY_MEMORY_MB.  There would be no reason for anyone to run it instead of regular canu.

Local tools on production could still be useful in future.  The 'test' label means the tool is hidden from anybody who is not an admin.