### PR TITLE
Revert "set phm1 to offline"

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -45,7 +45,6 @@ destinations:
       require:
       - pulsar
       - high-mem
-      - offline
   pulsar-high-mem2:
     cores: 126
     mem: 1922.49


### PR DESCRIPTION
phm1 was set offline because the disk was read-only, it must have been remounted or the vm rebooted since then because it is OK now.