### PR TITLE
Extend toolbox filter for test tools

### DIFF
--- a/aarnet_playbook.yml
+++ b/aarnet_playbook.yml
@@ -52,11 +52,13 @@
     - galaxy-pg-cleanup
     - usegalaxy_eu.tiaas2
   post_tasks:
-    - name: Clone galaxy-local-tools
-      git:
-        repo: https://github.com/usegalaxy-au/galaxy-local-tools
-        dest: "{{ galaxy_server_dir }}/tools/galaxy-local-tools"
-        update: yes
+    - name: Make local_tool directory group-writable by machine users
+      file:
+        path: "{{ galaxy_root }}/local_tools"
+        owner: root
+        group: devs
+        mode: 0775
+        state: directory
     - name: Install slurm-drmaa
       package:
         name: slurm-drmaa1

--- a/aarnet_update_configs_playbook.yml
+++ b/aarnet_update_configs_playbook.yml
@@ -34,6 +34,12 @@
         dest: "{{ galaxy_config_dir }}/object_store_conf.xml"
       notify: Restart Galaxy
       when: not ansible_user == 'jenkins_bot'  # do not let the automatic process object store or restart galaxy
+    - name: template toolbox filters
+      template:
+        src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2"
+        dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
+      notify: Restart Galaxy
+      when: not ansible_user == 'jenkins_bot'  # do not let the automatic process object store or restart galaxy
     - name: copy total perspective vortex files
       copy:
         src: "{{ galaxy_dynamic_job_rules_src_dir }}/total_perspective_vortex/{{ item }}"

--- a/aarnet_update_configs_playbook.yml
+++ b/aarnet_update_configs_playbook.yml
@@ -39,7 +39,7 @@
         src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2"
         dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
       notify: Restart Galaxy
-      when: not ansible_user == 'jenkins_bot'  # do not let the automatic process object store or restart galaxy
+      when: not ansible_user == 'jenkins_bot'  # do not let the automatic process restart galaxy
     - name: copy total perspective vortex files
       copy:
         src: "{{ galaxy_dynamic_job_rules_src_dir }}/total_perspective_vortex/{{ item }}"

--- a/templates/galaxy/toolbox/filters/ga_filters.py.j2
+++ b/templates/galaxy/toolbox/filters/ga_filters.py.j2
@@ -1,12 +1,26 @@
 test_tool_users = ["{{ test_tool_users | join('", "') }}"]
 test_tool_label = "test"
 
+test_tools = [
+    {
+        'id': 'maxquant_test',
+        'role': 'maxquant_test',
+    },
+]
+
 def hide_test_tools(context, tool):
     """
     hide tools with 'test' tag from all but selected_users
     """
     if hasattr(tool, 'labels') and test_tool_label in tool.labels:
         user = context.trans.user
+        for test_tool in test_tools:
+            if tool.id == test_tool['id']:
+                return user is not None and (
+                    user.email in test_tool_users or test_tool['role'] in [
+                        r.name for r in user.all_roles() if not r.deleted
+                    ]
+                )
         return user is not None and user.email in test_tool_users
     return True
 
@@ -22,3 +36,4 @@ def restrict_alphafold(context, tool):
                     role.name in ['Alphafold', 'UoM_Vet_Alphafold'] and not role.deleted
         )]))
     return True
+

--- a/templates/galaxy/toolbox/filters/test_ga_filters.py
+++ b/templates/galaxy/toolbox/filters/test_ga_filters.py
@@ -1,29 +1,9 @@
 from collections import namedtuple
 
-test_tool_users=['carrot@email.org']
+# contents of ga.filters.py here
+
+test_tool_users=['carrot@email.org'] # substituted
 test_tool_label = "test"
-
-Tool = namedtuple('Tool', ['id', 'labels'])
-context = namedtuple('context', ['trans'])
-transaction = namedtuple('transaction', 'user')
-User = namedtuple('User', ['all_roles', 'email'])
-Role = namedtuple('Role', ['name', 'deleted'])
-
-role1 = Role('Alphafold', False)
-role2 = Role('UoM_Vet_Alphafold', False)
-role3 = Role('some_role', False)
-
-user1 = User(lambda: [role1, role2], 'amy@email.org')
-user2 = User(lambda: [], 'amy@email.org')
-
-trans1 = transaction(user1)
-trans2 = transaction(user2)
-
-context1 = context(trans1)
-context2 = context(trans2)
-
-tool1 = Tool('toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold', [])
-tool2 = Tool('anything_but_alphafold', [])
 
 def restrict_alphafold(context, tool):
     """
@@ -38,26 +18,6 @@ def restrict_alphafold(context, tool):
         )]))
     return True
 
-assert restrict_alphafold(context1, tool1) == True  # if tool is alphafold and user is in groups, tool is visible
-assert restrict_alphafold(context2, tool1) == False  # if tool is alphafold and user not in groups, tool is not visible
-assert restrict_alphafold(context1, tool2) == True  # any tool other than alphafold is visible
-
-roleA = Role('maxquant_test', False)
-
-userA = User(lambda: [roleA], 'amy@email.org')
-userB = User(lambda: [], 'amy@email.org')
-userC = User(lambda: [], 'carrot@email.org')
-
-transA = transaction(userA)
-transB = transaction(userB)
-transC = transaction(userC)
-
-contextA = context(transA)
-contextB = context(transB)
-contextC = context(transC)
-
-toolA = Tool('maxquant_test', ['test'])
-toolB = Tool('something_else', ['test'])
 
 test_tools = [
     {
@@ -81,6 +41,65 @@ def hide_test_tools(context, tool):
                 )
         return user is not None and user.email in test_tool_users
     return True
+
+def restrict_alphafold(context, tool):
+    """
+    Only let GA team, alphafold beta users and UoM vet school alphafold users see alphafold
+    """
+    if tool.id.startswith('toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold'):
+        user = context.trans.user
+        return user is not None and (
+            user.email in test_tool_users or any([
+                role for role in user.all_roles() if (
+                    role.name in ['Alphafold', 'UoM_Vet_Alphafold'] and not role.deleted
+        )]))
+    return True
+
+# end contents of ga.filters.py here
+
+Tool = namedtuple('Tool', ['id', 'labels'])
+context = namedtuple('context', ['trans'])
+transaction = namedtuple('transaction', 'user')
+User = namedtuple('User', ['all_roles', 'email'])
+Role = namedtuple('Role', ['name', 'deleted'])
+
+role1 = Role('Alphafold', False)
+role2 = Role('UoM_Vet_Alphafold', False)
+role3 = Role('some_role', False)
+
+user1 = User(lambda: [role1, role2], 'amy@email.org')
+user2 = User(lambda: [], 'amy@email.org')
+
+trans1 = transaction(user1)
+trans2 = transaction(user2)
+
+context1 = context(trans1)
+context2 = context(trans2)
+
+tool1 = Tool('toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold', [])
+tool2 = Tool('anything_but_alphafold', [])
+
+assert restrict_alphafold(context1, tool1) == True  # if tool is alphafold and user is in groups, tool is visible
+assert restrict_alphafold(context2, tool1) == False  # if tool is alphafold and user not in groups, tool is not visible
+assert restrict_alphafold(context1, tool2) == True  # any tool other than alphafold is visible
+
+
+roleA = Role('maxquant_test', False)
+
+userA = User(lambda: [roleA], 'amy@email.org')
+userB = User(lambda: [], 'amy@email.org')
+userC = User(lambda: [], 'carrot@email.org')
+
+transA = transaction(userA)
+transB = transaction(userB)
+transC = transaction(userC)
+
+contextA = context(transA)
+contextB = context(transB)
+contextC = context(transC)
+
+toolA = Tool('maxquant_test', ['test'])
+toolB = Tool('something_else', ['test'])
 
 assert hide_test_tools(contextA, toolA) == True
 assert hide_test_tools(contextB, toolA) == False

--- a/templates/galaxy/toolbox/filters/test_ga_filters.py
+++ b/templates/galaxy/toolbox/filters/test_ga_filters.py
@@ -1,0 +1,90 @@
+from collections import namedtuple
+
+test_tool_users=['carrot@email.org']
+test_tool_label = "test"
+
+Tool = namedtuple('Tool', ['id', 'labels'])
+context = namedtuple('context', ['trans'])
+transaction = namedtuple('transaction', 'user')
+User = namedtuple('User', ['all_roles', 'email'])
+Role = namedtuple('Role', ['name', 'deleted'])
+
+role1 = Role('Alphafold', False)
+role2 = Role('UoM_Vet_Alphafold', False)
+role3 = Role('some_role', False)
+
+user1 = User(lambda: [role1, role2], 'amy@email.org')
+user2 = User(lambda: [], 'amy@email.org')
+
+trans1 = transaction(user1)
+trans2 = transaction(user2)
+
+context1 = context(trans1)
+context2 = context(trans2)
+
+tool1 = Tool('toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold', [])
+tool2 = Tool('anything_but_alphafold', [])
+
+def restrict_alphafold(context, tool):
+    """
+    Only let GA team, alphafold beta users and UoM vet school alphafold users see alphafold
+    """
+    if tool.id.startswith('toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold'):
+        user = context.trans.user
+        return user is not None and (
+            user.email in test_tool_users or any([
+                role for role in user.all_roles() if (
+                    role.name in ['Alphafold', 'UoM_Vet_Alphafold'] and not role.deleted
+        )]))
+    return True
+
+assert restrict_alphafold(context1, tool1) == True  # if tool is alphafold and user is in groups, tool is visible
+assert restrict_alphafold(context2, tool1) == False  # if tool is alphafold and user not in groups, tool is not visible
+assert restrict_alphafold(context1, tool2) == True  # any tool other than alphafold is visible
+
+roleA = Role('maxquant_test', False)
+
+userA = User(lambda: [roleA], 'amy@email.org')
+userB = User(lambda: [], 'amy@email.org')
+userC = User(lambda: [], 'carrot@email.org')
+
+transA = transaction(userA)
+transB = transaction(userB)
+transC = transaction(userC)
+
+contextA = context(transA)
+contextB = context(transB)
+contextC = context(transC)
+
+toolA = Tool('maxquant_test', ['test'])
+toolB = Tool('something_else', ['test'])
+
+test_tools = [
+    {
+        'id': 'maxquant_test',
+        'role': 'maxquant_test',
+    },
+]
+
+def hide_test_tools(context, tool):
+    """
+    hide tools with 'test' tag from all but selected_users
+    """
+    if hasattr(tool, 'labels') and test_tool_label in tool.labels:
+        user = context.trans.user
+        for test_tool in test_tools:
+            if tool.id == test_tool['id']:
+                return user is not None and (
+                    user.email in test_tool_users or test_tool['role'] in [
+                        r.name for r in user.all_roles() if not r.deleted
+                    ]
+                )
+        return user is not None and user.email in test_tool_users
+    return True
+
+assert hide_test_tools(contextA, toolA) == True
+assert hide_test_tools(contextB, toolA) == False
+assert hide_test_tools(contextC, toolA) == True
+assert hide_test_tools(contextA, toolB) == False
+assert hide_test_tools(contextB, toolB) == False
+assert hide_test_tools(contextC, toolB) == True


### PR DESCRIPTION
Stop cloning galaxy-local-tools/tools-au because it hasn't been useful.  If needed, individual users can clone it into /mnt/galaxy/local_tools which will be made writable by all machine users.

Extend the test_tool_user filter for allowing non-admin users access to test tools
We can define a list of id/role combinations
```
    {
        'id': 'maxquant_test',
        'role': 'maxquant_test',
    },
```

which will extend the visibility of tool with the 'test' label to anyone with a role, for a given tool id.

Add a test file for the toolbox filters.  This is checking the logic but mostly it is checking that the code runs.