### PR TITLE
user-data-test on separate volume

### DIFF
--- a/aarnet-user-nfs_playbook.yml
+++ b/aarnet-user-nfs_playbook.yml
@@ -16,10 +16,10 @@
           path: "{{ item }}"
           state: directory
         with_items:
-          - "{{ galaxy_nfs_user_data_dir }}"
-          - "{{ galaxy_nfs_user_data_2_dir }}"
-          - "{{ galaxy_nfs_user_data_3_dir }}"
-          - "{{ galaxy_nfs_user_data_4_dir }}"
+          # - "{{ galaxy_nfs_user_data_dir }}"
+          # - "{{ galaxy_nfs_user_data_2_dir }}"
+          # - "{{ galaxy_nfs_user_data_3_dir }}"
+          # - "{{ galaxy_nfs_user_data_4_dir }}"
           - "{{ galaxy_nfs_user_data_test_dir }}"
 
   roles:
@@ -35,10 +35,10 @@
           owner: galaxy
           group: galaxy
         with_items:
-          - "{{ galaxy_nfs_user_data_dir }}"
-          - "{{ galaxy_nfs_user_data_2_dir }}"
-          - "{{ galaxy_nfs_user_data_3_dir }}"
-          - "{{ galaxy_nfs_user_data_4_dir }}"
+          # - "{{ galaxy_nfs_user_data_dir }}"
+          # - "{{ galaxy_nfs_user_data_2_dir }}"
+          # - "{{ galaxy_nfs_user_data_3_dir }}"
+          # - "{{ galaxy_nfs_user_data_4_dir }}"
           - "{{ galaxy_nfs_user_data_test_dir }}"
       - name: Reload exportfs
         command: exportfs -ra

--- a/group_vars/aarnet_workers.yml
+++ b/group_vars/aarnet_workers.yml
@@ -46,14 +46,14 @@ shared_mounts:  # TODO: /mnt/custom-indices from aarnet-misc-nfs
       src: "{{ hostvars['aarnet-job-nfs']['internal_ip'] }}:/mnt/tmp"
       fstype: nfs
       state: mounted
-    - path: /mnt/files
-      src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
-      fstype: nfs
-      state: mounted
-    - path: /mnt/files2
-      src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
-      fstype: nfs
-      state: mounted
+    # - path: /mnt/files
+    #   src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
+    #   fstype: nfs
+    #   state: mounted
+    # - path: /mnt/files2
+    #   src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
+    #   fstype: nfs
+    #   state: mounted
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/group_vars/aarnet_workers.yml
+++ b/group_vars/aarnet_workers.yml
@@ -23,7 +23,7 @@ shared_mounts:  # TODO: /mnt/custom-indices from aarnet-misc-nfs
       fstype: nfs
       state: mounted
     - path: /mnt/user-data-test  # TODO: Unmount and remove this after testing
-      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data-test"
+      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/user-data-test"
       fstype: nfs
       state: mounted
     # - path: /mnt/user-data

--- a/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
@@ -1,6 +1,10 @@
 attached_volumes:
-  - device: /dev/vdb
-    path: /mnt  # this will contain user-data, user-data-2/3/4 from perth.  
+  # - device: /dev/vdb
+  #   path: /mnt  # this will contain user-data, user-data-2/3/4 from perth.  
+  #   fstype: ext4
+  #   partition: 1
+  - device: /dev/vdc
+    path: /user-data-test  # this will contain user-data, user-data-2/3/4 from perth.  
     fstype: ext4
     partition: 1
 
@@ -8,7 +12,7 @@ attached_volumes:
 # galaxy_nfs_user_data_2_dir: /mnt/user-data-2
 # galaxy_nfs_user_data_3_dir: /mnt/user-data-3
 # galaxy_nfs_user_data_4_dir: /mnt/user-data-4
-galaxy_nfs_user_data_test_dir: /mnt/user-data-test
+galaxy_nfs_user_data_test_dir: /user-data-test
 
 nfs_exports:
   # - "{{ galaxy_nfs_user_data_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
@@ -4,15 +4,15 @@ attached_volumes:
     fstype: ext4
     partition: 1
 
-galaxy_nfs_user_data_dir: /mnt/user-data
-galaxy_nfs_user_data_2_dir: /mnt/user-data-2
-galaxy_nfs_user_data_3_dir: /mnt/user-data-3
-galaxy_nfs_user_data_4_dir: /mnt/user-data-4
+# galaxy_nfs_user_data_dir: /mnt/user-data
+# galaxy_nfs_user_data_2_dir: /mnt/user-data-2
+# galaxy_nfs_user_data_3_dir: /mnt/user-data-3
+# galaxy_nfs_user_data_4_dir: /mnt/user-data-4
 galaxy_nfs_user_data_test_dir: /mnt/user-data-test
 
 nfs_exports:
-  - "{{ galaxy_nfs_user_data_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-  - "{{ galaxy_nfs_user_data_2_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-  - "{{ galaxy_nfs_user_data_3_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-  - "{{ galaxy_nfs_user_data_4_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  # - "{{ galaxy_nfs_user_data_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  # - "{{ galaxy_nfs_user_data_2_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  # - "{{ galaxy_nfs_user_data_3_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  # - "{{ galaxy_nfs_user_data_4_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
   - "{{ galaxy_nfs_user_data_test_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -74,14 +74,14 @@ shared_mounts:  # TODO: /mnt/custom-indices from aarnet-misc-nfs
       src: "{{ hostvars['aarnet-job-nfs']['internal_ip'] }}:/mnt/tmp"
       fstype: nfs
       state: mounted
-    - path: /mnt/files
-      src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
-      fstype: nfs
-      state: mounted
-    - path: /mnt/files2
-      src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
-      fstype: nfs
-      state: mounted
+    # - path: /mnt/files
+    #   src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
+    #   fstype: nfs
+    #   state: mounted
+    # - path: /mnt/files2
+    #   src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
+    #   fstype: nfs
+    #   state: mounted
 
 galaxy_db_user_password: "{{ vault_aarnet_db_user_password }}"
 

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -51,7 +51,7 @@ shared_mounts:  # TODO: /mnt/custom-indices from aarnet-misc-nfs
       fstype: nfs
       state: mounted
     - path: /mnt/user-data-test  # TODO: Unmount and remove this after testing
-      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data-test"
+      src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/user-data-test"
       fstype: nfs
       state: mounted
     # - path: /mnt/user-data


### PR DESCRIPTION
This isn't ready until the `device` for /user-data-test is double checked