### PR TITLE
replace dev-w1, ip stays the same

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -345,14 +345,14 @@ users:
 
 destinations:
   slurm:
-    cores: 4
-    mem: 15.625
+    cores: 16
+    mem: 62.5
     scheduling:
       accept:
         - slurm
   pulsar_destination:
-    cores: 4
-    mem: 7.77
+    cores: 2
+    mem: 7.76
     scheduling:
       accept:
         - dev-pulsar

--- a/group_vars/dev_pulsar_slurm.yml
+++ b/group_vars/dev_pulsar_slurm.yml
@@ -5,8 +5,8 @@ auth_key_user: ubuntu
 slurm_nodes:
     - name: dev-pulsar
       NodeAddr: "{{ hostvars['dev-pulsar']['ansible_ssh_host'] }}"
-      CPUs: 4
-      RealMemory: 7780
+      CPUs: 2
+      RealMemory: 7950
       State: UNKNOWN
 
 slurm_partitions:

--- a/group_vars/dev_slurm.yml
+++ b/group_vars/dev_slurm.yml
@@ -11,8 +11,8 @@ add_galaxy_user: true #Adds the galaxy user to all machines that have slurm on t
 slurm_nodes:
     - name: dev-w1
       NodeAddr: "{{ hostvars['dev-w1']['ansible_ssh_host'] }}"
-      CPUs: 4
-      RealMemory: 16000
+      CPUs: 16
+      RealMemory: 64000
       State: UNKNOWN
     - name: dev-queue
       NodeAddr: "{{ hostvars['dev-queue']['ansible_ssh_host'] }}"

--- a/terraform/dev/dev-initial.tf
+++ b/terraform/dev/dev-initial.tf
@@ -32,7 +32,7 @@ resource "openstack_compute_instance_v2" "dev-queue" {
 resource "openstack_compute_instance_v2" "dev-w1" {
   name            = "dev-w1"
   image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
-  flavor_name     = "uom.general.4c16g"
+  flavor_name     = "uom.general.16c64g"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "default"]
   availability_zone = "melbourne-qh2-uom"


### PR DESCRIPTION
dev-w1 is now 16cores/62.5GB.  I'll merge this straight away so that updates can be made to vortex_config for cactus.