### PR TITLE
Alphafold limits: env vars for docker jobs are set in docker_run_extra_arguments

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -180,11 +180,8 @@ tools:
           docker_memory: 107G
           docker_sudo: false
           require_container: true
-          docker_run_extra_arguments: "--gpus all"
+          docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=30 --env ALPHAFOLD_AA_LENGTH_MAX=2000"
           docker_set_user: '1000'
-        env:
-          ALPHAFOLD_AA_LENGTH_MIN: 50
-          ALPHAFOLD_AA_LENGTH_MAX: 100   
   toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1:
     cores: 2
     params:


### PR DESCRIPTION
Using an "env:" section in tpv will work as long as it's not docker_enabled.  Using the "env:" section in job_conf.yml does not work under any circumstances as far as I can tell.  For docker jobs, each variable can be appended to `docker_run_extra_arguments` i.e.
`docker_run_extra_arguments: "--env X=6 --env TEMP=warm"`