### PR TITLE
Outputs to working directory set everywhere

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -137,8 +137,7 @@ group_galaxy_config:
     use_heartbeat: true
     allow_user_dataset_purge: true
     enable_quotas: true
-    enable_job_recovery: true  # disappearing in 21.09
-    # outputs_to_working_directory: true
+    outputs_to_working_directory: true # disable in job confs for all pulsars
     enable_tool_recommendations: true
 
     static_enabled: true

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -230,7 +230,7 @@ aaf_client_id: "{{ vault_aaf_client_id_prod }}"
 aaf_client_secret: "{{ vault_aaf_client_secret_prod }}"
 
 # remote-pulsar-cron variables
-rpc_skip_cron_setup: true # TODO: Set to false once aarnet is the production galaxy
+rpc_skip_cron_setup: false
 rpc_db_connection_string: "postgres://reader:{{ vault_aarnet_db_reader_password }}@aarnet-db.usegalaxy.org.au:5432/galaxy"
 
 rpc_pulsar_machines:

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -333,7 +333,7 @@ slurm_singularity_volumes_list_restricted:
   - $job_directory:rw
   - $galaxy_root:ro
   - $tool_directory:ro
-  - /mnt/user-data-5:rw
+  - /mnt/user-data-5:ro
   - /mnt/user-data-4:ro
   - /mnt/user-data-3:ro
   - /mnt/user-data-2:ro

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -74,7 +74,6 @@ host_galaxy_config:  # renamed from __galaxy_config
     database_connection: "postgresql://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
     id_secret: "{{ vault_dev_id_secret }}"
     file_path: "{{ galaxy_file_path }}"
-    outputs_to_working_directory: true
     galaxy_infrastructure_url: 'https://dev.usegalaxy.org.au'
     enable_oidc: true
     oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"

--- a/templates/galaxy/config/aarnet_job_conf.yml.j2
+++ b/templates/galaxy/config/aarnet_job_conf.yml.j2
@@ -172,6 +172,7 @@ execution:
       docker_auto_rm: true
       docker_set_user: ''
       require_container: true
+      outputs_to_working_directory: false
       container_monitor_result: callback
       submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760 --partition=interactive_tools"
     slurm:
@@ -195,6 +196,7 @@ execution:
     pulsar-mel2:
       runner: pulsar_mel2_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -222,6 +224,7 @@ execution:
     pulsar-paw:
       runner: pulsar-paw_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -249,6 +252,7 @@ execution:
     pulsar-mel3:
       runner: pulsar-mel3_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -276,6 +280,7 @@ execution:
     pulsar-high-mem1:
       runner: pulsar-high-mem1_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -303,6 +308,7 @@ execution:
     pulsar-high-mem2:
       runner: pulsar-high-mem2_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -330,6 +336,7 @@ execution:
     pulsar-qld-high-mem0:
       runner: pulsar-qld-high-mem0_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -357,6 +364,7 @@ execution:
     pulsar-qld-high-mem1:
       runner: pulsar-qld-high-mem1_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -384,6 +392,7 @@ execution:
     pulsar-qld-high-mem2:
       runner: pulsar-qld-high-mem2_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -411,6 +420,7 @@ execution:
     pulsar-nci-training:
       runner: pulsar-nci-training_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -438,6 +448,7 @@ execution:
     pulsar-qld-blast:
       runner: pulsar-qld-blast_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/pulsar/files/staging
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -465,6 +476,7 @@ execution:
     pulsar-QLD:
       runner: pulsar-QLD_runner
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       jobs_directory: /mnt/tmp/files/staging
       persistence_directory: /mnt/tmp/files/persisted_data
@@ -495,6 +507,7 @@ execution:
       transport: curl
       remote_metadata: "false"
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: "true"
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -505,6 +518,7 @@ execution:
       transport: curl
       remote_metadata: "false"
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: "true"
       persistence_directory: /mnt/pulsar/files/persisted_data

--- a/templates/galaxy/config/staging_job_conf.yml.j2
+++ b/templates/galaxy/config/staging_job_conf.yml.j2
@@ -57,6 +57,7 @@ execution:
       transport: curl
       remote_metadata: 'false'
       default_file_action: remote_transfer
+      outputs_to_working_directory: false
       dependency_resolution: remote
       rewrite_parameters: 'true'
       persistence_directory: /mnt/pulsar/files/persisted_data
@@ -80,6 +81,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     interactive_pulsar:
       runner: pulsar_embedded
+      outputs_to_working_directory: false
       docker_enabled: true
       docker_volumes: $defaults
       docker_sudo: false


### PR DESCRIPTION
true in galaxyservers.yml, false for all pulsars.  This has fixed dev w.r.t read-only file directories for singularity.