### PR TITLE
Tpv upgrade 120 production

### DIFF
--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/roles.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/roles.yml
@@ -5,7 +5,7 @@ roles:
         - training
     rules:
     - if: |
-        from vortex.core.entities import Tool
+        from tpv.core.entities import Tool
         value = True  # assume rule matches, opt out if there is a pulsar tag
         for ent in filter(lambda x: isinstance(x, Tool), entities):
             value = not list(ent.tags.filter(tag_value='pulsar')) and not list(entity.tags.filter(tag_value='interactive-tool')) # tool has no pulsar tag and so runs on slurm
@@ -18,7 +18,7 @@ roles:
         require:
           - slurm
     - if: |
-        from vortex.core.entities import Tool
+        from tpv.core.entities import Tool
         value = False
         for ent in filter(lambda x: isinstance(x, Tool), entities):
             value = list(ent.tags.filter(tag_value='pulsar')) and not list(ent.tags.filter(tag_value='pulsar-training-large'))
@@ -29,7 +29,7 @@ roles:
         require:
           - pulsar  # require pulsar and training: only one place to go
     - if: |
-        from vortex.core.entities import Tool
+        from tpv.core.entities import Tool
         value = False
         for ent in filter(lambda x: isinstance(x, Tool), entities):
             value = list(ent.tags.filter(tag_value='pulsar-training-large'))

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/roles.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/roles.yml
@@ -3,39 +3,39 @@ roles:
     scheduling:
       require:
         - training
-    rules:
-    - if: |
-        from tpv.core.entities import Tool
-        value = True  # assume rule matches, opt out if there is a pulsar tag
-        for ent in filter(lambda x: isinstance(x, Tool), entities):
-            value = not list(ent.tags.filter(tag_value='pulsar')) and not list(entity.tags.filter(tag_value='interactive-tool')) # tool has no pulsar tag and so runs on slurm
-        value
-      cores: 2
-      mem: cores * 3.8  # TODO check multiplier
-      params:
-        nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=training"
-      scheduling:
-        require:
-          - slurm
-    - if: |
-        from tpv.core.entities import Tool
-        value = False
-        for ent in filter(lambda x: isinstance(x, Tool), entities):
-            value = list(ent.tags.filter(tag_value='pulsar')) and not list(ent.tags.filter(tag_value='pulsar-training-large'))
-        value
-      cores: 4
-      mem: cores * 2.9  # ratio for pulsar-nci-training
-      scheduling:
-        require:
-          - pulsar  # require pulsar and training: only one place to go
-    - if: |
-        from tpv.core.entities import Tool
-        value = False
-        for ent in filter(lambda x: isinstance(x, Tool), entities):
-            value = list(ent.tags.filter(tag_value='pulsar-training-large'))
-        value
-      cores: 8
-      mem: cores * 2.9  # ratio for pulsar-nci-training
-      scheduling:
-        require:
-          - pulsar  # require pulsar and training: only one place to go
+    # rules:
+    # - if: |
+    #     from tpv.core.entities import Tool
+    #     value = True  # assume rule matches, opt out if there is a pulsar tag
+    #     for ent in filter(lambda x: isinstance(x, Tool), entities):
+    #         value = not list(ent.tags.filter(tag_value='pulsar')) and not list(entity.tags.filter(tag_value='interactive-tool')) # tool has no pulsar tag and so runs on slurm
+    #     value
+    #   cores: 2
+    #   mem: cores * 3.8  # TODO check multiplier
+    #   params:
+    #     nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=training"
+    #   scheduling:
+    #     require:
+    #       - slurm
+    # - if: |
+    #     from tpv.core.entities import Tool
+    #     value = False
+    #     for ent in filter(lambda x: isinstance(x, Tool), entities):
+    #         value = list(ent.tags.filter(tag_value='pulsar')) and not list(ent.tags.filter(tag_value='pulsar-training-large'))
+    #     value
+    #   cores: 4
+    #   mem: cores * 2.9  # ratio for pulsar-nci-training
+    #   scheduling:
+    #     require:
+    #       - pulsar  # require pulsar and training: only one place to go
+    # - if: |
+    #     from tpv.core.entities import Tool
+    #     value = False
+    #     for ent in filter(lambda x: isinstance(x, Tool), entities):
+    #         value = list(ent.tags.filter(tag_value='pulsar-training-large'))
+    #     value
+    #   cores: 8
+    #   mem: cores * 2.9  # ratio for pulsar-nci-training
+    #   scheduling:
+    #     require:
+    #       - pulsar  # require pulsar and training: only one place to go

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/users.yml
@@ -1,30 +1,30 @@
 users:
-    default:
-      rules:
-        - if: |
-            from galaxy.jobs.rule_helper import RuleHelper
-            from tpv.core.entities import TagType
+    # default:
+    #   rules:
+    #     - if: |
+    #         from galaxy.jobs.rule_helper import RuleHelper
+    #         from tpv.core.entities import TagType
 
-            user_high_mem_jobs_limit = 3
-            if entity.tags.filter(tag_value='high-mem'):
-              rule_helper = RuleHelper(app)
-              # Find all destinations that support high-mem
-              destinations = [d.id for d in mapper.destinations.values()
-                              if any(d.tags.filter(tag_value='high-mem',
-                                    tag_type=[TagType.REQUIRE, TagType.PREFER, TagType.ACCEPT]))]
-              count = rule_helper.job_count(
-                for_user_email=user.email, for_destinations=destinations, for_job_states=['queued', 'running']
-              )
-              if count > user_high_mem_jobs_limit:
-                retval = True
-              else:
-                retval = False
-            else:
-              retval = False
-            retval
-          execute: |
-            from galaxy.jobs.mapper import JobNotReadyException
-            raise JobNotReadyException()
+    #         user_high_mem_jobs_limit = 3
+    #         if entity.tags.filter(tag_value='high-mem'):
+    #           rule_helper = RuleHelper(app)
+    #           # Find all destinations that support high-mem
+    #           destinations = [d.id for d in mapper.destinations.values()
+    #                           if any(d.tags.filter(tag_value='high-mem',
+    #                                 tag_type=[TagType.REQUIRE, TagType.PREFER, TagType.ACCEPT]))]
+    #           count = rule_helper.job_count(
+    #             for_user_email=user.email, for_destinations=destinations, for_job_states=['queued', 'running']
+    #           )
+    #           if count > user_high_mem_jobs_limit:
+    #             retval = True
+    #           else:
+    #             retval = False
+    #         else:
+    #           retval = False
+    #         retval
+    #       execute: |
+    #         from galaxy.jobs.mapper import JobNotReadyException
+    #         raise JobNotReadyException()
     jenkins_bot@usegalaxy.org.au:
       cores: 1
       mem: cores * 3.8

--- a/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/pawsey/total_perspective_vortex/users.yml
@@ -3,7 +3,7 @@ users:
       rules:
         - if: |
             from galaxy.jobs.rule_helper import RuleHelper
-            from vortex.core.entities import TagType
+            from tpv.core.entities import TagType
 
             user_high_mem_jobs_limit = 3
             if entity.tags.filter(tag_value='high-mem'):

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -33,7 +33,7 @@ galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_21.09
 
 # total perspective vortex
-tpv_version: '1.1.0'
+tpv_version: '1.2.0'
 
 # Mounts for various connections:
 shared_mounts:  # TODO: /mnt/custom-indices from aarnet-misc-nfs

--- a/host_vars/pawsey.usegalaxy.org.au.yml
+++ b/host_vars/pawsey.usegalaxy.org.au.yml
@@ -27,7 +27,7 @@ nginx_ssl_servers:
 interactive_tools_server_name: "usegalaxy.org.au"
 
 # total perspective vortex
-tpv_version: '1.1.0'
+tpv_version: '1.2.0'
 
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_21.09

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -7,7 +7,7 @@ attached_volumes:
     fstype: ext4
 
 # total perspective vortex
-tpv_version: '1.1.0'
+tpv_version: '1.2.0'
 
 certbot_domains:
 - "{{ hostname }}"

--- a/templates/galaxy/config/aarnet_job_conf.yml.j2
+++ b/templates/galaxy/config/aarnet_job_conf.yml.j2
@@ -141,16 +141,16 @@ runners:
     load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
     pulsar_config: "{{ galaxy_config_dir }}/pulsar_app.yml"
 execution:
-  default: vortex_dispatcher
+  default: tpv_dispatcher
   environments:
     local:
       runner: local
-    vortex_dispatcher:
+    tpv_dispatcher:
       runner: dynamic
       type: python
       function: map_tool_to_destination
-      rules_module: vortex.rules
-      vortex_config_files:
+      rules_module: tpv.rules
+      tpv_config_files:
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/aarnet_tpv_config.yml"
         # - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/aarnet_tools.yml"
         # - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/default_tool.yml"

--- a/templates/galaxy/config/pawsey_job_conf.yml.j2
+++ b/templates/galaxy/config/pawsey_job_conf.yml.j2
@@ -141,16 +141,16 @@ runners:
     load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
     pulsar_config: "{{ galaxy_config_dir }}/pulsar_app.yml"
 execution:
-  default: vortex_dispatcher
+  default: tpv_dispatcher
   environments:
     local:
       runner: local
-    vortex_dispatcher:
+    tpv_dispatcher:
       runner: dynamic
       type: python
       function: map_tool_to_destination
-      rules_module: vortex.rules
-      vortex_config_files:
+      rules_module: tpv.rules
+      tpv_config_files:
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/default_tool.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/tools.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/users.yml"

--- a/templates/galaxy/config/staging_job_conf.yml.j2
+++ b/templates/galaxy/config/staging_job_conf.yml.j2
@@ -24,16 +24,16 @@ runners:
     load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
     pulsar_config: "{{ galaxy_config_dir }}/pulsar_app.yml"
 execution:
-  default: vortex_dispatcher
+  default: tpv_dispatcher
   environments:
     local:
       runner: local
-    vortex_dispatcher:
+    tpv_dispatcher:
       runner: dynamic
       type: python
       function: map_tool_to_destination
-      rules_module: vortex.rules
-      vortex_config_files:
+      rules_module: tpv.rules
+      tpv_config_files:
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/vortex_config.yml"
     gateway:
       runner: dynamic


### PR DESCRIPTION
Set tpv version to 1.2.0 on staging, pawsey and aarnet.  Update rules that will now import from tpv instead of from vortex, temporarily comment these out until pawsey tpv has been upgraded.