### PR TITLE
Set tmp_dir: True for all destinations, meaning temp files will be in subdirectories of the job working directories

### DIFF
--- a/templates/galaxy/config/aarnet_job_conf.yml.j2
+++ b/templates/galaxy/config/aarnet_job_conf.yml.j2
@@ -175,6 +175,7 @@ execution:
       type: dtd
     interactive_pulsar:
       runner: pulsar_embedded
+      tmp_dir: True
       docker_enabled: true
       docker_volumes: $defaults
       docker_sudo: false
@@ -187,6 +188,7 @@ execution:
       submit_native_specification: "--nodes=1 --ntasks=2 --ntasks-per-node=2 --mem=7760 --partition=interactive_tools"
     slurm:
       runner: slurm
+      tmp_dir: True
       nativeSpecification: --nodes=1 --ntasks=32 --ntasks-per-node=32 --mem=124160 --partition=main
       singularity_enabled: false
       singularity_volumes: '{{ slurm_singularity_volumes }}'
@@ -196,6 +198,7 @@ execution:
       docker_volumes: '{{ slurm_docker_volumes }}'
     slurm-training:
       runner: slurm
+      tmp_dir: True
       nativeSpecification: --nodes=1 --ntasks=16 --ntasks-per-node=16 --mem=62080 --partition=training
       singularity_enabled: false
       singularity_volumes: '{{ slurm_singularity_volumes }}'
@@ -205,6 +208,7 @@ execution:
       docker_volumes: '{{ slurm_docker_volumes }}'
     pulsar-mel2:
       runner: pulsar_mel2_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -231,6 +235,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-paw:
       runner: pulsar-paw_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -257,6 +262,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-mel3:
       runner: pulsar-mel3_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -283,6 +289,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-high-mem1:
       runner: pulsar-high-mem1_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -309,6 +316,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-high-mem2:
       runner: pulsar-high-mem2_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -335,6 +343,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-high-mem0:
       runner: pulsar-qld-high-mem0_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -361,6 +370,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-high-mem1:
       runner: pulsar-qld-high-mem1_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -387,6 +397,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-high-mem2:
       runner: pulsar-qld-high-mem2_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -413,6 +424,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-nci-training:
       runner: pulsar-nci-training_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -439,6 +451,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-qld-blast:
       runner: pulsar-qld-blast_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -465,6 +478,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-QLD:
       runner: pulsar-QLD_runner
+      tmp_dir: True
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -491,6 +505,7 @@ execution:
           value: /mnt/pulsar/deps/singularity/tmp
     pulsar-azure:
       runner: pulsar_azure_0_runner
+      tmp_dir: True
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: "false"
@@ -502,6 +517,7 @@ execution:
       submit_native_specification: "--nodes=1 --ntasks=6 --ntasks-per-node=6 --mem=110000"
     pulsar-azure-gpu:
       runner: pulsar_azure_0_runner
+      tmp_dir: True
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: "false"
@@ -517,6 +533,7 @@ execution:
       require_container: true
     pulsar-azure-1:
       runner: pulsar_azure_1_runner
+      tmp_dir: True
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: "false"
@@ -528,6 +545,7 @@ execution:
       submit_native_specification: "--nodes=1 --ntasks=24 --ntasks-per-node=24 --mem=212000"
     pulsar-azure-1-gpu:
       runner: pulsar_azure_1_runner
+      tmp_dir: True
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: "false"


### PR DESCRIPTION
At the moment this is used for `__DATA_FETCH__` which means that tool no longer causes the worker tmp disks to overflow.

I can't think of what could go wrong with this, however

@Slugger70 would there be a greater overhead for the workers storing temp things on the NFS mounts instead of on the mounted /mnt/tmpdisk disks?