### PR TITLE
add jq to common packages

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -115,6 +115,7 @@ common_packages:
     - tree
     - python3-passlib
     - xfsprogs
+    - jq
 
 #Set pip to be pip3 by default - see roles/geerlingguy.pip/defaults/main.yml
 pip_package: python3-pip


### PR DESCRIPTION
The machines that need this are the galaxy head nodes because `gxadmin report job-info X` uses jq to unpack json fields