### PR TITLE
Add webdav upgrade to aarnet playbook, add terms_url to galaxyservers.yml

### DIFF
--- a/aarnet_playbook.yml
+++ b/aarnet_playbook.yml
@@ -64,6 +64,11 @@
       package:
         name: slurm-drmaa1
         state: latest
+    - name: Workaround content-length header bug in webdav through forcible update to newer version
+      pip:
+        name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
+        state: forcereinstall
+        virtualenv: "{{ galaxy_venv_dir }}"
     - name: Reload exportfs
       command: exportfs -ra
       become: yes

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -145,6 +145,7 @@ group_galaxy_config:
     error_email_to: <help@genome.edu.au> # error reports are disabled if no email is set
     email_from: <galaxy-no-reply@usegalaxy.org.au>
     support_url: "{{ galaxy_australia_website }}/help"
+    terms_url: "{{ galaxy_australia_website }}/about#terms-of-service"
 
     data_dir: "{{ galaxy_root }}/cache" # cache paths are set relative to data_dir (cache_dir will become a config option in 21.05)
 

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -163,7 +163,6 @@ host_galaxy_config: # renamed from __galaxy_config
     trs_servers_config_file: "{{ galaxy_config_dir }}/trs_servers_conf.yml"
     # TUS
     tus_upload_store: "{{ galaxy_tus_upload_store }}"
-    terms_url: "https://site.usegalaxy.org.au/about#terms-of-service"
     datatypes_config_file: "{{ galaxy_server_dir }}/lib/galaxy/config/sample/datatypes_conf.xml.sample,{{ galaxy_config_dir }}/additional_datatypes_conf.xml"
 
 galaxy_handler_count: 2 ############# europe uses 5, this could be host specific

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -56,6 +56,11 @@
     - name: Install slurm-drmaa
       package:
         name: slurm-drmaa1
+    - name: Workaround content-length header bug in webdav through forcible update to newer version
+      pip:
+        name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
+        state: forcereinstall
+        virtualenv: "{{ galaxy_venv_dir }}"
     - name: Reload exportfs
       command: exportfs -ra
       become: yes


### PR DESCRIPTION
Apply Nuwan's webdav fix (tested on dev) to staging and aarnet playbooks.

Add `terms_url` to galaxyservers.yml.  This means there will be an extra menu item 'Terms and Conditions' and will be the value used in validation emails if email validation is switched on.  Tested on dev.