### PR TITLE
new rabbit for dev-queue, add runner and destination to job conf

### DIFF
--- a/host_vars/dev-queue.usegalaxy.org.au.yml
+++ b/host_vars/dev-queue.usegalaxy.org.au.yml
@@ -37,7 +37,7 @@ rabbitmq_vhosts:
   - /pulsar/galaxy_azure_0
   - /pulsar/galaxy_azure_1
 
-rabbitmq_version: 3.9.7-1
+rabbitmq_version: 3.10.5-1
 
 rabbitmq_password_admin: "{{ vault_rabbitmq_password_admin_dev }}"
 rabbitmq_password_telegraf: "{{ vault_rabbitmq_password_telegraf_dev }}"

--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -53,6 +53,16 @@ runners:
     amqp_consumer_timeout: 2.0
     amqp_publish_retry: True
     amqp_publish_retry_max_retries: 60
+  pulsar_azure_1_runner:
+    load: galaxy.jobs.runners.pulsar:PulsarMQJobRunner
+    amqp_url: "pyamqp://galaxy_azure_1:{{ vault_rabbitmq_password_galaxy_azure_1 }}@dev-queue.usegalaxy.org.au:5671//pulsar/galaxy_azure_1?ssl=1"
+    galaxy_url: "https://dev.usegalaxy.org.au"
+    manager: _default_
+    amqp_acknowledge: True
+    amqp_ack_republish_time: 1200
+    amqp_consumer_timeout: 2.0
+    amqp_publish_retry: True
+    amqp_publish_retry_max_retries: 60
 execution:
   default: tpv_dispatcher
   environments:
@@ -234,6 +244,17 @@ execution:
       require_container: true
       docker_run_extra_arguments: "--gpus all"
       docker_set_user: '1000'
+    pulsar-azure-1-std:
+      runner: pulsar_azure_1_runner
+      jobs_directory: /mnt/pulsar/files/staging
+      transport: curl
+      remote_metadata: "false"
+      default_file_action: remote_transfer
+      outputs_to_working_directory: false
+      dependency_resolution: remote
+      rewrite_parameters: "true"
+      persistence_directory: /mnt/pulsar/files/persisted_data
+      submit_native_specification: "--nodes=1 --ntasks=8 --ntasks-per-node=8 --mem=32000"
 
 limits:
 - type: anonymous_user_concurrent_jobs


### PR DESCRIPTION
update rabbitmq version on dev to 3.10.5-1 because there were erlang clashes when running the playbook.