### PR TITLE
schedule bionano_scaffold to slurm only

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -57,9 +57,9 @@ tools:
     cores: 16
     params:
       docker_enabled: true
-    scheduling:
-      accept:
-      - pulsar
+    # scheduling:  # TODO: fix bionano on pulsar
+    #   accept:
+    #   - pulsar
   toolshed.g2.bx.psu.edu/repos/bgruening/chemfp/ctb_chemfp_nxn_clustering/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
There are errors running this on pulsar, it is OK on slurm.