### PR TITLE
Set tmp_dir param for dev data fetch

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -1,7 +1,7 @@
 tools:
   __DATA_FETCH__:
-    env:
-      TEMP: /mnt/galaxy/tmp/data_fetch
+    params:
+      tmp_dir: True
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
     scheduling:
       accept:


### PR DESCRIPTION
If this works as expected, the url_paste* file will be created within a subdirectory of the job working directory and no url_paste* file will be created in the worker temp disk.