### PR TITLE
Update default tool on dev to have partition in context

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/default_tool.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/default_tool.yml
@@ -6,9 +6,11 @@ tools:
     cores: 1
     mem: cores * 3.8
     env: {}
+    context:
+      partition: main
     params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
-      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
+      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
+      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
       docker_memory: '{mem}G'
     scheduling:
       reject:

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -159,6 +159,7 @@ tools:
   .*alphafold.*:  # match local or toolshed alphafold
     cores: 40
     mem: 107
+    gpus: 1
     scheduling:
       accept:
         - pulsar
@@ -172,12 +173,11 @@ tools:
             - pulsar-azure-0
         cores: 6
         mem: 106
+        context:
+          partition: azuregpu1
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=azuregpu1"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=azuregpu1"
           docker_enabled: true
           docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro'
-          docker_memory: 107G
           docker_sudo: false
           require_container: true
           docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=30 --env ALPHAFOLD_AA_LENGTH_MAX=2000"
@@ -188,15 +188,14 @@ tools:
             - pulsar-azure-1
         cores: 8
         mem: 69
+        context:
+          partition: azuregpu1
         params:
-          nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=azuregpu1"
-          submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=azuregpu1"
           docker_enabled: true
           docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro'
-          #docker_memory: 107G
           docker_sudo: false
-          require_container: true
           docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=30 --env ALPHAFOLD_AA_LENGTH_MAX=2000"
+          require_container: true
           docker_set_user: '1000'
   toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1:
     cores: 2
@@ -415,6 +414,7 @@ destinations:
   pulsar-eu-gpu-alpha:
     cores: 40
     mem: 107
+    gpus: 1
     scheduling:
       accept:
         - general
@@ -425,6 +425,7 @@ destinations:
   pulsar-azure-0-std:  # TODO: this needs higher cores/mem for alphafold
     cores: 120
     mem: 2000
+    gpus: 1
     scheduling:
       accept:
         - general
@@ -436,6 +437,7 @@ destinations:
   pulsar-azure-1-std:  # TODO: this needs higher cores/mem for alphafold
     cores: 24
     mem: 210
+    gpus: 1
     scheduling:
       accept:
         - general
@@ -446,6 +448,7 @@ destinations:
   pulsar-azure-0-docker:  # TODO: this needs higher cores/mem for alphafold
     cores: 6
     mem: 107
+    gpus: 1
     scheduling:
       accept:
         - general


### PR DESCRIPTION
the native spec parameter becomes
`nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"`
on default tool and partition is overridden on alphafold tools to azuregpu1