### PR TITLE
Set pqhm2 to offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -83,6 +83,7 @@ destinations:
       require:
       - pulsar
       - high-mem
+      - offline
   pulsar-nci-training:
     cores: 16
     mem: 47.07


### PR DESCRIPTION
Setting pulsar qld high mem 2 to offline so that jobs scheduled there can be restarted.  There is no slurm data for it on grafana and I can't ssh to it.  One of the running jobs is mothur_cluster_split - I won't restart this one.