### PR TITLE
Fix vhosts and destinations for reservation pulsars

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 vault_password_file=.vault_pass.txt
 stdout_callback=debug
 stderr_callback=debug
+roles_path=roles
 
 [colors]
 verbose = bright blue

--- a/dev_update_configs_playbook.yml
+++ b/dev_update_configs_playbook.yml
@@ -16,16 +16,18 @@
       - vortex_config.yml
       - reservation_destinations.yml
   handlers:
-    - name: Restart Galaxy
-      systemd:
-        name: galaxy
-        state: restarted
+    - name: galaxy gravity restart
+      become: True
+      become_user: galaxy
+      command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
+      environment:
+        GRAVITY_STATE_DIR: "{{ galaxy_root }}/gravity"
   pre_tasks:
     - name: copy job_conf file
       template:
         src: "{{ galaxy_config_template_src_dir }}/config/dev_job_conf.yml.j2"
         dest: "{{ galaxy_config_dir }}/job_conf.yml"
-      notify: Restart Galaxy
+      notify: galaxy gravity restart
     - name: Copy tpv files to dev
       copy:
         src: "files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/{{ item }}"

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/reservation_destinations.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/reservation_destinations.yml
@@ -7,7 +7,6 @@ destinations:
       require:
         - pulsar
         - reservation-pulsar
-        - offline
       accept:
         - alphafold
         - pulsar-reservation-g2-xlarge-A

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -6,9 +6,11 @@ tools:
     scheduling:
       accept:
         - pulsar
+        - reservation-pulsar
+      prefer:
+        - pulsar-reservation-g2-xlarge-A
     params:
       docker_enabled: true
-      docker_memory: '{mem}G'
     cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/links/links/.*:
     params:
@@ -140,6 +142,13 @@ tools:
         - pulsar-eu-gpu-alpha
       require:
         - alphafold
+    params:
+      docker_enabled: true
+      docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro'
+      docker_sudo: false
+      require_container: true
+      docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=30 --env ALPHAFOLD_AA_LENGTH_MAX=2000"
+      docker_set_user: '1000'
     rules:
       - if: user.email == "pulsar_azure_0@genome.edu.au"
         scheduling:
@@ -149,13 +158,6 @@ tools:
         mem: 106
         context:
           partition: azuregpu1
-        params:
-          docker_enabled: true
-          docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro'
-          docker_sudo: false
-          require_container: true
-          docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=30 --env ALPHAFOLD_AA_LENGTH_MAX=2000"
-          docker_set_user: '1000'
       - if: user.email == "pulsar_azure_1@genome.edu.au"
         scheduling:
           require:
@@ -164,13 +166,13 @@ tools:
         mem: 69
         context:
           partition: azuregpu1
-        params:
-          docker_enabled: true
-          docker_volumes: '$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro'
-          docker_sudo: false
-          docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=30 --env ALPHAFOLD_AA_LENGTH_MAX=2000"
-          require_container: true
-          docker_set_user: '1000'
+      - if: user.email == "star@email.com"
+        scheduling:
+          require:
+            - reservation-pulsar
+        cores: 6 # there are 60, but match the regular alphafold
+        mem: 106 # there is 120ish, but match the regular alphafold
+
   toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1:
     cores: 2
     params:

--- a/host_vars/dev-queue.usegalaxy.org.au.yml
+++ b/host_vars/dev-queue.usegalaxy.org.au.yml
@@ -42,6 +42,8 @@ rabbitmq_vhosts:
   - /pulsar/galaxy_eu_gpu
   - /pulsar/galaxy_azure_0
   - /pulsar/galaxy_azure_1
+  - /pulsar/galaxy_reservation_g2_xlarge_A
+  - /pulsar/galaxy_reservation_g2_xlarge_B
 
 rabbitmq_version: 3.10.5-1
 

--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -125,7 +125,7 @@ execution:
       docker_enabled: false
       docker_sudo: false
       docker_volumes: '{{ pulsar_docker_volumes }}'
-      docker_run_user: '1000'
+      docker_set_user: '1000'
       singularity_enabled: false
       singularity_volumes: '{{ pulsar_singularity_volumes }}'
       singularity_default_container_id: '{{ singularity_default_container_id }}'
@@ -152,7 +152,7 @@ execution:
       docker_enabled: false
       docker_sudo: false
       docker_volumes: '{{ pulsar_docker_volumes }}'
-      docker_run_user: '1000'
+      docker_set_user: '1000'
       singularity_enabled: false
       singularity_volumes: '{{ pulsar_singularity_volumes }}'
       singularity_default_container_id: '{{ singularity_default_container_id }}'
@@ -289,18 +289,18 @@ execution:
       docker_enabled: false
       docker_sudo: false
       docker_volumes: '{{ pulsar_docker_volumes }}'
-      docker_run_user: '1000'
-      singularity_enabled: false
-      singularity_volumes: '{{ pulsar_singularity_volumes }}'
-      singularity_default_container_id: '{{ singularity_default_container_id }}'
-      container_resolvers: 
-        - type: explicit_singularity
-        - type: mulled_singularity
-      env:
-        - name: SINGULARITY_CACHEDIR
-          value: /mnt/pulsar/deps/singularity
-        - name: SINGULARITY_TMPDIR
-          value: /mnt/pulsar/deps/singularity/tmp
+      docker_set_user: '1000'
+      # singularity_enabled: false  # TODO: having singularity variables causes docker jobs to fail, these need to be set in destinations
+      # singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      # singularity_default_container_id: '{{ singularity_default_container_id }}'
+      # container_resolvers: 
+      #   - type: explicit_singularity
+      #   - type: mulled_singularity
+      # env:
+      #   - name: SINGULARITY_CACHEDIR
+      #     value: /mnt/pulsar/deps/singularity
+      #   - name: SINGULARITY_TMPDIR
+      #     value: /mnt/pulsar/deps/singularity/tmp
     pulsar-reservation-g2-xlarge-B:
       runner: pulsar_reservation_g2_xlarge_B_runner
       jobs_directory: /mnt/pulsar/files/staging
@@ -316,18 +316,18 @@ execution:
       docker_enabled: false
       docker_sudo: false
       docker_volumes: '{{ pulsar_docker_volumes }}'
-      docker_run_user: '1000'
-      singularity_enabled: false
-      singularity_volumes: '{{ pulsar_singularity_volumes }}'
-      singularity_default_container_id: '{{ singularity_default_container_id }}'
-      container_resolvers: 
-        - type: explicit_singularity
-        - type: mulled_singularity
-      env:
-        - name: SINGULARITY_CACHEDIR
-          value: /mnt/pulsar/deps/singularity
-        - name: SINGULARITY_TMPDIR
-          value: /mnt/pulsar/deps/singularity/tmp
+      docker_set_user: '1000'
+      # singularity_enabled: false
+      # singularity_volumes: '{{ pulsar_singularity_volumes }}'
+      # singularity_default_container_id: '{{ singularity_default_container_id }}'
+      # container_resolvers: 
+      #   - type: explicit_singularity
+      #   - type: mulled_singularity
+      # env:
+      #   - name: SINGULARITY_CACHEDIR
+      #     value: /mnt/pulsar/deps/singularity
+      #   - name: SINGULARITY_TMPDIR
+      #     value: /mnt/pulsar/deps/singularity/tmp
 
 limits:
 - type: anonymous_user_concurrent_jobs


### PR DESCRIPTION
dev-queue host_vars was missing the vhosts for the reservation pulsars

dev_update_configs playbook restart handler has been updated to use galaxyctl

reservation destinations in job conf have their singularity variables commented out because the container_resolvers override interacts badly with docker (with a TODO to refactor destinations)

TPV has been updated so that bionano prefers reservation pulsars and there is a user who can test alphafold on the reservation pulsar



