### PR TITLE
Cactus on toolshed

### DIFF
--- a/files/galaxy/config/local_tool_conf_dev.xml
+++ b/files/galaxy/config/local_tool_conf_dev.xml
@@ -6,8 +6,6 @@
         <tool file="/mnt/galaxy/local_tools/smudgeplot.xml" />
         <tool file="/mnt/galaxy/local_tools/wtdbg2/wtdbg2.xml" />
         <tool file="/mnt/galaxy/local_tools/ipa/ipa.xml" />
-        <tool file="/mnt/galaxy/local_tools/glt_tom/tools/cactus/cactus_cactus.xml" />
-        <tool file="/mnt/galaxy/local_tools/glt_tom/tools/cactus/cactus_export.xml" />
         <tool file="/mnt/galaxy/local_tools/glt_tom/tools/pbgcpp/pbgcpp.xml" />
         <tool file="/mnt/galaxy/local_tools/glt_tom/tools/pbmm2/pbmm2.xml" />
         <tool file="/mnt/galaxy/local_tools/glt_tom/tools/purge_haplotigs/purge_haplotigs_cov.xml"/>

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -222,14 +222,14 @@ tools:
       singularity_enabled: True
       singularity_volumes: '$defaults'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
-  cactus_cactus:
+  https://toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/.*:
     cores: 16
     mem: 32
     params:
       singularity_enabled: True
       singularity_volumes: '$defaults,/cvmfs:ro'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
-  cactus_export:
+  https://toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_export/.*:
     cores: 1
     params:
       singularity_enabled: True

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -222,14 +222,14 @@ tools:
       singularity_enabled: True
       singularity_volumes: '$defaults'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
-  https://toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/.*:
+  https://toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
     cores: 16
     mem: 32
     params:
       singularity_enabled: True
       singularity_volumes: '$defaults,/cvmfs:ro'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
-  https://toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_export/.*:
+  https://toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_export/cactus_export/.*:
     cores: 1
     params:
       singularity_enabled: True


### PR DESCRIPTION
Removing install from /mnt/galaxy/local_tools because cactus_cactus and cactus_export are on the toolshed now (https://toolshed.g2.bx.psu.edu/view/galaxy-australia/suite_cactus/5f4d0fc906ad).

I also updated the rules in vortex_config but maybe we don't need those any more?