### PR TITLE
Temporarily comment out toolbox-filters from pawsey playbook

### DIFF
--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -113,8 +113,8 @@ host_galaxy_config_templates:
     dest: "{{ galaxy_config_dir }}/job_conf.yml"
   - src: "{{ galaxy_dynamic_job_rules_src_dir }}/total_perspective_vortex/default_tool.yml.j2"
     dest: "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/default_tool.yml"
-  - src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2"
-    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
+  # - src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2"  # TODO: uncomment to enable filters
+  #   dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
 
 host_galaxy_config:  # renamed from __galaxy_config
   uwsgi:
@@ -149,7 +149,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     watch_job_rules: true  # important for total perspective vortex
     enable_mulled_containers: true
     enable_beta_containers_interface: true
-    tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_alphafold
+    # tool_filters: ga_filters:hide_test_tools,ga_filters:restrict_alphafold  # TODO: uncomment to enable filters
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs


### PR DESCRIPTION
This can be reverted after the first run of the playbook