### PR TITLE
Exact conda and mamba versions in all.yml

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -141,14 +141,16 @@ bashrc_env: |
   export SACCT_FORMAT="jobid%8,partition%9,jobname%30,alloccpus,elapsed,totalcpu,END,state,MaxRSS,ReqMem,NodeList"
 
 # miniconda
-# miniconda installs the latest version of conda by default
-# installing mamba will also install the latest version of conda
+miniconda_version: '4.12.0'
+miniconda_mamba_version: '0.23.3'
+
 miniconda_channels:
   - conda-forge
   - bioconda
   - defaults
 miniconda_base_env_packages:
-  - mamba
+  - mamba="{{ miniconda_mamba_version }}"
+  - conda="{{ miniconda_version }}"
 
 # Monitoring
 influx_url: stats.usegalaxy.org.au

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -329,3 +329,8 @@ slurm_docker_volumes: "{{ slurm_docker_volumes_list | join(',') }}"
 pulsar_docker_volumes: "{{ pulsar_docker_volumes_list | join(',') }}"
 
 singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
+
+# conda/mamba overrides for pawsey
+miniconda_version: '4.13.0'
+miniconda_base_env_packages: []
+galaxy_conda_exec: conda

--- a/pawsey_playbook.yml
+++ b/pawsey_playbook.yml
@@ -30,9 +30,9 @@
       become_user: postgres
     - geerlingguy.pip
     - galaxyproject.galaxy
-    - role: galaxyproject.miniconda
-      become: true
-      become_user: galaxy
+    # - role: galaxyproject.miniconda
+    #   become: true
+    #   become_user: galaxy
     - usegalaxy_eu.galaxy_systemd
     - nginx-upload-module
     - galaxyproject.nginx


### PR DESCRIPTION
Stick to conda=4.12.0 and mamba=0.23.3 and no longer automatically update conda with playbook runs.  This will have the advantage of making the playbooks run quicker.  pawsey already has conda version 4.13.0 so instead of downgrading this it can use conda instead of mamba.  aarnet and production pulsars still have conda version 4.12.0.   dev and staging have conda 4.13.0 so this will downgrade conda for them but hopefully it will be OK.  dev-pulsar was downgraded from 4.13.0 to 4.12.0 with no apparent ill-effects.