### PR TITLE
set outputs_to_working_directory: True on dev, override for all pulsars

### DIFF
--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -74,6 +74,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     database_connection: "postgresql://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
     id_secret: "{{ vault_dev_id_secret }}"
     file_path: "{{ galaxy_file_path }}"
+    outputs_to_working_directory: true
     galaxy_infrastructure_url: 'https://dev.usegalaxy.org.au'
     enable_oidc: true
     oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"

--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -85,6 +85,7 @@ execution:
       transport: curl
       remote_metadata: 'false'
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: 'true'
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -112,6 +113,7 @@ execution:
       transport: curl
       remote_metadata: 'false'
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: 'true'
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -144,6 +146,7 @@ execution:
       docker_require_container: true
     interactive_pulsar:
       runner: pulsar_embedded
+      outputs_to_working_directory: false
       docker_enabled: true
       docker_volumes: $defaults
       docker_sudo: false
@@ -158,6 +161,7 @@ execution:
       transport: curl
       remote_metadata: "false"
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: "true"
       persistence_directory: /mnt/share/persisted_data
@@ -168,6 +172,7 @@ execution:
       transport: curl
       remote_metadata: "false"
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: 'none'
       rewrite_parameters: "true"
       persistence_directory: /mnt/share/persisted_data
@@ -181,6 +186,7 @@ execution:
       transport: curl
       remote_metadata: "false"
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: "true"
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -191,6 +197,7 @@ execution:
       transport: curl
       remote_metadata: "false"
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       rewrite_parameters: "true"
       persistence_directory: /mnt/pulsar/files/persisted_data
       submit_native_specification: "--nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=32000"
@@ -219,6 +226,7 @@ execution:
       docker_memory: 105G
       docker_sudo: false
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: "true"
       persistence_directory: /mnt/pulsar/files/persisted_data


### PR DESCRIPTION
See if this configuration allows for user-data:ro to be preserved in singularity_volumes while being able to run featurecounts, chemfp etc with singularity