### PR TITLE
Fix user limits for pulsar-azure-gpu and pulsar-QLD

### DIFF
--- a/templates/galaxy/config/aarnet_job_conf.yml.j2
+++ b/templates/galaxy/config/aarnet_job_conf.yml.j2
@@ -629,21 +629,21 @@ limits:
 - type: destination_total_concurrent_jobs
   id: pulsar-QLD
   value: 20
-- type: user_total_concurrent_jobs
+- type: destination_user_concurrent_jobs
   id: pulsar-QLD
   value: 5
 
 - type: destination_total_concurrent_jobs
   id: pulsar-azure
   value: 4
-- type: user_total_concurrent_jobs
+- type: destination_user_concurrent_jobs
   id: pulsar-azure
   value: 1
 
 - type: destination_total_concurrent_jobs
   id: pulsar-azure-gpu
   value: 4
-- type: user_total_concurrent_jobs
+- type: destination_user_concurrent_jobs
   id: pulsar-azure-gpu
-  value: 1
+  value: 2
 


### PR DESCRIPTION
The key `user_total_concurrent_jobs` should be `destination_user_concurrent_jobs`, this mistake has been copied over from the pawsey job conf. Set alphafold limit to 2 concurrent jobs per user.