### PR TITLE
Give bwa-mem2 one eighth of a high-mem, switch pulsar-high-mem1 to online

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/destinations.yml
@@ -44,7 +44,6 @@ destinations:
       accept:
       - pulsar-high-mem1
       require:
-      - offline
       - pulsar
       - high-mem
   pulsar-high-mem2:

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/tools.yml
@@ -1071,7 +1071,19 @@ tools:
         accept:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/.*:
-    inherits: toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/.*
+    cores: 2
+    scheduling:
+      accept:
+      - pulsar
+    rules:
+    - match: 0.25 <= input_size < 2
+      cores: 8
+    - match: input_size >= 2
+      cores: 30
+      mem: 480.5
+      scheduling:
+        accept:
+        - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/.*:
     cores: 2
     scheduling:

--- a/templates/galaxy/config/pawsey_job_conf.yml.j2
+++ b/templates/galaxy/config/pawsey_job_conf.yml.j2
@@ -373,15 +373,15 @@ limits:
 
 - type: destination_total_concurrent_jobs
   id: pulsar-qld-high-mem0
-  value: 4
+  value: 6
 
 - type: destination_total_concurrent_jobs
   id: pulsar-qld-high-mem1
-  value: 4
+  value: 6
 
 - type: destination_total_concurrent_jobs
   id: pulsar-qld-high-mem2
-  value: 4
+  value: 6
 
 - type: destination_total_concurrent_jobs
   id: pulsar-QLD


### PR DESCRIPTION
bwa-mem2 needs more memory than would be allowed with a 16 core/ 62Gb.  It doesn't need 1Tb, more like 100GB

Also increase the number of queued jobs allowed at qld high mem pulsars from 4 to 6.