### PR TITLE
Fix alphafold rule for members of both groups

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1335,7 +1335,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
     rules:
       - if: |
-          user and 'Alphafold' in [role.name for role in user.all_roles() if not role.deleted]
+          user and 'Alphafold' in [role.name for role in user.all_roles() if not role.deleted] and not (
+            'UoM_Vet_Alphafold' in [role.name for role in user.all_roles() if not role.deleted]
+          )
         cores: 6
         mem: 106
         context:


### PR DESCRIPTION
As a member of both groups I cannot run alphafold