### PR TITLE
the new pulsar azure on dev  was offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -439,7 +439,6 @@ destinations:
       accept:
         - general
         - alphafold
-        - offline
       require:
         - pulsar
         - pulsar-azure-1


### PR DESCRIPTION
@Slugger70 When I copied the destination from the original, I included `offline: true` and that's why tpv couldn't find a matching destination earlier.