### PR TITLE
Fix dev docker/singularity volumes

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -293,14 +293,18 @@ tools:
     params:
       singularity_enabled: True
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/hifiadapterfilt/hifiadapterfilt/.*:
-    scheduling:
-       require:
-         - pulsar
-         - pulsar-nci-test
-    cores: 8
     params:
       singularity_enabled: True
       singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
+    rules:
+      - if: user.email == 'star@email.com'
+        cores: 8
+      - if: user.email != 'star@email.com'
+        cores: 8
+        scheduling:
+          require:
+            - pulsar
+            - pulsar-nci-test
   toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/.*:
     # context:
     #   minimum_singularity_version: 5.0.0+galaxy0  # not working, ref https://github.com/galaxyproject/total-perspective-vortex/pull/32

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -247,7 +247,10 @@ slurm_singularity_volumes_list:
   - "$job_directory:rw"
   - "$galaxy_root:ro"
   - "$tool_directory:ro"
-  - "$default_file_path:ro"
+  - "/mnt/galaxy/data:ro"
+  - "/mnt/galaxy/data-2:ro"
+  - "/mnt/galaxy/data-3:ro"
+  - "/mnt/test_mount:ro"
   - "/cvmfs/data.galaxyproject.org:ro"
 
 pulsar_singularity_volumes_list:


### PR DESCRIPTION
There are several data directories on dev now that have not been accounted for in the docker/singularity volumes list.  This also adds a rule for hifiadaptorfilt so that I can test it now on slurm without interrupting current users.