### PR TITLE
bionano docker_volumes

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -53,8 +53,8 @@ tools:
     cores: 16
     params:
       docker_enabled: true
-      docker_volumes: '$defaults'
-      docker_memory: '{mem}'
+      docker_volumes: '$defaults,/cvmfs/data.galaxyproject.org:ro,/mnt/user-data:ro,/mnt/user-data-2:ro,/mnt/user-data-3:ro'
+      docker_memory: '{mem}G'
       docker_sudo: false
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/.*:
     cores: 9


### PR DESCRIPTION
I think '$defaults' will only cover the current default data directory (user-data-4) 

I haven't included user-data-4 in docker_volumes here because it might break it.  TODO: test consequences of listing a directory twice on dev