### PR TITLE
Give dev a hierarchical object store

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -52,6 +52,15 @@
     - dj-wasabi.telegraf
     - login-override
   post_tasks:
+    - name: Ensure object store paths exist
+      file:
+        state: directory
+        path: "{{ item }}"
+        owner: galaxy
+        group: galaxy
+      with_items:
+        - /mnt/galaxy/data
+        - /mnt/galaxy/data-2
     - name: Make local_tool directory group-writable by machine users
       file:
         path: /mnt/galaxy/local_tools

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -48,12 +48,14 @@ galaxy_tus_upload_store: "{{ galaxy_tmp_dir }}/tus"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_22.01
 
-galaxy_file_path: "{{ galaxy_root }}/data"
+galaxy_file_path: "{{ galaxy_root }}/data-2"
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
 
 host_galaxy_config_templates:
+  - src: "{{ galaxy_config_template_src_dir }}/config/dev_object_store_conf.xml.j2"
+    dest: "{{ galaxy_config_dir }}/object_store_conf.xml"
   - src: "{{ galaxy_config_template_src_dir }}/config/oidc_backends_config.xml.j2"
     dest: "{{ galaxy_config_dir}}/oidc_backends_config.xml"
   - src: "{{ galaxy_config_template_src_dir }}/config/dev_job_conf.yml.j2"
@@ -74,6 +76,7 @@ host_galaxy_config:  # renamed from __galaxy_config
     database_connection: "postgresql://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
     id_secret: "{{ vault_dev_id_secret }}"
     file_path: "{{ galaxy_file_path }}"
+    object_store_config_file: "{{ galaxy_config_dir }}/object_store_conf.xml"
     galaxy_infrastructure_url: 'https://dev.usegalaxy.org.au'
     enable_oidc: true
     oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"

--- a/templates/galaxy/config/dev_object_store_conf.xml.j2
+++ b/templates/galaxy/config/dev_object_store_conf.xml.j2
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object_store type="hierarchical">
+    <backends>
+        <backend id="dev_objects_1" type="disk" order="0">
+            <files_dir path="/mnt/galaxy/data" />
+        </backend>
+        <backend id="dev_objects_2" type="disk" order="1">
+            <files_dir path="/mnt/galaxy/data-2" />
+        </backend>
+    </backends>
+</object_store>
+


### PR DESCRIPTION
Replicate the production object store setup on the dev with the aim of migrating this to a distributed object store with new datasets being stored by UUID. The old directories would have weight 0 meaning that nothing would be written to them.