### PR TITLE
sudo permissions for tool devs on dev

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -2,7 +2,7 @@
   become: true
   vars_files:
       - group_vars/all.yml
-      - group_vars/dev.yml
+      - group_vars/dev.yml  # machine_users overridden in this file
       - group_vars/VAULT
       - group_vars/galaxyservers.yml
       - group_vars/dev_slurm.yml

--- a/group_vars/dev.yml
+++ b/group_vars/dev.yml
@@ -14,3 +14,86 @@ telegraf_agent_output:
     - database = "dev"
     - username = "node"
     - password = "{{ vault_influx_node_password }}"
+
+# Override permission level for tool devs on dev (quick fix)
+machine_users:
+    - name: simon
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/simon.pub
+      email: "{{ simon_email }}"
+    - name: nick
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/nick.pub
+      email: "{{ nick_email }}"
+    - name: cat
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/catherine.pub
+      email: "{{ cat_email }}"
+    - name: igor
+      roles:
+        - tiaas_admin
+        - galaxy_admin
+      key: files/keys/igor.pub
+      email: "{{ igor_email }}"
+    - name: mike
+      roles:
+        - galaxy_admin
+        - sudo
+      key: files/keys/mike.pub
+      email: "{{ mike_email }}"
+    - name: gareth
+      roles:
+        - galaxy_admin
+      key: files/keys/gareth.pub
+      email: "{{ gareth_email }}"
+    - name: jenkins_bot
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/jenkins_bot.pub
+      email: "{{ jenkins_bot_email }}" # this is not a real email address and will cause issues if validation is required
+    - name: nuwan
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/nuwan.pub
+      galaxy_admin: true
+      email: "{{ nuwan_email }}"
+    - name: justin
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/justin.pub
+      email: "{{ justin_email }}"
+    - name: grace
+      roles:
+        - sudo
+      key: files/keys/grace.pub
+      email: "{{ grace_email }}"
+    - name: cameron
+      roles:
+        - sudo
+      key: files/keys/cameron.pub
+      email: "{{ cameron_email }}"
+    - name: anna
+      roles:
+        - tiaas_admin
+      key: files/keys/anna.pub
+      email: "{{ anna_email }}"
+    - name: tom
+      roles:
+        - sudo
+      key: files/keys/tom.pub
+      email: "{{ tom_email }}"
+    - name: gavin
+      roles:
+        - sudo
+        - galaxy_admin
+      key: files/keys/gavin.pub
+      email: "{{ gavin_email }}"


### PR DESCRIPTION
this is a hacky solution to something will need more thought when there is time.  Tool devs need sudo on dev, so this overrides `machine_users` in dev.yml.