### PR TITLE
[WIP] alphafold-dev on production

### DIFF
--- a/files/galaxy/config/local_tool_conf.xml
+++ b/files/galaxy/config/local_tool_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <toolbox monitor="true">
     <section id="local_tools" name="Local Tools">
-        <!-- <tool file="galaxy-local-tools/tools/canu/canu.xml" labels="test"/> -->
+        <tool file="galaxy-local-tools/tools/alphafold/alphafold.xml" labels="test"/>
     </section>
 </toolbox>

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1339,10 +1339,20 @@ tools:
         - pulsar
         - pulsar-azure-gpu
     rules:
-      - if: |
+      - id: alphafold_role_rule
+        if: |
           not user or 'Alphafold' not in [role.name for role in user.all_roles() if not role.deleted]
         fail: |
           This tool is currently being beta-tested on GPUs and your account has not been given access. Contact help@genome.edu.au if you think this is in error.
+  # alphafold-dev
+  alphafold-dev:
+    inherits: toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*
+    rules:
+      - id: alphafold_role_rule
+        if: |
+          not user or 'alphafold-dev' not in [role.name for role in user.all_roles() if not role.deleted]
+        fail: |
+          This is a development version of alphafold.  Only users with the role 'alphafold-dev' are allowed to run it.
   # Peptide shaker and other galaxyP tools
   toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/.*:
     cores:  7


### PR DESCRIPTION
Not sure where to put the alphafold.xml etc.  The galaxy-local-tools path is a clone of tools-au which is updated with each playbook run.  Ideally it would be somewhere that could be written to without sudo.