### PR TITLE
Uom vet alphafold tpv rules

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -6,9 +6,11 @@ tools:
     cores: 1
     mem: cores * 3.8
     env: {}
+    context:
+      partition: main
     params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
-      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
+      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
+      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
       docker_memory: '{mem}G'
     scheduling:
       reject:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -123,3 +123,17 @@ destinations:
       require:
         - pulsar
         - pulsar-azure-gpu
+  pulsar-azure-1:
+    cores: 24
+    mem: 218
+    scheduling:
+      require:
+        - pulsar
+        - pulsar-azure-1
+  pulsar-azure-1-gpu:
+    cores: 24
+    mem: 218
+    scheduling:
+      require:
+        - pulsar
+        - pulsar-azure-1-gpu

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/roles.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/roles.yml
@@ -12,8 +12,8 @@ roles:
         value
       cores: 2
       mem: cores * 3.8  # TODO check multiplier
-      params:
-        nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=training"
+      context:
+        partition: training
       scheduling:
         require:
           - slurm

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -226,16 +226,16 @@ tools:
     cores: 6
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant/.*:
     cores: 16
-    params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=max_quant_w8"
+    context:
+      partition: max_quant_w8
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant_mqpar/.*:
     cores: 16
-    params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=max_quant_w8"
+    context:
+      partition: max_quant_w8
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant_mqpar/maxquant_mqpar/.*:
     cores: 16
-    params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=max_quant_w8"
+    context:
+      partition: max_quant_w8
   toolshed.g2.bx.psu.edu/repos/iuc/barrnap/barrnap/.*:
     rules:
     - if: input_size >= 0.0003
@@ -1333,25 +1333,38 @@ tools:
 
   # alphafold
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
-    cores: 6
-    mem: 106
-    params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=azuregpu1"
-      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=azuregpu1"
-      docker_enabled: true
-      docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro'
-      docker_memory: '{mem}G'
-      docker_sudo: false
-      require_container: true
-      docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=16 --env ALPHAFOLD_AA_LENGTH_MAX=3000"
-      docker_set_user: '1000'
-    scheduling:
-      require:
-        - pulsar
-        - pulsar-azure-gpu
     rules:
       - if: |
-          not user or 'Alphafold' not in [role.name for role in user.all_roles() if not role.deleted]
+          user and 'Alphafold' in [role.name for role in user.all_roles if not role.deleted]
+        cores: 6
+        mem: 106
+        context:
+          partition: azuregpu1
+        params:
+          docker_enabled: true
+          docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=16 --env ALPHAFOLD_AA_LENGTH_MAX=3000"
+        scheduling:
+          require:
+            - pulsar
+            - pulsar-azure-gpu
+      - if: |
+          user and 'UoM_Vet_Alphafold' in [role.name for role in user.all_roles if not role.deleted]
+        cores: 8
+        mem: 69
+        context:
+          partition: azuregpu1
+        params:
+          docker_enabled: true
+          docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=16 --env ALPHAFOLD_AA_LENGTH_MAX=3000"
+        scheduling:
+          require:
+            - pulsar
+            - pulsar-azure-1-gpu
+      - if: |
+          not user or not any([
+            role for role in user.all_roles() if (
+              role.name in ['Alphafold', 'UoM_Vet_Alphafold'] and not role.deleted
+          )])
         fail: |
           This tool is currently being beta-tested on GPUs and your account has not been given access. Contact help@genome.edu.au if you think this is in error.
   # Peptide shaker and other galaxyP tools

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1335,7 +1335,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
     rules:
       - if: |
-          user and 'Alphafold' in [role.name for role in user.all_roles if not role.deleted]
+          user and 'Alphafold' in [role.name for role in user.all_roles() if not role.deleted]
         cores: 6
         mem: 106
         context:
@@ -1348,7 +1348,7 @@ tools:
             - pulsar
             - pulsar-azure-gpu
       - if: |
-          user and 'UoM_Vet_Alphafold' in [role.name for role in user.all_roles if not role.deleted]
+          user and 'UoM_Vet_Alphafold' in [role.name for role in user.all_roles() if not role.deleted]
         cores: 8
         mem: 69
         context:

--- a/templates/galaxy/toolbox/filters/ga_filters.py.j2
+++ b/templates/galaxy/toolbox/filters/ga_filters.py.j2
@@ -12,9 +12,13 @@ def hide_test_tools(context, tool):
 
 def restrict_alphafold(context, tool):
     """
-    Only let GA team and alphafold beta users see alphafold
+    Only let GA team, alphafold beta users and UoM vet school alphafold users see alphafold
     """
     if tool.id.startswith('toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold'):
         user = context.trans.user
-        return user is not None and (user.email in test_tool_users or 'Alphafold' in [role.name for role in user.all_roles() if not role.deleted])
+        return user is not None and (
+            user.email in test_tool_users or any([
+                role for role in user.all_roles() if (
+                    role.name in ['Alphafold', 'UoM_Vet_Alphafold'] and not role.deleted
+        )]))
     return True


### PR DESCRIPTION
Changes for new alphafold pulsar and group 'UoM_Vet_Alphafold'

I believe that if a user is a member of both 'Alphafold' and 'UoM_Vet_Alphafold' then the last matching rule will apply and their jobs will go to the 'UoM_Vet_Alphafold' pulsar.

The toolbox filter will require a playbook run in order to work for members of 'UoM_Vet_Alphafold' that are not already members of 'Alphafold'.