### PR TITLE
changed cores from 16 to 8 for mafft and pulsar scheduling from accep…

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1060,9 +1060,9 @@ tools:
     - if: input_size >= 60
       fail: Too much data, please don't use Spades for this
   toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/.*:
-    cores: 16
+    cores: 8
     scheduling:
-      accept:
+      prefer:
       - pulsar
     rules:
     - if: input_size >= 0.5


### PR DESCRIPTION
Mafft was hogging too much resources on slurm even though it usually only uses a single core most of the time - not very parallel.
