### PR TITLE
Reduce resources for some high-mem tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -693,8 +693,8 @@ tools:
     - if: 1 <= input_size < 10
       cores: 16
     - if: input_size >= 10
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -707,8 +707,8 @@ tools:
     - if: 0.05 <= input_size < 5
       cores: 8
     - if: input_size >= 5
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -888,8 +888,8 @@ tools:
     - if: 0.5 <= input_size < 15
       cores: 8
     - if: input_size >= 15
-      cores: 60  # one quarter of a QLD high mem pulsar
-      mem: 961
+      cores: 30
+      mem: 480.5
       scheduling:
         accept:
         - high-mem
@@ -972,8 +972,8 @@ tools:
     - if: 0.5 <= input_size < 5
       cores: 8
     - if: input_size >= 5
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -1020,8 +1020,8 @@ tools:
     - if: 5 <= input_size < 20
       cores: 16
     - if: input_size >= 20
-      cores: 120
-      mem: 1922
+      cores: 30
+      mem: 480.5
       scheduling:
         accept:
         - high-mem
@@ -1040,8 +1040,8 @@ tools:
     - if: 10 <= input_size < 20
       cores: 4
     - if: input_size >= 20
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -1167,8 +1167,8 @@ tools:
       - pulsar-training-large
     rules:
     - if: input_size >= 0.2
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -1238,8 +1238,8 @@ tools:
     - if: 0.05 <= input_size < 0.3
       cores: 8
     - if: input_size >= 0.3
-      cores: 60
-      mem: 961
+      cores: 30
+      mem: 480.5
       scheduling:
         accept:
         - high-mem
@@ -1271,11 +1271,7 @@ tools:
       - pulsar
     rules:
     - if: input_size >= 1
-      cores: 60
-      mem: 961
-      scheduling:
-        accept:
-        - high-mem
+      cores: 16
   toolshed.g2.bx.psu.edu/repos/iuc/raven/raven/.*:
     cores: 2
     scheduling:
@@ -1315,8 +1311,8 @@ tools:
     - if: 0.002 <= input_size < 5
       cores: 16
     - if: input_size >= 5
-      cores: 120
-      mem: 1922
+      cores: 60
+      mem: 961
       scheduling:
         accept:
         - high-mem
@@ -1346,8 +1342,8 @@ tools:
     - if: 0.005 <= input_size < 2
       cores: 8
     - if: 2 <= input_size < 20
-      cores: 60
-      mem: 961
+      cores: 30
+      mem: 480.5
       scheduling:
         accept:
         - high-mem


### PR DESCRIPTION
Reduce the cores/mem allocations for some high-mem tools to reduce congestion in the high-mem queues.  @Slugger70, @jlqfab what do you think?  We have sacct data but I'm not sure how to tell how efficient the allocations have been for the different tools.

```
halved:
flye: 120 -> 60
hifiasm: 120 -> 60
racon: 120 -> 60
medaka_consensus_pipeline: 120 -> 60
seqtk_seq: 120 -> 60
raven: 120 -> 60
hisat2: 60 -> 30
busco: 60 -> 30
spades tools: 60 -> 30

quartered:
minimap2: 120 -> 30

taken off high-mem altogether:
quast: 60 -> 16
```
