### PR TITLE
update tpv resources for openbabel_svg_depiction

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -613,6 +613,13 @@ tools:
       scheduling:
         accept:
         - high-mem
+  toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_svg_depiction/openbabel_svg_depiction/.*:
+    scheduling:
+      accept:
+      - pulsar
+    rules:
+    - match: input_size >= 5e-06  # over ~5KB
+      cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/racon/racon/.*:
     cores: 1
     scheduling:


### PR DESCRIPTION
Gareth has brought up openbabel_svg_depiction which has generally pretty small inputs.  So far all of the jobs have run in a few seconds with inputs < 1KB but the current job (350KB) has been running for 12+ hours.  I can't find any info from other galaxy configurations about what resources this needs.