### PR TITLE
Set parameter for  __DATA_FETCH__ to store its temp files within the jwd

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2,6 +2,8 @@ tools:
   __DATA_FETCH__:
     cores: 1
     mem: 10
+    params:
+      tmp_dir: True
     rules:
     - if: |
         user_limit = 4


### PR DESCRIPTION
This will stop url_paste* files accumulating in the worker temp dirs and overflowing onto the workers' root disks.