### PR TITLE
fix missing closing tag in object store config

### DIFF
--- a/files/galaxy/config/pawsey_object_store_conf.xml
+++ b/files/galaxy/config/pawsey_object_store_conf.xml
@@ -18,6 +18,7 @@
         </backend>
         <backend id="NFS" type="disk" order="6">
             <files_dir path="/mnt/files2" />
+        </backend>
         <backend id="loadtest" type="disk" order="0">
 		<files_dir path="/mnt/user-data/load-test" />
         </backend>


### PR DESCRIPTION
added missing tag in pawsey_object_store_conf.xml