### PR TITLE
Set up TPV for s3fs testing

### DIFF
--- a/dev-workers_playbook.yml
+++ b/dev-workers_playbook.yml
@@ -65,4 +65,8 @@
             become_user: root
             when: links.stat.islnk is defined and not links.stat.islnk
         when: attached_volumes is defined
-
+      - name: Reload cvmfs config
+        command:
+          cmd: cvmfs_config reload
+        become: yes
+        when: "{{ hostname.startswith('dev-w1') }}"

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -45,10 +45,10 @@ tools:
       accept:
         - pulsar
   toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/.*:
-    cores: 1
-    scheduling:
-      accept:
-        - pulsar
+    cores: 2
+    # scheduling:
+    #   accept:
+    #     - pulsar
     rules:
       - if: user.email == "pulsar_azure_0@genome.edu.au" and input_size < 10
         scheduling:
@@ -321,6 +321,30 @@ users:
         scheduling:
           require:
             - pulsar
+      - id: cvmfs_test_user_rule
+        if: |
+          tag = 'cvmfs'
+          tag_present = False
+          if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
+            try:
+              tag_present = tag in [hta.user_tname for hta in job.history.tags]
+            except:
+              pass
+          tag_present
+        context:
+          partition: cvmfs
+      - id: s3fs_test_user_rule
+        if: |
+          tag = 's3fs'
+          tag_present = False
+          if tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed'):
+            try:
+              tag_present = tag in [hta.user_tname for hta in job.history.tags]
+            except:
+              pass
+          tag_present
+        context:
+          partition: s3fs
   star@email.com:
     inherits: test_user
   pulsar_user@usegalaxy.org.au:

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -45,14 +45,12 @@ tools:
       accept:
         - pulsar
   toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/.*:
-    cores: 2
-    # scheduling:
-    #   accept:
-    #     - pulsar
+    cores: 6
     rules:
       - if: user.email == "pulsar_azure_0@genome.edu.au" and input_size < 10
         scheduling:
           require:
+            - pulsar
             - pulsar-azure-0
         cores: 4
         mem: 15
@@ -62,6 +60,7 @@ tools:
       - if: user.email == "pulsar_azure_0@genome.edu.au" and input_size >= 10
         scheduling:
           require:
+            - pulsar
             - pulsar-azure-0
         cores: 16
         mem: 60.8

--- a/group_vars/dev_workers.yml
+++ b/group_vars/dev_workers.yml
@@ -30,11 +30,11 @@ docker_daemon_options:
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 20000
+cvmfs_quota_limit: 5000
 
 # s3fs
 s3fs_cache_base: /mnt/var/lib/s3fs
-s3fs_ensure_diskfree: 75000
+s3fs_ensure_diskfree: 90077
 
 s3fs:
   access_key:


### PR DESCRIPTION
A user who inherits test_user can select s3fs or cvmfs using history tags.  The cache sizes have been changed so that each worker has 5000Mb