### PR TITLE
fix high-mem rule for CB

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/users.yml
@@ -12,7 +12,9 @@ users:
             destinations = [d.id for d in mapper.destinations.values()
                             if any(d.tags.filter(tag_value='high-mem',
                                    tag_type=[TagType.REQUIRE, TagType.PREFER, TagType.ACCEPT]))]
-            count = rule_helper.job_count(for_user_email=user.email, for_destinations=destinations)
+            count = rule_helper.job_count(
+              for_user_email=user.email, for_destinations=destinations, for_job_states=['queued', 'running']
+            )
             if count > user_high_mem_jobs_limit:
               retval = True
             else:


### PR DESCRIPTION
I forgot to limit the count to queued and running jobs