### PR TITLE
comment out metadata strategy in dev job conf

### DIFF
--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -94,7 +94,7 @@ execution:
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: 'false'
-      metadata_strategy: 'extended'
+      # metadata_strategy: 'extended'
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote
@@ -121,7 +121,7 @@ execution:
       jobs_directory: /mnt/pulsar/files/staging
       transport: curl
       remote_metadata: 'false'
-      metadata_strategy: 'extended'
+      # metadata_strategy: 'extended'
       default_file_action: remote_transfer
       outputs_to_working_directory: false
       dependency_resolution: remote


### PR DESCRIPTION
`metadata_strategy: 'extended'` is causing pulsar jobs to fail on dev.  Will need to find out more about this setting before it can be used