### PR TITLE
Add volume to staging-w1

### DIFF
--- a/group_vars/staging_workers.yml
+++ b/group_vars/staging_workers.yml
@@ -3,6 +3,12 @@ slurm_roles: ['exec']
 add_hosts_head: yes
 add_hosts_galaxy: yes
 
+attached_volumes:
+  - device: /dev/vdb
+    path: /mnt
+    fstype: ext4
+    partition: 1
+
 shared_mounts:
     - path: /mnt/galaxy
       src: staging:/mnt/galaxy
@@ -13,3 +19,5 @@ shared_mounts:
 docker_install_compose: false
 docker_users:
   - "{{ galaxy_user.name }}"
+docker_daemon_options:
+  data-root: /mnt/docker-data

--- a/staging-workers_playbook.yml
+++ b/staging-workers_playbook.yml
@@ -7,6 +7,10 @@
       - group_vars/staging_slurm.yml
       - group_vars/staging_workers.yml
       - secret_group_vars/stats_server_vault
+  pre_tasks:
+      - name: Attach volume to instance
+        include_role:
+          name: attached-volumes
   roles:
       - common
       - insspb.hostname
@@ -25,3 +29,30 @@
         systemd:
             name: munge
             state: restarted
+      - name: Move /tmp to /mnt
+        block:
+          - name: Create worker tmpdir on /mnt
+            file:
+                path: /mnt/tmpdisk
+                state: directory
+                owner: root
+                group: root
+                mode: '1777'
+          - name: stat links
+            stat:
+                path: /tmp
+            register: links
+          - name: remove old tmp
+            file:
+                path: /tmp
+                state: absent
+            when: links.stat.islnk is defined and not links.stat.islnk
+          - name: Link /tmp to /mnt/tmpdisk
+            file:
+                src: /mnt/tmpdisk
+                dest: /tmp
+                state: link
+            become: yes
+            become_user: root
+            when: links.stat.islnk is defined and not links.stat.islnk
+        when: attached_volumes is defined

--- a/terraform/staging/staging-initial.tf
+++ b/terraform/staging/staging-initial.tf
@@ -1,7 +1,19 @@
+# August 3, 2022
+# The state file is somehow out of whack for this project and calls to `terraform plan` result in terraform planning
+# to double up the VMs that already exist in the state
+# This could be fixed by:
+# (1) throwing away the state file
+# (2) using `terraform import` to repopulate the state file with the existing instances/volumes/attachments
+# (3) deleting the custom security groups and using "default" instead
+# instances to reimport are
+# - VMs: staging, staging-db, staging-pulsar, staging-queue, staging-w1
+# - Volumes: 1200 for staging, 100 for staging-w1
+# - Attachments between VMs and volumes
+
 # staging database
 resource "openstack_compute_instance_v2" "staging-db" {
   name            = "staging-db"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "m3.small"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-staging-db.name}"]
@@ -11,7 +23,7 @@ resource "openstack_compute_instance_v2" "staging-db" {
 # application server / web server
 resource "openstack_compute_instance_v2" "staging" {
   name            = "staging"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "m3.large"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "Web-Services", "${openstack_networking_secgroup_v2.galaxy-staging.name}", "${openstack_networking_secgroup_v2.galaxy-staging-db.name}"]
@@ -21,7 +33,7 @@ resource "openstack_compute_instance_v2" "staging" {
 # slurm / rabbitMQ
 resource "openstack_compute_instance_v2" "staging-queue" {
   name            = "staging-queue"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "m3.small"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "Web-Services", "rabbitmq", "${openstack_networking_secgroup_v2.galaxy-staging.name}"]
@@ -31,7 +43,7 @@ resource "openstack_compute_instance_v2" "staging-queue" {
 # slurm worker
 resource "openstack_compute_instance_v2" "staging-w1" {
   name            = "staging-w1"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "m3.large"  # intended to be c3.xlarge
   key_pair        = "galaxy-australia"
   security_groups = ["SSH", "${openstack_networking_secgroup_v2.galaxy-staging.name}"]
@@ -41,7 +53,7 @@ resource "openstack_compute_instance_v2" "staging-w1" {
 # pulsar test server
 resource "openstack_compute_instance_v2" "staging-pulsar" {
   name            = "staging-pulsar"
-  image_name      = "NeCTAR Ubuntu 20.04 LTS (Focal) amd64"
+  image_id        = "f8b79936-6616-4a22-b55d-0d0a1d27bceb"
   flavor_name     = "r3.large"
   key_pair        = "galaxy-australia"
   security_groups = ["SSH"]


### PR DESCRIPTION
Add a 100G volume at /dev/vdb on staging-w1
Terraform was not used - I've written a note in staging-initial-tf.  For some reason terraform is not seeing that the VMs exist despite their being in the state file.  I might need to throw it out and repopulate it using `terraform import`.