### PR TITLE
Common rule for picard tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -193,6 +193,15 @@ tools:
             - pulsar
           require:
             - pulsar-qld-blast
+  toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/.*:
+    scheduling:
+      accept:
+        - pulsar
+    env:
+      _JAVA_OPTIONS: '-Xmx{int(mem)}G -Xms1G'
+    rules:
+      - if: input_size >= 1
+        cores: 3
   toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_SamToFastq/.*:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/.*:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -193,7 +193,7 @@ tools:
             - pulsar
           require:
             - pulsar-qld-blast
-  toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/.*:
+  toolshed.g2.bx.psu.edu/repos/devteam/picard/.*:
     scheduling:
       accept:
         - pulsar
@@ -202,8 +202,6 @@ tools:
     rules:
       - if: input_size >= 1
         cores: 3
-  toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_SamToFastq/.*:
-    cores: 5
   toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/.*:
     cores: 3
   toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/.*:


### PR DESCRIPTION
The picard repository has ~30 tool wrappers and they all pass tests on pulsar.  None of them make use of GALAXY_SLOTS or GALAXY_MEMORY_MB in the wrapper.  This sets the env var `_JAVA_OPTIONS` to `-Xmx{int(mem)}G -Xms1G`