### PR TITLE
Add cached_explicit_singularity to container_resolvers

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -224,6 +224,8 @@ group_galaxy_config:
 
     container_resolvers:
       - type: explicit
+      - type: cached_explicit_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
       - type: explicit_singularity
         cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
       - type: cached_mulled_singularity


### PR DESCRIPTION
The cached_explicit_singularity resolver is new as of release_22.01. Before this, the explicit singularity containers were not being stored.