### PR TITLE
take pulsar-high-mem1 offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
@@ -72,6 +72,7 @@ destinations:
       accept:
       - pulsar-qld-high-mem1
       require:
+      - offline
       - pulsar
       - high-mem
   pulsar-qld-high-mem2:

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
@@ -44,6 +44,7 @@ destinations:
       accept:
       - pulsar-high-mem1
       require:
+      - offline
       - pulsar
       - high-mem
   pulsar-high-mem2:
@@ -72,7 +73,6 @@ destinations:
       accept:
       - pulsar-qld-high-mem1
       require:
-      - offline
       - pulsar
       - high-mem
   pulsar-qld-high-mem2:


### PR DESCRIPTION
pulsar-high-mem1 is offline in the tpv because the disk became read-only at some point today.  The disk is rw now but there has been a high rate of errors over the past few weeks compared to the qld high mem pulsars. I can look at the syslog tomorrow.