### PR TITLE
aarnet nfs playbooks

### DIFF
--- a/aarnet-job-nfs_playbook.yml
+++ b/aarnet-job-nfs_playbook.yml
@@ -26,7 +26,6 @@
           path: "{{ galaxy_job_dir }}"
           owner: galaxy
           group: galaxy
-          recurse: yes
       - name: Reload exportfs
         command: exportfs -ra
         become: yes

--- a/aarnet-misc-nfs_playbook.yml
+++ b/aarnet-misc-nfs_playbook.yml
@@ -7,14 +7,14 @@
       - group_vars/nfs_servers.yml
       - host_vars/aarnet-misc-nfs.usegalaxy.org.au.yml
   pre_tasks:
-      - name: Create galaxy_nfs_app_dir directory
+      - name: Create nfs directories
         file:
-          path: "{{ galaxy_nfs_app_dir }}"
+          path: "{{ item }}"
           state: directory
-      - name: Create galaxy_nfs_tools_dir dir
-        file:
-          path: "{{ galaxy_nfs_tools_dir }}"
-          state: directory
+        with_items:
+          - "{{ galaxy_nfs_app_dir }}"
+          - "{{ galaxy_nfs_tools_dir }}"
+          - "{{ galaxy_nfs_custom_indices_dir }}"
       - name: Attach volume to instance
         include_role:
           name: attached-volumes
@@ -27,16 +27,13 @@
   post_tasks:
       - name: Chown shared dirs to Galaxy user
         file:
-          path: "{{ galaxy_nfs_app_dir }}"
+          path: "{{ item }}"
           owner: galaxy
           group: galaxy
-          recurse: yes
-      - name: Chown tools dir to Galaxy user
-        file:
-          path: "{{ galaxy_nfs_tools_dir }}"
-          owner: galaxy
-          group: galaxy
-          recurse: yes
+        with_items:
+          - "{{ galaxy_nfs_app_dir }}"
+          - "{{ galaxy_nfs_tools_dir }}"
+          - "{{ galaxy_nfs_custom_indices_dir }}"
       - name: Reload exportfs
         command: exportfs -ra
         become: yes

--- a/aarnet-user-nfs_playbook.yml
+++ b/aarnet-user-nfs_playbook.yml
@@ -6,18 +6,15 @@
       - group_vars/VAULT
       - group_vars/nfs_servers.yml
       - host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
+      - secret_group_vars/stats_server_vault
   pre_tasks:
-      - name: Create galaxy_aarnet_user_data_dir directory
-        file:
-          path: /mnt/aarnet/user-data-3
-          state: directory
-      - name: Create galaxy_perth_user_data_dir directory
-        file:
-          path: /mnt/perth
-          state: directory
       - name: Attach volumes to instance
         include_role:
           name: attached-volumes
+      - name: Create galaxy_nfs_user_data_dir directory
+        file:
+          path: "{{ galaxy_nfs_user_data_dir }}"
+          state: directory
   roles:
       - common
       - insspb.hostname
@@ -27,10 +24,9 @@
   post_tasks:
       - name: Chown shared dirs to Galaxy user
         file:
-          path: "{{ galaxy_aarnet_user_data_dir }}"
+          path: "{{ galaxy_nfs_user_data_dir }}"
           owner: galaxy
           group: galaxy
-          recurse: yes
       - name: Reload exportfs
         command: exportfs -ra
         become: yes

--- a/host_vars/aarnet-job-nfs.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-job-nfs.usegalaxy.org.au.yml
@@ -1,9 +1,10 @@
 attached_volumes:
-  - device: /dev/vdb
+  - device: /dev/vdZZZZZZ  # TODO: Find out
     path: /mnt
     fstype: ext4
+    partition: 1
 
 galaxy_job_dir: /mnt/tmp
 
 nfs_exports:
-  - "{{ galaxy_job_dir }} 192.168.199.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ galaxy_job_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/host_vars/aarnet-misc-nfs.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-misc-nfs.usegalaxy.org.au.yml
@@ -1,14 +1,22 @@
 attached_volumes:
-  - device: /dev/vde
+  - device: /dev/vdXYZ  # TODO: Find out
     path: /mnt/tools-indices
     fstype: ext4
-  - device: /dev/vdc
+    partition: 1
+  - device: /dev/vdXYZ  # TODO: Find out
+    path: /mnt/custom-indices
+    fstype: ext4
+    partition: 1
+  - device: /dev/vdXYZ  # TODO: Find out
     path: /mnt/ghost-galaxy-app
     fstype: ext4
+    partition: 1
 
 galaxy_nfs_app_dir: /mnt/ghost-galaxy-app
 galaxy_nfs_tools_dir: /mnt/tools-indices
+galaxy_nfs_custom_indices_dir: /mnt/custom-indices
 
 nfs_exports:
-  - "{{ galaxy_nfs_app_dir }} 192.168.199.0/24(rw,async,no_root_squash,no_subtree_check)"
-  - "{{ galaxy_nfs_tools_dir }} 192.168.199.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ galaxy_nfs_app_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ galaxy_nfs_tools_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ galaxy_nfs_custom_indices_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
@@ -1,16 +1,10 @@
 attached_volumes:
-  - device: /dev/vdb
-    path: /mnt/perth
+  - device: /dev/vdXYZ  # TODO: Find out
+    path: /mnt  # this will contain user-data, user-data-2/3/4 from perth.  
     fstype: ext4
-  - device: /dev/vdc  
-    path: /mnt/aarnet/user-data-3
-    fstype: ext4
+    partition: 1
 
-galaxy_perth_user_data_dir: /mnt/perth/user-data
-galaxy_perth_user_data_2_dir: /mnt/perth/user-data-2
-galaxy_aarnet_user_data_dir: /mnt/aarnet/user-data-3
+galaxy_nfs_user_data_dir: /mnt
 
 nfs_exports:
-  - "{{ galaxy_perth_user_data_dir }} 192.168.199.0/24(rw,async,no_root_squash,no_subtree_check)"
-  - "{{ galaxy_perth_user_data_2_dir }} 192.168.199.0/24(rw,async,no_root_squash,no_subtree_check)"
-  - "{{ galaxy_aarnet_user_data_dir }} 192.168.199.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ galaxy_nfs_user_data_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"


### PR DESCRIPTION
Some updates to aarnet nfs playbooks.  For user-nfs there will be one giant volume instead of the smaller ones.  When the existing folders are copied over will they remain separate subfolders: user-data, user-data-2 etc?  I've chosen `/mnt` as the path for that volume on the machine but could change it to `mnt/data` to allow for future volumes at subdirectories of /mnt.

I've also added a 200G volume to the pulumi for misc-nfs.  Will check with aarnet tomorrow whether this will be OK.