### PR TITLE
Hide any version of sra_pileup

### DIFF
--- a/jenkins/update_labels/hidden_tools.yml
+++ b/jenkins/update_labels/hidden_tools.yml
@@ -11,4 +11,4 @@ hidden_tool_ids:
 - toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3r.1
 - toolshed.g2.bx.psu.edu/repos/vlefort/phyml/phyml/*
 - toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/jmoleditor/1.0.0
-- toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/2.9.1.2
+- toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/*


### PR DESCRIPTION
Requested by Igor.  sra_pileup is in the hidden tools list but it needs to cover all versions.