### PR TITLE
Fix container_resolvers for pulsars in job conf

### DIFF
--- a/templates/galaxy/config/aarnet_job_conf.yml.j2
+++ b/templates/galaxy/config/aarnet_job_conf.yml.j2
@@ -223,7 +223,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -249,7 +249,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -275,7 +275,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -301,7 +301,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -327,7 +327,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -353,7 +353,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -379,7 +379,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -405,7 +405,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -431,7 +431,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -457,7 +457,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -483,7 +483,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity

--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -109,7 +109,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity
@@ -135,7 +135,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity

--- a/templates/galaxy/config/staging_job_conf.yml.j2
+++ b/templates/galaxy/config/staging_job_conf.yml.j2
@@ -71,7 +71,7 @@ execution:
       singularity_default_container_id: '{{ singularity_default_container_id }}'
       container_resolvers: 
         - type: explicit_singularity
-        - type: cached_mulled_singularity
+        - type: mulled_singularity
       env:
         - name: SINGULARITY_CACHEDIR
           value: /mnt/pulsar/deps/singularity


### PR DESCRIPTION
The container_resolvers overrides in pulsar destination parameters should have entries for `mulled_singularity` instead of `cached_mulled_singularity` now that containers are not being sourced from cvmfs.