### PR TITLE
Production singularity

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/default_tool.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/default_tool.yml
@@ -9,6 +9,7 @@ tools:
     params:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
+      docker_memory: '{mem}G'
     scheduling:
       reject:
         - offline
@@ -16,20 +17,3 @@ tools:
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)
       final_destinations
-    #   import requests
-    #   params = {
-    #     'pretty': 'true',
-    #     'db': 'pulsar-test',
-    #     'q': 'SELECT last("percent_allocated") from "sinfo" group by "host"'
-    #   }
-    #   try:
-    #     response = requests.get('http://stats.genome.edu.au:8086/query', params=params)
-    #     data = response.json()
-    #     cpu_by_destination = {s['tags']['host']:s['values'][0][1] for s in data.get('results')[0].get('series', [])}
-    #     # sort by destination preference, and then by cpu usage
-    #     candidate_destinations.sort(key=lambda d: (-1 * d.score(resource), cpu_by_destination.get(d.id)))
-    #     final_destinations = candidate_destinations
-    #   except Exception:
-    #     log.exception("An error occurred while querying influxdb. Using a weighted random candidate destination")
-    #     final_destinations = helpers.weighted_random_sampling(candidate_destinations)
-    #   final_destinations

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/default_tool.yml.j2
@@ -9,6 +9,7 @@ tools:
     params:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
+      docker_memory: '{mem}G'
     scheduling:
       reject:
         - offline

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
@@ -9,6 +9,7 @@ tools:
     params:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
+      docker_memory: '{mem}G'
     scheduling:
       reject:
         - offline
@@ -23,9 +24,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
     params:
       docker_enabled: true
-      docker_volumes: '$defaults'
-      docker_memory: '{mem}'
-      docker_sudo: false
 
 destinations:
   slurm:

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -201,6 +201,20 @@ group_galaxy_config:
         exec: "{{ galaxy_conda_prefix }}/bin/{{ galaxy_conda_exec|d('conda') }}"
         versionless: true
 
+    container_resolvers:
+      - type: explicit
+      - type: explicit_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+      - type: cached_mulled_singularity
+        # cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+        cache_directory: /cvmfs/singularity.galaxyproject.org/all  # from usa usegalaxy-playbook
+        cache_directory_cacher_type: dir_mtime
+      - type: mulled_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+      - type: build_mulled_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
+        auto_install: false
+
     # Taken from usegalaxy.org
     tool_name_boost: 0.1
     tool_section_boost: 1

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -93,20 +93,6 @@ host_galaxy_config:  # renamed from __galaxy_config
     sentry_dsn: "{{ vault_sentry_dsn_dev }}"
     tool_filters: ga_filters:hide_test_tools
 
-    container_resolvers:
-      - type: explicit
-      - type: explicit_singularity
-        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
-      - type: cached_mulled_singularity
-        # cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
-        cache_directory: /cvmfs/singularity.galaxyproject.org/all  # from usa usegalaxy-playbook
-        cache_directory_cacher_type: dir_mtime
-      - type: mulled_singularity
-        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
-      - type: build_mulled_singularity
-        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
-        auto_install: false
-
 galaxy_handler_count: 2   ############# europe uses 5, this could be host specific
 
 # NFS stuff

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -155,23 +155,17 @@ docker_daemon_options:
   data-root: /mnt/docker-data
 
 # Singularity and docker volumes
-slurm_singularity_volumes_list: # for production this needs /mnt/user-data 1,2,3,4 + /mnt/custom-indices, all ro
+slurm_singularity_volumes_list:
+  - '$job_directory:rw'
   - '$galaxy_root:ro'
   - '$tool_directory:ro'
-  - '$job_directory:ro'
-  - '$job_directory/outputs:rw'
-  - '$working_directory:rw'
-  - '$default_file_path:rw'
+  - '$default_file_path:ro'
   - '/cvmfs/data.galaxyproject.org:ro'
-  - '/tmp:rw'
 
 pulsar_singularity_volumes_list:
-  - '$job_directory:ro'
+  - '$job_directory:rw'
   - '$tool_directory:ro'
-  - '$job_directory/outputs:rw'
-  - '$working_directory:rw'
   - '/cvmfs/data.galaxyproject.org:ro'
-  - '/tmp:rw'
 
 slurm_docker_volumes_list: "{{ slurm_singularity_volumes_list }}"
 pulsar_docker_volumes_list: "{{ pulsar_singularity_volumes_list }}"

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -301,31 +301,24 @@ docker_daemon_options:
 
 # Singularity and docker volumes
 slurm_singularity_volumes_list: # for production this needs /mnt/user-data 1,2,3,4 + /mnt/custom-indices, all ro
-  - '$galaxy_root:ro'
-  - '$tool_directory:ro'
-  - '$job_directory:ro'
-  - '$job_directory/outputs:rw'
-  - '$working_directory:rw'
-  - '$default_file_path:rw'
-  - '/cvmfs/data.galaxyproject.org:ro'
-  - '/tmp:rw'
+  - $job_directory:rw
+  - $galaxy_root:ro
+  - $tool_directory:ro
   - /mnt/user-data-4:ro
   - /mnt/user-data-3:ro
   - /mnt/user-data-2:ro
-  - /mnt/user-data:rw
+  - /mnt/user-data:ro
   - /mnt/galaxy/files:ro
   - /mnt/files:ro
   - /mnt/files2:ro
   - /mnt/custom-indices:ro
+  - /cvmfs/data.galaxyproject.org:ro
 
 pulsar_singularity_volumes_list:
-  - '$job_directory:ro'
-  - '$tool_directory:ro'
-  - '$job_directory/outputs:rw'
-  - '$working_directory:rw'
-  - '/cvmfs/data.galaxyproject.org:ro'
-  - '/tmp:rw'
+  - $job_directory:rw
+  - $tool_directory:ro
   - /mnt/custom-indices:ro
+  - /cvmfs/data.galaxyproject.org:ro
 
 slurm_docker_volumes_list: "{{ slurm_singularity_volumes_list }}"
 pulsar_docker_volumes_list: "{{ pulsar_singularity_volumes_list }}"

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -298,3 +298,42 @@ docker_users:
   - "{{ galaxy_user.name }}"
 docker_daemon_options:
   data-root: /mnt/docker-data
+
+# Singularity and docker volumes
+slurm_singularity_volumes_list: # for production this needs /mnt/user-data 1,2,3,4 + /mnt/custom-indices, all ro
+  - '$galaxy_root:ro'
+  - '$tool_directory:ro'
+  - '$job_directory:ro'
+  - '$job_directory/outputs:rw'
+  - '$working_directory:rw'
+  - '$default_file_path:rw'
+  - '/cvmfs/data.galaxyproject.org:ro'
+  - '/tmp:rw'
+  - /mnt/user-data-4:ro
+  - /mnt/user-data-3:ro
+  - /mnt/user-data-2:ro
+  - /mnt/user-data:rw
+  - /mnt/galaxy/files:ro
+  - /mnt/files:ro
+  - /mnt/files2:ro
+  - /mnt/custom-indices:ro
+
+pulsar_singularity_volumes_list:
+  - '$job_directory:ro'
+  - '$tool_directory:ro'
+  - '$job_directory/outputs:rw'
+  - '$working_directory:rw'
+  - '/cvmfs/data.galaxyproject.org:ro'
+  - '/tmp:rw'
+  - /mnt/custom-indices:ro
+
+slurm_docker_volumes_list: "{{ slurm_singularity_volumes_list }}"
+pulsar_docker_volumes_list: "{{ pulsar_singularity_volumes_list }}"
+
+# comma separated strings for the job conf
+slurm_singularity_volumes: "{{ slurm_singularity_volumes_list | join(',') }}"
+pulsar_singularity_volumes: "{{ pulsar_singularity_volumes_list | join(',') }}"
+slurm_docker_volumes: "{{ slurm_docker_volumes_list | join(',') }}"
+pulsar_docker_volumes: "{{ pulsar_docker_volumes_list | join(',') }}"
+
+singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -114,18 +114,15 @@ docker_daemon_options:
 
 # Singularity and docker volumes
 slurm_singularity_volumes_list:
+  - '$job_directory:rw'
   - '$galaxy_root:ro'
   - '$tool_directory:ro'
-  - '$job_directory:ro'
-  - '$working_directory:rw'
-  - '$default_file_path:rw'
+  - '$default_file_path:ro'
   - '/cvmfs/data.galaxyproject.org:ro'
 
 pulsar_singularity_volumes_list:
-  - '$job_directory:ro'
+  - '$job_directory:rw'
   - '$tool_directory:ro'
-  - '$job_directory/outputs:rw'
-  - '$working_directory:rw'
   - '/cvmfs/data.galaxyproject.org:ro'
 
 slurm_docker_volumes_list: "{{ slurm_singularity_volumes_list }}"

--- a/templates/galaxy/config/pawsey_job_conf.yml.j2
+++ b/templates/galaxy/config/pawsey_job_conf.yml.j2
@@ -177,9 +177,21 @@ execution:
     slurm:
       runner: slurm
       nativeSpecification: --nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=124160 --partition=main
+      singularity_enabled: false
+      singularity_volumes: '{{ slurm_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ slurm_docker_volumes }}'
     slurm-training:
       runner: slurm
       nativeSpecification: --nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=62080 --partition=training
+      singularity_enabled: false
+      singularity_volumes: '{{ slurm_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ slurm_docker_volumes }}'
     pulsar-mel2:
       runner: pulsar_mel2_runner
       default_file_action: remote_transfer
@@ -190,6 +202,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=32116
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-paw:
       runner: pulsar-paw_runner
       default_file_action: remote_transfer
@@ -200,6 +229,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=32116
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-mel3:
       runner: pulsar-mel3_runner
       default_file_action: remote_transfer
@@ -210,6 +256,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=62080
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-high-mem1:
       runner: pulsar-high-mem1_runner
       default_file_action: remote_transfer
@@ -220,6 +283,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=126 --ntasks-per-node=126 --mem=3937380
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-high-mem2:
       runner: pulsar-high-mem2_runner
       default_file_action: remote_transfer
@@ -230,6 +310,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=126 --ntasks-per-node=126 --mem=1968631
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-high-mem0:
       runner: pulsar-qld-high-mem0_runner
       default_file_action: remote_transfer
@@ -240,6 +337,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=3937354
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-high-mem1:
       runner: pulsar-qld-high-mem1_runner
       default_file_action: remote_transfer
@@ -250,6 +364,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=3937354
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-high-mem2:
       runner: pulsar-qld-high-mem2_runner
       default_file_action: remote_transfer
@@ -260,6 +391,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=240 --ntasks-per-node=240 --mem=3937354
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-nci-training:
       runner: pulsar-nci-training_runner
       default_file_action: remote_transfer
@@ -270,6 +418,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=48195
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-blast:
       runner: pulsar-qld-blast_runner
       default_file_action: remote_transfer
@@ -280,6 +445,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=60 --ntasks-per-node=60 --mem=200000
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     pulsar-QLD:
       runner: pulsar-QLD_runner
       default_file_action: remote_transfer
@@ -290,6 +472,23 @@ execution:
       rewrite_parameters: true
       submit_native_specification: --nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=62000
       transport: curl
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/tmp/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/tmp/deps/singularity/tmp
     pulsar-azure:
       runner: pulsar_azure_runner
       jobs_directory: /mnt/pulsar/files/staging

--- a/templates/galaxy/config/staging_job_conf.yml.j2
+++ b/templates/galaxy/config/staging_job_conf.yml.j2
@@ -45,6 +45,12 @@ execution:
     slurm:
       runner: slurm
       nativeSpecification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760"
+      singularity_enabled: false
+      singularity_volumes: '{{ slurm_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ slurm_docker_volumes }}'
     pulsar:
       runner: pulsar_au_01
       jobs_directory: /mnt/pulsar/files/staging
@@ -55,6 +61,23 @@ execution:
       rewrite_parameters: 'true'
       persistence_directory: /mnt/pulsar/files/persisted_data
       submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2"
+      docker_enabled: false
+      docker_sudo: false
+      docker_volumes: '{{ pulsar_docker_volumes }}'
+      docker_run_user: '1000'
+      singularity_enabled: false
+      singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      singularity_default_container_id: '{{ singularity_default_container_id }}'
+      container_resolvers: 
+        - type: explicit_singularity
+        - type: cached_mulled_singularity  # if not using cvmfs, omit cache directory
+          cache_directory: /cvmfs/singularity.galaxyproject.org/all 
+          cache_directory_cacher_type: dir_mtime
+      env:
+        - name: SINGULARITY_CACHEDIR
+          value: /mnt/pulsar/deps/singularity
+        - name: SINGULARITY_TMPDIR
+          value: /mnt/pulsar/deps/singularity/tmp
     interactive_pulsar:
       runner: pulsar_embedded
       docker_enabled: true


### PR DESCRIPTION
Updated job conf to have destination parameters for docker and singularity.  In this setup a job destination could be pulsar-mel3 but would run with singularity only if the param `singularity_enabled: true` were set for the tool in the TPV.  The only parameter required would be `singularity_enabled`, everything else (`singularity_volumes` etc) lives on the job conf.  This has already been done on dev.

Every job will have in their destination parameters `singularity_enabled: False` or `singularity_enabled: True` and `docker_volumes` and `singularity_volumes`.  There is enough room on the destination_params field to have all of this data, and it's nothing in size compared to stdout/stderr for some jobs. 

An alternative design choice would be to have multiple destinations per cluster, i.e. `pulsar_mel3`, `pulsar_mel3_docker` and `pulsar_mel3_singularity` and use tags such as `singularity` to send jobs to the right destination.  It would be easy to map these destination names to the usage data used in the ranking function.

@nuwang @Slugger70 I'm interested in what you think of this given that GA's TPV config will be the example copy.  Would the `resubmit` example that Nuwan was talking about benefit from having destinations that are more specific?