### PR TITLE
upgrade tpv and use versions instead of git commits

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -20,14 +20,10 @@
     - name: Attach volume to instance
       include_role:
         name: attached-volumes
-    - name: Install Total Perspective Vortex
-      pip:  # on the first run, this will create the galaxy venv before the galaxy role is run
-        name: "{{ total_perspective_vortex_package }}"
-        virtualenv: "{{ galaxy_venv_dir }}"
-        state: forcereinstall
   roles:
     - galaxyproject.repos
     - common
+    - install-tpv
     - galaxyproject.postgresql
     - role: natefoo.postgresql_objects
       become: true

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -32,9 +32,8 @@ interactive_tools_server_name: "aarnet.usegalaxy.org.au"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_21.09
 
-# total perspective vortex package
-tpv_commit_id: "b5a91079622a8c76529d08abd3fa8e865289767a"
-total_perspective_vortex_package: "git+https://github.com/usegalaxy-au/total-perspective-vortex@{{ tpv_commit_id }}"
+# total perspective vortex
+tpv_version: '1.1.0'
 
 # Mounts for various connections:
 shared_mounts:  # TODO: /mnt/custom-indices from aarnet-misc-nfs

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -3,9 +3,8 @@
 # Login override - checksum for Login.vue
 galaxy_login_checksum_expected: fd733fa7ea21a22f6f99a095f8c2646b
 
-# total perspective vortex package
-tpv_commit_id: "b5a91079622a8c76529d08abd3fa8e865289767a"
-total_perspective_vortex_package: "git+https://github.com/usegalaxy-au/total-perspective-vortex@{{ tpv_commit_id }}"
+# total perspective vortex
+tpv_version: '1.1.0'
 
 # variables for attaching mounted volume to application server
 attached_volumes:

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -26,9 +26,8 @@ nginx_ssl_servers:
   #gie proxy hostname
 interactive_tools_server_name: "usegalaxy.org.au"
 
-# total perspective vortex package
-tpv_commit_id: "b5a91079622a8c76529d08abd3fa8e865289767a"
-total_perspective_vortex_package: "git+https://github.com/usegalaxy-au/total-perspective-vortex@{{ tpv_commit_id }}"
+# total perspective vortex
+tpv_version: '1.1.0'
 
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_21.09

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -6,9 +6,8 @@ attached_volumes:
     path: /mnt
     fstype: ext4
 
-# total perspective vortex package
-tpv_commit_id: "b5a91079622a8c76529d08abd3fa8e865289767a"
-total_perspective_vortex_package: "git+https://github.com/usegalaxy-au/total-perspective-vortex@{{ tpv_commit_id }}"
+# total perspective vortex
+tpv_version: '1.1.0'
 
 certbot_domains:
 - "{{ hostname }}"

--- a/roles/install-tpv/defaults/main.yml
+++ b/roles/install-tpv/defaults/main.yml
@@ -1,1 +1,0 @@
-tpv_repo: https://github.com/galaxyproject/total-perspective-vortex

--- a/roles/install-tpv/tasks/main.yml
+++ b/roles/install-tpv/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Install Total Perspective Vortex
   pip:
-    name: "git+{{ tpv_repo }}{% if tpv_commit_id|d('') %}@{{ tpv_commit_id }}{% endif %}"
+    name: "total-perspective-vortex{% if tpv_version|d('') %}=={{ tpv_version }}{% endif %}"
     virtualenv: "{{ galaxy_venv_dir }}"
-    state: forcereinstall

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -12,11 +12,6 @@
     - name: Attach volume to instance
       include_role:
         name: attached-volumes
-    - name: Install Total Perspective Vortex
-      pip:  # on the first run, this will create the galaxy venv before the galaxy role is run
-        name: "{{ total_perspective_vortex_package }}"
-        virtualenv: "{{ galaxy_venv_dir }}"
-        state: forcereinstall
   handlers:
     - name: Restart Galaxy
       systemd:
@@ -25,6 +20,7 @@
   roles:
     - galaxyproject.repos
     - common
+    - install-tpv
     - galaxyproject.postgresql
     - role: natefoo.postgresql_objects
       become: true


### PR DESCRIPTION
install `total-perspective-vortex=={{ tpv_version }}` so no need to use `state: forcereinstall` anymore

This update is needed for #784 .  Once this is updated on dev, staging, and whatever production galaxy that can be rebased and merged.  The match -> if change is backwards compatible.