### PR TITLE
Switch galaxy file path to user-data-3

### DIFF
--- a/files/galaxy/config/object_store_conf.xml
+++ b/files/galaxy/config/object_store_conf.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <object_store type="hierarchical">
     <backends>
+        <backend id="perthNFS3" type="disk" order="0">
+            <files_dir path="/mnt/user-data-3" />
+        </backend>
         <backend id="perthNFS4" type="disk" order="1">
             <files_dir path="/mnt/user-data-4" />
         </backend>
-        <backend id="perthNFS1" type="disk" order="0">
+        <backend id="perthNFS1" type="disk" order="2">
             <files_dir path="/mnt/user-data" />
         </backend>
-        <backend id="perthNFS2" type="disk" order="2">
+        <backend id="perthNFS2" type="disk" order="3">
             <files_dir path="/mnt/user-data-2" />
-        </backend>
-        <backend id="perthNFS3" type="disk" order="3">
-            <files_dir path="/mnt/user-data-3" />
         </backend>
         <backend id="GPFS" type="disk" order="4">
             <files_dir path="/mnt/galaxy/files" />

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -97,7 +97,7 @@ group_galaxy_config:
   uwsgi:  # todo: check desired dev settings for processes, threads, logging, mule, farm, look at how this is defined in prod galaxy.yml
     socket: 127.0.0.1:8080
     buffer-size: 16384
-    processes: 4
+    processes: 5
     threads: 4
     offload-threads: 2
     static-map:

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -98,7 +98,7 @@ galaxy_tmp_dir: /mnt/tmp
 
 galaxy_handler_count: 5   ############# europe uses 5, this could be host specific
 
-galaxy_file_path: /mnt/user-data
+galaxy_file_path: /mnt/user-data-3
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"


### PR DESCRIPTION
Set uwsgi.processes to 5 (already in production config)

This needs a full playbook run because the location of the upload_store moves with the file path and nginx conf etc gets updated.  nginx needs to be reloaded from the pawsey machine command line after galaxy has restarted.