### PR TITLE
Dev distributed object store

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -61,6 +61,7 @@
       with_items:
         - /mnt/galaxy/data
         - /mnt/galaxy/data-2
+        - /mnt/galaxy/data-3
     - name: Make local_tool directory group-writable by machine users
       file:
         path: /mnt/galaxy/local_tools

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -48,7 +48,7 @@ galaxy_tus_upload_store: "{{ galaxy_tmp_dir }}/tus"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_22.01
 
-galaxy_file_path: "{{ galaxy_root }}/data-2"
+galaxy_file_path: "{{ galaxy_root }}/data-3"
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"

--- a/scripts/set_object_store_id.py
+++ b/scripts/set_object_store_id.py
@@ -34,11 +34,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--path', help='file path')
     parser.add_argument('-i', '--id', help='object store id')
+    parser.add_argument('-y', '--yes', action='store_true', help='skip confirmation, just do it')
     args = parser.parse_args()
 
-    answer = input(f"Set all datasets in {args.path} to have object_store_id {args.id}: Type y/yes to and enter to continue: ")
-    if not answer in ['y', 'yes']:
-        raise Exception()
+    if not args.yes:
+        answer = input(f"Set all datasets in {args.path} to have object_store_id {args.id}: Type y/yes to and enter to continue: ")
+        if not answer in ['y', 'yes']:
+            raise Exception()
 
     counter = 0
     temp_data = []

--- a/scripts/set_object_store_id.py
+++ b/scripts/set_object_store_id.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+"""
+Script to set object_store_id of each dataset and metadata_file in the database.  When using a hierarchical
+object store this field is not set.  When using a distributed object store each dataset needs to have an
+object_store_id corresponding to the id of the backend in the object store, i.e:
+    `<backend id="dev_objects_1" type="disk" weight="0" store_by="id">
+        <files_dir path="/mnt/galaxy/data" />
+    </backend>`
+Usage: To set object_store_id to "dev_objects_1" for all items in /mnt/galaxy/data, run
+$ python set_object_store_id.py --path /mnt/galaxy/data --id dev_objects_1
+"""
+
+def update_dataset_object_store_ids(temp_data, object_store_id, counter):
+    dataset_ids = ','.join([y['id'] for y in temp_data])
+    command = f'psql -c "update dataset set object_store_id = \'{object_store_id}\' where id in ({dataset_ids});"'
+    # print(command)
+    response_code = subprocess.call(command, shell = True)
+    print(f'updated {counter} datasets, response code {response_code}')
+
+def update_metadata_file_object_store_ids(temp_data, object_store_id, counter):
+    metadata_ids = ','.join([y['id'] for y in temp_data])
+    command = f'psql -c "update metadata_file set object_store_id = \'{object_store_id}\' where id in ({metadata_ids});"'
+    # print(command)
+    response_code = subprocess.call(command, shell = True)
+    print(f'updated {counter} metadata files, response code {response_code}')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--path', help='file path')
+    parser.add_argument('-i', '--id', help='object store id')
+    args = parser.parse_args()
+
+    answer = input(f"Set all datasets in {args.path} to have object_store_id {args.id}: Type y/yes to and enter to continue: ")
+    if not answer in ['y', 'yes']:
+        raise Exception()
+
+    counter = 0
+    temp_data = []
+
+    for i in pathlib.Path(args.path).glob('**/dataset_*.dat'):
+        counter += 1
+        test = re.search("dataset_(\d+).dat", str(i))
+        if hasattr(test, 'group'):
+            id = test.group(1)
+        else:
+            continue
+        temp_data.append({'id': id, 'path': str(i)})
+        if counter % 1000 == 0:
+            update_dataset_object_store_ids(temp_data=temp_data, object_store_id=args.id, counter=counter)
+            temp_data = []
+    # update object store ids for whatever remains
+    update_dataset_object_store_ids(temp_data=temp_data, object_store_id=args.id, counter=counter)
+
+    counter = 0
+    temp_data = []
+    for i in pathlib.Path(args.path).glob('**/metadata_*.dat'):
+        counter += 1
+        test = re.search("metadata_(\d+).dat", str(i))
+        if hasattr(test, 'group'):
+            id = test.group(1)
+        else:
+            continue
+        temp_data.append({'id': id, 'path': str(i)})
+        if counter % 1000 == 0:
+            update_metadata_file_object_store_ids(temp_data=temp_data, object_store_id=args.id, counter=counter)
+            temp_data = []
+    # update object store ids for whatever remains
+    update_metadata_file_object_store_ids(temp_data=temp_data, object_store_id=args.id, counter=counter)
+
+if __name__ == '__main__':
+    main()

--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -94,6 +94,7 @@ execution:
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: 'false'
+      metadata_strategy: 'extended'
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -120,6 +121,7 @@ execution:
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: 'false'
+      metadata_strategy: 'extended'
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote

--- a/templates/galaxy/config/dev_object_store_conf.xml.j2
+++ b/templates/galaxy/config/dev_object_store_conf.xml.j2
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
-<object_store type="hierarchical">
-    <backends>
-        <backend id="dev_objects_2" type="disk" order="0">
+<object_store type="distributed" id="primary" order="0">
+    <backends search_for_missing="false">
+        <backend id="dev_objects_2" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/galaxy/data-2" />
         </backend>
-        <backend id="dev_objects_1" type="disk" order="1">
+        <backend id="dev_objects_1" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/galaxy/data" />
+        </backend>
+        <backend id="dev_objects_3" type="disk" weight="1" store_by="uuid">
+            <files_dir path="/mnt/galaxy/data-3" />
         </backend>
     </backends>
 </object_store>


### PR DESCRIPTION
Dev object store has been changed from hierarchical to distributed, with new objects stored by uuid.  There is also a script for updating dataset and metadata_file database objects to have object_store_id values which is needed when migrating to the distributed object store.