### PR TITLE
Stop using AWS as rw dir in object store, omit /mnt/test_mount from singularity volumes

### DIFF
--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -250,7 +250,7 @@ slurm_singularity_volumes_list:
   - "/mnt/galaxy/data:ro"
   - "/mnt/galaxy/data-2:ro"
   - "/mnt/galaxy/data-3:ro"
-  - "/mnt/test_mount:ro"
+  # - "/mnt/test_mount:ro"  # including this causes singularity jobs to fail
   - "/cvmfs/data.galaxyproject.org:ro"
 
 pulsar_singularity_volumes_list:

--- a/templates/galaxy/config/dev_object_store_conf.xml.j2
+++ b/templates/galaxy/config/dev_object_store_conf.xml.j2
@@ -7,10 +7,10 @@
         <backend id="dev_objects_1" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/galaxy/data" />
         </backend>
-        <backend id="dev_objects_3" type="disk" weight="0" store_by="uuid">
+        <backend id="dev_objects_3" type="disk" weight="1" store_by="uuid">
             <files_dir path="/mnt/galaxy/data-3" />
         </backend>
-        <backend id="dev_aws_test" type="disk" weight="1" store_by="uuid">
+        <backend id="dev_aws_test" type="disk" weight="0" store_by="uuid">
             <files_dir path="/mnt/test_mount" />
         </backend>
     </backends>


### PR DESCRIPTION
On dev, the aws storage is causing pulsar jobs with large outputs to fail.  Including the path to it in singularity_volumes causes all singularity jobs on slurm to fail.

There may be workarounds, this PR is just to stop using it as the primary storage for now.  Any singularity jobs using files created in the past two weeks will not work unless the datasets are copied.