### PR TITLE
try to force protk tools to use their docker container

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -246,10 +246,7 @@ tools:
     params:
       singularity_enabled: True
       singularity_run_extra_arguments: '--writable-tmpfs'
-      singularity_volumes: '$defaults'
-      singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
-
-
+      dependency_resolution: 'none'
 
 users:
   default:

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -241,6 +241,15 @@ tools:
       singularity_enabled: True
       singularity_volumes: '$defaults,/cvmfs:ro'
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
+  https://toolshed.g2.bx.psu.edu/repos/iracooke/protk_proteogenomics/.*:
+    cores: 1
+    params:
+      singularity_enabled: True
+      singularity_run_extra_arguments: '--writable-tmpfs'
+      singularity_volumes: '$defaults'
+      singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
+
+
 
 users:
   default:


### PR DESCRIPTION
Hi @cat-bro ! I'm not sure if this will work.

These protk tools have multiple entries in the `requirements` field, e.g.

```xml
    <requirements>
        <container type="docker">iracooke/protk-1.4.3</container>
        <requirement type="package" version="1.4.3">protk</requirement>
   </requirements>
```
**Only** the docker container works - the conda package and the biocontainer are broken.

I want to see if setting `use_singularity` in the vortex config will pull the container off docker hub or biocontainers... of if there's another way to do this without changing the wrapper

Also, one of the tools writes to its own installation directory in the container, hence the need for `'--writable-tmpfs'`

cc @mthang 
