### PR TITLE
Add `listen: restart galaxy` to staging and aarnet playbook restart handlers

### DIFF
--- a/aarnet_playbook.yml
+++ b/aarnet_playbook.yml
@@ -18,6 +18,7 @@
       systemd:
         name: galaxy
         state: restarted
+      listen: restart galaxy
   roles:
     - galaxyproject.repos
     - common

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -17,6 +17,7 @@
       systemd:
         name: galaxy
         state: restarted
+      listen: restart galaxy
   roles:
     - galaxyproject.repos
     - common


### PR DESCRIPTION
the restart handler is no longer triggered with the updated galaxyproject.galaxy role