### PR TITLE
Add extra datatypes conf to dev and set terms_url

### DIFF
--- a/files/galaxy/config/additional_datatypes_conf.xml
+++ b/files/galaxy/config/additional_datatypes_conf.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!-- See /mnt/galaxy/galaxy-app/lib/galaxy/config/sample/datatypes_conf.xml.sample for main dataypes conf file -->
+<datatypes>
+  <registration converters_path="lib/galaxy/datatypes/converters" display_path="display_applications">
+    <datatype extension="no_unzip.zip" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true"/>
+  </registration>
+</datatypes>

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -79,6 +79,8 @@ host_galaxy_config_files:
     dest: "{{ galaxy_config_dir}}/oidc_config.xml"
   - src: "{{ galaxy_config_file_src_dir }}/config/local_tool_conf_dev.xml"
     dest: "{{ galaxy_config_dir }}/local_tool_conf.xml"
+  - src: "{{ galaxy_config_file_src_dir }}/config/additional_datatypes_conf.xml"
+    dest: "{{ galaxy_config_dir }}/additional_datatypes_conf.xml"
 
 host_galaxy_config: # renamed from __galaxy_config
   gravity:
@@ -157,6 +159,8 @@ host_galaxy_config: # renamed from __galaxy_config
     tool_filters: ga_filters:hide_test_tools
     # TUS
     tus_upload_store: "{{ galaxy_tus_upload_store }}"
+    terms_url: "https://site.usegalaxy.org.au/about#terms-of-service"
+    datatypes_config_file: "{{ galaxy_server_dir }}/lib/galaxy/config/sample/datatypes_conf.xml.sample,{{ galaxy_config_dir }}/additional_datatypes_conf.xml"
 
 galaxy_handler_count: 2 ############# europe uses 5, this could be host specific
 


### PR DESCRIPTION
Add an extra datatypes conf file.

Set terms_url in galaxy.yml. This value is used in account registration emails.