### PR TITLE
hide two tools that are not working

### DIFF
--- a/jenkins/update_labels/hidden_tools.yml
+++ b/jenkins/update_labels/hidden_tools.yml
@@ -10,3 +10,5 @@ hidden_tool_ids:
 - toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_download/4.3r.1
 - toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3r.1
 - toolshed.g2.bx.psu.edu/repos/vlefort/phyml/phyml/*
+- toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/jmoleditor/1.0.0
+- toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/2.9.1.2


### PR DESCRIPTION
Hide jmoleditor from chemical_data_sources, it is an old repo and clicking on this tool from the panel leads to a 404 page.  It is installed because another wrapper from the repo is needed for GTN.

Hide sra_pileup from sra_tools.  This wrapper was dropped from the repository at the beginning of 2020 and hasn't worked on GA since before pawsey.