### PR TITLE
Added a separate gpu destination with separate limits

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
@@ -114,3 +114,10 @@ destinations:
       require:
         - pulsar
         - pulsar-azure
+  pulsar-azure-gpu:
+    cores: 6
+    mem: 106
+    scheduling:
+      require:
+        - pulsar
+        - pulsar-azure-gpu

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -1272,7 +1272,7 @@ tools:
     scheduling:
       require:
         - pulsar
-        - pulsar-azure
+        - pulsar-azure-gpu
     rules:
       - match: |
           not user or 'Alphafold' not in [role.name for role in user.all_roles() if not role.deleted]

--- a/templates/galaxy/config/pawsey_job_conf.yml.j2
+++ b/templates/galaxy/config/pawsey_job_conf.yml.j2
@@ -300,6 +300,16 @@ execution:
       rewrite_parameters: "true"
       persistence_directory: /mnt/pulsar/files/persisted_data
       submit_native_specification: "--nodes=1 --ntasks=6 --ntasks-per-node=6 --mem=110000"
+    pulsar-azure-gpu:
+      runner: pulsar_azure_runner
+      jobs_directory: /mnt/pulsar/files/staging
+      transport: curl
+      remote_metadata: "false"
+      default_file_action: remote_transfer
+      dependency_resolution: remote
+      rewrite_parameters: "true"
+      persistence_directory: /mnt/pulsar/files/persisted_data
+      submit_native_specification: "--nodes=1 --ntasks=6 --ntasks-per-node=6 --mem=110000"
 tools:
 - id: interactive_tool_ethercalc
   environment: interactive_pulsar
@@ -385,5 +395,12 @@ limits:
   value: 4
 - type: user_total_concurrent_jobs
   id: pulsar-azure
+  value: 1
+
+- type: destination_total_concurrent_jobs
+  id: pulsar-azure-gpu
+  value: 4
+- type: user_total_concurrent_jobs
+  id: pulsar-azure-gpu
   value: 1
 


### PR DESCRIPTION
I thought it might be a better idea in terms of limits to have a separate destination for gpu work than normal work on azure. That way we can control the limits in a more fine grained manner.