### PR TITLE
Send tpv updates to aarnet, fix dev paths

### DIFF
--- a/jenkins/update_tool_destinations.sh
+++ b/jenkins/update_tool_destinations.sh
@@ -3,7 +3,7 @@ PROD_TPV_FILE_PATH="files/galaxy/dynamic_job_rules/production/total_perspective_
 PROD_TPV_UPDATED=$(git diff --name-only $GIT_PREVIOUS_COMMIT $GIT_COMMIT | cat | grep $PROD_TPV_FILE_PATH)
 
 # check whether dev files of interest have changed
-DEV_LOCAL_TOOL_CONF="files/config/local_tool_conf_dev.xml"
+DEV_LOCAL_TOOL_CONF="files/galaxy/config/local_tool_conf_dev.xml"
 DEV_JOB_CONF_PATH="templates/galaxy/config/dev_job_conf.yml.j2"
 DEV_TPV_FILE_PATH="files/galaxy/dynamic_job_rules/dev/total_perspective_vortex"
 DEV_RELEVANT_FILES_UPDATED=$(git diff --name-only $GIT_PREVIOUS_COMMIT $GIT_COMMIT | cat | grep -E "$DEV_TPV_FILE_PATH|$DEV_JOB_CONF_PATH|$DEV_LOCAL_TOOL_CONF")
@@ -41,7 +41,7 @@ fi
 if [ "$PROD_TPV_UPDATED" ]; then
     echo -e "\nUpdating tool destinations file on Galaxy production instance\n"
 
-    ansible-playbook -i hosts pawsey_update_job_conf_playbook.yml --extra-vars "ansible_user=jenkins_bot" --vault-password-file "$VAULT_PASS"
+    ansible-playbook -i hosts aarnet_update_job_conf_playbook.yml --extra-vars "ansible_user=jenkins_bot" --vault-password-file "$VAULT_PASS"
 fi
 
 if [ "$DEV_RELEVANT_FILES_UPDATED" ]; then


### PR DESCRIPTION
Update aarnet tpv files when production files are updated.

The script had the wrong path for checking for changes in the dev local tool conf.