### PR TITLE
specify cvmfs bind

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -217,13 +217,13 @@ tools:
     cores: 2
     params:
       singularity_enabled: True
-      singularity_volumes: '$defaults'
+      singularity_volumes: '$defaults,/cvmfs:ro'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
   pbmm2:
     cores: 2
     params:
       singularity_enabled: True
-      singularity_volumes: '$defaults'
+      singularity_volumes: '$defaults,/cvmfs:ro'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
 
 users:


### PR DESCRIPTION
I think I need to bind `/cvmfs` for these tools because the tool uses reference genomes from the `all_fasta` table. Not sure if this is the right way.

Right now I'm getting a "file not found" error which suggests to me that the path isn't mounted when the container runs.
