### PR TITLE
configure apt to set erlang version to fixed - no updates

### DIFF
--- a/roles/jasonroyle.rabbitmq/tasks/Debian/install.yml
+++ b/roles/jasonroyle.rabbitmq/tasks/Debian/install.yml
@@ -11,6 +11,11 @@
   apt:
     name: erlang
 
+- name: hold erlang version
+  dpkg_selections:
+    name: erlang
+    selection: hold
+
 - name: import rabbitmq rpm key
   apt_key:
     url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc


### PR DESCRIPTION
Configure apt to set erlang version to fixed (hold) so that it doesn't get updated. As per request from @Slugger70 