### PR TITLE
Common ansible env for jenkins jobs, add config_backup playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vault_password
 venv
 ansible.cfg
-ansible_config_backup/*
 terraform/terraform*
 terraform/.terraform
 terraform/prod/.terraform

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vault_password
 venv
 ansible.cfg
+ansible_config_backup/*
 terraform/terraform*
 terraform/.terraform
 terraform/prod/.terraform

--- a/jenkins/config_backup/config_backup_playbook.yml
+++ b/jenkins/config_backup/config_backup_playbook.yml
@@ -1,0 +1,79 @@
+- hosts:
+    - aarnet
+    - staging
+    - dev
+  become: true
+  pre_tasks:
+    - name: Copy files from /mnt/galaxy/var
+      fetch:
+        flat: yes
+        fail_on_missing: no
+        src: "/mnt/galaxy/var/{{ item }}"
+        dest: "configs/{{ ansible_hostname }}/var/"
+      with_items:
+        - integrated_tool_panel.xml
+        - migrated_tools_conf.xml
+        - sanitize_allowlist.txt
+        - shed_data_manager_conf.xml
+        - shed_tool_conf.xml
+        - shed_tool_data_table_conf.xml
+        - galaxy_install_db.sqlite
+    - name: Copy files from /mnt/galaxy/config
+      fetch:
+        flat: yes
+        fail_on_missing: no
+        src: "/mnt/galaxy/config/{{ item }}"
+        dest: "configs/{{ ansible_hostname }}/config/"
+      with_items:
+        - build_sites.yml
+        - galaxy.yml
+        - job_conf.yml
+        - object_store_conf.xml
+        - nagios_tool_conf.xml
+        - reports.yml
+        - tool_conf.xml
+        - tool_sheds_conf.xml
+        - user_preferences_extra_conf.yml
+    - name: Check for tiaas dir
+      stat:
+        path: /opt/tiaas
+      register: tiaas_dir
+    - name: Copy tiaas db
+      fetch:
+        flat: yes
+        fail_on_missing: no
+        src: "/opt/tiaas/{{ item }}"
+        dest: "configs/{{ ansible_hostname }}/tiaas/"
+      with_items:
+        - db.sqlite3
+      when: tiaas_dir.stat.exists
+
+- hosts:
+    - pulsar-mel2
+    - pulsar-mel3
+    - pulsar-QLD
+    - pulsar-paw
+    - pulsar-nci-training
+    - pulsar-qld-blast
+    - pulsar-high-mem1
+    - pulsar-high-mem2
+    - qld-pulsar-himem-0
+    - qld-pulsar-himem-1
+    - qld-pulsar-himem-2
+    - dev-pulsar
+    - staging-pulsar
+    - pulsar-nci-test
+    # TODO: allow jenkins_bot to log into azure pulsars and add them to this list
+  become: yes
+  pre_tasks:
+    - name: Copy files from /mnt/pulsar/config
+      fetch:
+        flat: yes
+        fail_on_missing: no
+        src: "/mnt/pulsar/config/{{ item }}"
+        dest: "configs/{{ ansible_hostname }}/config/"
+      with_items:
+        - app.yml
+        - job_metrics_conf.yml
+        - local_env.sh
+        - server.ini

--- a/jenkins/config_backup/config_backup_playbook.yml
+++ b/jenkins/config_backup/config_backup_playbook.yml
@@ -9,7 +9,7 @@
         flat: yes
         fail_on_missing: no
         src: "/mnt/galaxy/var/{{ item }}"
-        dest: "configs/{{ ansible_hostname }}/var/"
+        dest: "{{ backup_dir }}/{{ ansible_hostname }}/var/"
       with_items:
         - integrated_tool_panel.xml
         - migrated_tools_conf.xml
@@ -23,7 +23,7 @@
         flat: yes
         fail_on_missing: no
         src: "/mnt/galaxy/config/{{ item }}"
-        dest: "configs/{{ ansible_hostname }}/config/"
+        dest: "{{ backup_dir }}/{{ ansible_hostname }}/config/"
       with_items:
         - build_sites.yml
         - galaxy.yml
@@ -43,7 +43,7 @@
         flat: yes
         fail_on_missing: no
         src: "/opt/tiaas/{{ item }}"
-        dest: "configs/{{ ansible_hostname }}/tiaas/"
+        dest: "{{ backup_dir }}/{{ ansible_hostname }}/tiaas/"
       with_items:
         - db.sqlite3
       when: tiaas_dir.stat.exists
@@ -71,7 +71,7 @@
         flat: yes
         fail_on_missing: no
         src: "/mnt/pulsar/config/{{ item }}"
-        dest: "configs/{{ ansible_hostname }}/config/"
+        dest: "{{ backup_dir }}/{{ ansible_hostname }}/config/"
       with_items:
         - app.yml
         - job_metrics_conf.yml

--- a/jenkins/config_backup/run_backup.sh
+++ b/jenkins/config_backup/run_backup.sh
@@ -3,6 +3,7 @@
 source jenkins/utils.sh
 
 activate_virtualenv
+echo "banana_fritter" > .vault_pass.txt  # ansible needs .vault_pass.txt to exist
 
 GITLAB_REPO_DIR='../ansible_config_backup'
 
@@ -10,11 +11,10 @@ GITLAB_REPO_DIR='../ansible_config_backup'
 [ -d $GITLAB_REPO_DIR ] && rm -rf $GITLAB_REPO_DIR
 git clone git@gitlab.usegalaxy.org.au:galaxyaustralia/configs.git $GITLAB_REPO_DIR
 
-ansible-playbook -i hosts jenkins/config_backup/config_backup_playbook.yml --extra-vars "ansible_user=jenkins_bot backup_dir=$GITLAB_REPO_DIR"
+ansible-playbook -i hosts jenkins/config_backup/config_backup_playbook.yml --extra-vars "ansible_user=jenkins_bot backup_dir=$(realpath $GITLAB_REPO_DIR)"
 
 cd $GITLAB_REPO_DIR || exit 1
 git add *
 git commit -am "backup $(date '+%Y-%m-%d')"
 git push
 cd ../workspace
-rm -rf $GITLAB_REPO_DIR

--- a/jenkins/config_backup/run_backup.sh
+++ b/jenkins/config_backup/run_backup.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+source jenkins/utils.sh
+
+activate_virtualenv
+
+GITLAB_REPO_DIR='../ansible_config_backup'
+
+# CLONE GITLAB REPO HERE
+[ -d $GITLAB_REPO_DIR ] && rm -rf $GITLAB_REPO_DIR
+git clone git@gitlab.usegalaxy.org.au:galaxyaustralia/configs.git $GITLAB_REPO_DIR
+
+ansible-playbook -i hosts jenkins/config_backup/config_backup_playbook.yml --extra-vars "ansible_user=jenkins_bot backup_dir=$GITLAB_REPO_DIR"
+
+cd $GITLAB_REPO_DIR || exit 1
+git add *
+git commit -am "backup $(date '+%Y-%m-%d')"
+git push
+cd ../workspace
+rm -rf $GITLAB_REPO_DIR

--- a/jenkins/requirements.txt
+++ b/jenkins/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.9.2
+ansible==4.0.0a1

--- a/jenkins/update_labels/update_tool_labels.sh
+++ b/jenkins/update_labels/update_tool_labels.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 source jenkins/utils.sh
 
 activate_virtualenv

--- a/jenkins/update_labels/update_tool_labels.sh
+++ b/jenkins/update_labels/update_tool_labels.sh
@@ -1,6 +1,7 @@
 # Activate the virtual environment on jenkins. If this script is being run for
 # the first time we will need to set up the virtual environment
-VIRTUALENV="../.ansible_venv"
+VENV_DIR="/var/lib/jenkins/jobs_common"
+VIRTUALENV="$VENV_DIR/.ansible_venv"
 REQUIREMENTS_FILE="jenkins/requirements.txt"
 CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.txt"
 

--- a/jenkins/update_labels/update_tool_labels.sh
+++ b/jenkins/update_labels/update_tool_labels.sh
@@ -1,21 +1,6 @@
-# Activate the virtual environment on jenkins. If this script is being run for
-# the first time we will need to set up the virtual environment
-VENV_DIR="/var/lib/jenkins/jobs_common"
-VIRTUALENV="$VENV_DIR/.ansible_venv"
-REQUIREMENTS_FILE="jenkins/requirements.txt"
-CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.txt"
+source jenkins/utils.sh
 
-[ ! -d $VIRTUALENV ] && virtualenv -p python3 $VIRTUALENV
-# shellcheck source=../.venv3/bin/activate
-. "$VIRTUALENV/bin/activate"
-
-# if requirements change, reinstall requirements
-[ ! -f $CACHED_REQUIREMENTS_FILE ] && touch $CACHED_REQUIREMENTS_FILE
-if [ "$(diff $REQUIREMENTS_FILE $CACHED_REQUIREMENTS_FILE)" ]; then
-pip install -r $REQUIREMENTS_FILE
-cp $REQUIREMENTS_FILE $CACHED_REQUIREMENTS_FILE
-fi
-
+activate_virtualenv
 echo "secret" > .vault_pass.txt  # ansible needs .vault_pass.txt to exist
 
 ansible-playbook -i hosts jenkins/update_labels/update_tool_labels_playbook.yml --extra-vars "ansible_user=jenkins_bot update_labels_hostname=staging_galaxy_server"

--- a/jenkins/update_tool_destinations.sh
+++ b/jenkins/update_tool_destinations.sh
@@ -1,3 +1,5 @@
+source jenkins/utils.sh
+
 # check whether the production tpv files have changed
 PROD_TPV_FILE_PATH="files/galaxy/dynamic_job_rules/production/total_perspective_vortex"
 PROD_TPV_UPDATED=$(git diff --name-only $GIT_PREVIOUS_COMMIT $GIT_COMMIT | cat | grep $PROD_TPV_FILE_PATH)
@@ -20,24 +22,8 @@ if [ ! "$PROD_TPV_UPDATED" ] && [ ! "$DEV_RELEVANT_FILES_UPDATED" ] && [ ! "$STA
     exit 0
 fi
 
-# Activate the virtual environment on jenkins. If this script is being run for
-# the first time we will need to set up the virtual environment
-VENV_DIR="/var/lib/jenkins/jobs_common"
-VIRTUALENV="$VENV_DIR/.ansible_venv"
-REQUIREMENTS_FILE="jenkins/requirements.txt"
-CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.txt"
+activate_virtualenv
 echo "helloworld" > .vault_pass.txt  # ansible needs .vault_pass.txt to exist
-
-[ ! -d $VIRTUALENV ] && virtualenv -p python3 $VIRTUALENV
-# shellcheck source=../.venv3/bin/activate
-. "$VIRTUALENV/bin/activate"
-
-# if requirements change, reinstall requirements
-[ ! -f $CACHED_REQUIREMENTS_FILE ] && touch $CACHED_REQUIREMENTS_FILE
-if [ "$(diff $REQUIREMENTS_FILE $CACHED_REQUIREMENTS_FILE)" ]; then
-pip install -r $REQUIREMENTS_FILE
-cp $REQUIREMENTS_FILE $CACHED_REQUIREMENTS_FILE
-fi
 
 if [ "$PROD_TPV_UPDATED" ]; then
     echo -e "\nUpdating tool destinations file on Galaxy production instance\n"

--- a/jenkins/update_tool_destinations.sh
+++ b/jenkins/update_tool_destinations.sh
@@ -22,7 +22,8 @@ fi
 
 # Activate the virtual environment on jenkins. If this script is being run for
 # the first time we will need to set up the virtual environment
-VIRTUALENV="../.ansible_venv"
+VENV_DIR="/var/lib/jenkins/jobs_common"
+VIRTUALENV="$VENV_DIR/.ansible_venv"
 REQUIREMENTS_FILE="jenkins/requirements.txt"
 CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.txt"
 echo "helloworld" > .vault_pass.txt  # ansible needs .vault_pass.txt to exist

--- a/jenkins/update_tool_destinations.sh
+++ b/jenkins/update_tool_destinations.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 source jenkins/utils.sh
 
 # check whether the production tpv files have changed

--- a/jenkins/utils.sh
+++ b/jenkins/utils.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+activate_virtualenv() {
+    # Activate the virtual environment on jenkins. If this script is being run for
+    # the first time we will need to set up the virtual environment
+    VENV_DIR="/var/lib/jenkins/jobs_common"
+    VIRTUALENV="$VENV_DIR/.ansible_venv"
+    REQUIREMENTS_FILE="jenkins/requirements.txt"
+    CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.txt"
+
+    [ ! -d $VIRTUALENV ] && virtualenv -p python3 $VIRTUALENV
+    # shellcheck source=../.venv3/bin/activate
+    . "$VIRTUALENV/bin/activate"
+
+    # if requirements change, reinstall requirements
+    [ ! -f $CACHED_REQUIREMENTS_FILE ] && touch $CACHED_REQUIREMENTS_FILE
+    if [ "$(diff $REQUIREMENTS_FILE $CACHED_REQUIREMENTS_FILE)" ]; then
+        pip install -r $REQUIREMENTS_FILE
+        cp $REQUIREMENTS_FILE $CACHED_REQUIREMENTS_FILE
+    fi
+}

--- a/jenkins/utils.sh
+++ b/jenkins/utils.sh
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 activate_virtualenv() {
     # Activate the virtual environment on jenkins. If this script is being run for
     # the first time we will need to set up the virtual environment


### PR DESCRIPTION
Add config backup playbook to this repo. It has been running in its own gitlab repository but the hosts file goes out of date every time an IP address changes so it's better to use the source-of-truth host file in this repo.  The backed up files still go to the 'configs' gitlab repository.

Every jenkins ansible job can use the same virtual environment (/var/lib/jenkins/jobs_common/.ansible_venv), previously each one had its own venv.