### PR TITLE
training pulsar should tolerate high-mem tag

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -88,6 +88,7 @@ destinations:
       accept:
         - pulsar-nci-training
         - pulsar-qld-blast # allow training jobs with require: pulsar-qld-blast to run here
+        - high-mem
       require:
         - pulsar
         - training


### PR DESCRIPTION
pulsar-nci-training needs to be able to run a job that would have gone to high-mem if the user were not in the training queue.