### PR TITLE
Run busco and cuffdiff with singularity, reduce rnastar cores to 8

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -301,6 +301,17 @@ tools:
     params:
       singularity_enabled: True
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
+  toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/.*:
+    # context:
+    #   minimum_singularity_version: 5.0.0+galaxy0  # not working, ref https://github.com/galaxyproject/total-perspective-vortex/pull/32
+    rules:
+      - if: |
+          import packaging.version
+          minimum_singularity_version = '5.0.0+galaxy0'
+          packaging.version.parse(tool.version) >= packaging.version.parse(minimum_singularity_version)
+        params:
+          singularity_enabled: true
+          dependency_resolution: none
 
 users:
   default: {}

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -704,6 +704,16 @@ tools:
       cores: 4
     - if: input_size >= 1
       cores: 8
+  toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/.*:
+    scheduling:
+      accept:
+      - pulsar
+    params:
+      singularity_enabled: True
+      dependency_resolution: none
+    rules:
+    - if: 2 <= input_size
+      cores: 4    
   toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/.*:
     cores: 2
     scheduling:
@@ -959,7 +969,7 @@ tools:
         accept:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/.*:
-    cores: 12
+    cores: 8
     scheduling:
       accept:
       - pulsar
@@ -1160,9 +1170,14 @@ tools:
     scheduling:
       accept:
       - pulsar
-      reject:
-      - pulsar-mel2
     rules:
+    - if: |
+        import packaging.version
+        minimum_singularity_version = '5.0.0+galaxy0'
+        packaging.version.parse(tool.version) >= packaging.version.parse(minimum_singularity_version)
+      params:
+        singularity_enabled: true
+        dependency_resolution: none
     - if: 0.05 <= input_size < 0.3
       cores: 8
     - if: input_size >= 0.3

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
@@ -46,6 +46,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_export/cactus_export/.*:
     params:
       singularity_enabled: True
+  toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/.*:
+    params:
+      singularity_enabled: True
 
 destinations:
   slurm:


### PR DESCRIPTION
All busco 5 versions can run with singularity containers.  This has been tested on slurm and most of the pulsars with the latest version of busco and the tests are OK.

Add tpv rules for cuffdiff, also singularity_enabled and OK on pulsar.

Reduce rna_star cores from 12 to 8.  It was increased to 12 a few months ago to solve a problem that turned out to be due to squid+cvmfs, so the increase was not necessary.