### PR TITLE
use singularity for xtandem

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -247,6 +247,13 @@ tools:
       singularity_enabled: True
       singularity_run_extra_arguments: '--writable-tmpfs'
       dependency_resolution: 'none'
+  toolshed.g2.bx.psu.edu/repos/iracooke/xtandem/.*:
+    cores: 1
+    params:
+      singularity_enabled: True
+      singularity_run_extra_arguments: '--writable-tmpfs'
+      dependency_resolution: 'none'
+
 
 users:
   default:


### PR DESCRIPTION
xtandem has the same problem as protk_proteogenomics (https://github.com/usegalaxy-au/infrastructure/pull/770) - only the Docker container works.