### PR TITLE
Test user jobs run with singularity enabled if history has 'singularity' tag

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -278,49 +278,25 @@ tools:
 
 users:
   default: {}
-  # test_user:
-  #   rules:
-  #     - id: toolshed_tool
-  #       if: |
-  #         enable_singularity = False
-  #         if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
-  #           with open('/home/galaxy/tpv_test_file', 'w') as handle:
-  #             handle.write('str(locals())')
-  #           try:
-  #             enable_singularity = (
-  #               any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in history.tags]
-  #             )
-  #           except:
-  #             pass
-  #         enable_singularity
-  #       params:
-  #         singularity_enabled: True
-  star@email.com:
-    params:
-      is_any_of_this_working: 'yes'
+  test_user:
     rules:
-      # - if: |
-      #     'featurecounts' in tool.id
-      #   params:
-      #     singularity_enabled: true
-      #     this_tool_is_featurecounts: true
       - id: toolshed_tool
         if: |
           enable_singularity = False
           if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
-            with open('/home/galaxy/tpv_test_file', 'w') as handle:
-              handle.write('str(locals())')
             try:
               enable_singularity = (
-                any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in history.tags])
+                any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in job.history.tags])
               )
             except:
               pass
           enable_singularity
         params:
           singularity_enabled: True
+  star@email.com:
+    inherits: test_user
   pulsar_user@usegalaxy.org.au:
-    # inherits: test_user
+    inherits: test_user
     rules:
       - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')  # this locks out all local tools, might need to make exceptions for these by id
         scheduling:
@@ -328,7 +304,7 @@ users:
             - pulsar  # if pulsar requires the pulsar tag, nothing without the pulsar tag will go there
             - dev-pulsar
   pulsar_nci_test_user@usegalaxy.org.au:
-    # inherits: test_user
+    inherits: test_user
     rules:
       - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
         scheduling:
@@ -343,7 +319,7 @@ users:
             - pulsar
             - pulsar-eu-gpu-alpha
   jenkins_bot@usegalaxy.org.au:
-    # inherits: test_user
+    inherits: test_user
     cores: 1
     scheduling:
       require:

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -280,14 +280,12 @@ users:
   default: {}
   test_user:
     rules:
-      - id: toolshed_tool
+      - id: singularity_test_user_rule
         if: |
           enable_singularity = False
           if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
             try:
-              enable_singularity = (
-                any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in job.history.tags])
-              )
+              enable_singularity = 'singularity' in [hta.user_tname for hta in job.history.tags]
             except:
               pass
           enable_singularity

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -277,47 +277,50 @@ tools:
       singularity_enabled: True
 
 users:
-  default:
+  default: {}
+  # test_user:
+  #   rules:
+  #     - id: toolshed_tool
+  #       if: |
+  #         enable_singularity = False
+  #         if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
+  #           with open('/home/galaxy/tpv_test_file', 'w') as handle:
+  #             handle.write('str(locals())')
+  #           try:
+  #             enable_singularity = (
+  #               any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in history.tags]
+  #             )
+  #           except:
+  #             pass
+  #         enable_singularity
+  #       params:
+  #         singularity_enabled: True
+  star@email.com:
+    params:
+      is_any_of_this_working: 'yes'
     rules:
       # - if: |
-      #     from galaxy.jobs.rule_helper import RuleHelper  # this is a test of raising JobNotReadyException, jobs per user limit is already taken care of by galaxy
-
-      #     retval = False
-      #     if user:
-      #       rule_helper = RuleHelper(app)
-      #       job_limit = 1
-      #       # job_limit = app.job_config.limits.registered_user_concurrent_jobs
-      #       user_job_count = rule_helper.job_count(for_user_email=user.email, for_job_states=['queued', 'running'])
-      #       if user_job_count >= job_limit:
-      #         retval = True
-      #     retval
-      #   execute: |
-      #       from galaxy.jobs.mapper import JobNotReadyException
-      #       raise JobNotReadyException()
-      - if: |
-          from galaxy.jobs.rule_helper import RuleHelper
-          from tpv.core.entities import TagType
-          if entity.tags.filter(tag_value='highmem'):
-            rule_helper = RuleHelper(app)
-            # Find all destinations that support highmem
-            destinations = [d.id for d in mapper.destinations.values()
-                            if any(d.tags.filter(tag_value='highmem',
-                                   tag_type=[TagType.REQUIRE, TagType.PREFER, TagType.ACCEPT]))]
-            count = rule_helper.job_count(
-              for_user_email=user.email,
-              for_destinations=destinations,
-              for_job_states=['queued', 'running'],
-            )
-            if count > 4:
-              retval = True
-            else:
-              retval = False
-          else:
-            retval = False
-          retval
-        execute: |
-          from galaxy.jobs.mapper import JobNotReadyException; raise JobNotReadyException()
+      #     'featurecounts' in tool.id
+      #   params:
+      #     singularity_enabled: true
+      #     this_tool_is_featurecounts: true
+      - id: toolshed_tool
+        if: |
+          enable_singularity = False
+          if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
+            with open('/home/galaxy/tpv_test_file', 'w') as handle:
+              handle.write('str(locals())')
+            try:
+              enable_singularity = (
+                any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in history.tags])
+              )
+            except:
+              pass
+          enable_singularity
+        params:
+          singularity_enabled: True
   pulsar_user@usegalaxy.org.au:
+    # inherits: test_user
     rules:
       - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')  # this locks out all local tools, might need to make exceptions for these by id
         scheduling:
@@ -325,6 +328,7 @@ users:
             - pulsar  # if pulsar requires the pulsar tag, nothing without the pulsar tag will go there
             - dev-pulsar
   pulsar_nci_test_user@usegalaxy.org.au:
+    # inherits: test_user
     rules:
       - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
         scheduling:
@@ -339,6 +343,7 @@ users:
             - pulsar
             - pulsar-eu-gpu-alpha
   jenkins_bot@usegalaxy.org.au:
+    # inherits: test_user
     cores: 1
     scheduling:
       require:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
@@ -25,7 +25,23 @@ users:
           execute: |
             from galaxy.jobs.mapper import JobNotReadyException
             raise JobNotReadyException()
+    test_user:
+      rules:
+        - id: toolshed_tool
+          if: |
+            enable_singularity = False
+            if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
+              try:
+                enable_singularity = (
+                  any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in job.history.tags])
+                )
+              except:
+                pass
+            enable_singularity
+          params:
+            singularity_enabled: True
     jenkins_bot@usegalaxy.org.au:
+      inherits: test_user
       cores: 1
       mem: cores * 3.8
       params:
@@ -34,12 +50,14 @@ users:
         require:
           - slurm
     testbot@usegalaxy.org:
+      inherits: test_user
       cores: 1
       mem: cores * 3.8
       scheduling:
         require:
           - slurm
     pulsar_mel2_user@usegalaxy.org.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -49,6 +67,7 @@ users:
             require:
               - pulsar-mel2
     pulsar_mel3_user@usegalaxy.org.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -58,6 +77,7 @@ users:
             require:
               - pulsar-mel3
     pulsar_paw_user@usegalaxy.org.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -67,6 +87,7 @@ users:
             require:
               - pulsar-paw
     phm1@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -77,6 +98,7 @@ users:
             require:
               - pulsar-high-mem1
     phm2@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -87,6 +109,7 @@ users:
             require:
               - pulsar-high-mem2
     pncitrain@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -97,6 +120,7 @@ users:
             require:
               - pulsar-nci-training
     pqhm0@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -107,6 +131,7 @@ users:
             require:
               - pulsar-qld-high-mem0
     pqhm1@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -117,6 +142,7 @@ users:
             require:
               - pulsar-qld-high-mem1
     pqhm2@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -127,6 +153,7 @@ users:
             require:
               - pulsar-qld-high-mem2
     pblast@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:
@@ -136,6 +163,7 @@ users:
             require:
               - pulsar-qld-blast
     pqld@genome.edu.au:
+      inherits: test_user
       rules:
         - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
           scheduling:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
@@ -27,14 +27,12 @@ users:
             raise JobNotReadyException()
     test_user:
       rules:
-        - id: toolshed_tool
+        - id: singularity_test_user_rule
           if: |
             enable_singularity = False
             if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
               try:
-                enable_singularity = (
-                  any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in job.history.tags])
-                )
+                enable_singularity = 'singularity' in [hta.user_tname for hta in job.history.tags]
               except:
                 pass
             enable_singularity

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
@@ -58,7 +58,23 @@ destinations:
         - pulsar
 
 users:
+  test_user:
+    rules:
+      - id: toolshed_tool
+        if: |
+          enable_singularity = False
+          if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
+            try:
+              enable_singularity = (
+                any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in job.history.tags])
+              )
+            except:
+              pass
+          enable_singularity
+        params:
+          singularity_enabled: True
   jenkins_bot@usegalaxy.org.au:
+    inherits: test_user
     cores: 1
     scheduling:
       require:

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
@@ -60,14 +60,12 @@ destinations:
 users:
   test_user:
     rules:
-      - id: toolshed_tool
+      - id: singularity_test_user_rule
         if: |
           enable_singularity = False
           if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
             try:
-              enable_singularity = (
-                any([(hta.user_value == 'singularity' or hta.user_tname == 'singularity') for hta in job.history.tags])
-              )
+              enable_singularity = 'singularity' in [hta.user_tname for hta in job.history.tags]
             except:
               pass
           enable_singularity


### PR DESCRIPTION
- remove high-mem rule from dev default user (this contains errors fixed in the production rule, besides, dev has no high-mem destinations)
- add test_user with the rule that any toolshed tool will run will run on singularity if the history has a 'singularity' tag.  All test user accounts inherit this rule.

I got this idea from Galaxy Main because testers were encouraged to add a 'training' tag to their histories to have their jobs run on priority resources.  This seems like a neat way to control a job destination from the outside.  I'm not suggesting anything like this for general users, just for test user accounts that only we have access to.  