### PR TITLE
12 cores for rna_star

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -908,7 +908,7 @@ tools:
         accept:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/.*:
-    cores: 8
+    cores: 12
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
This might be enough?  Another possibility would be to have some jobs go to low high-mem allocation such as 15 or 30 cores on high-mem but the current limits are set around the idea of all high-mem jobs being large.