### PR TITLE
Add the option to symlink custom-indices folder in pulsar-post-tasks role

### DIFF
--- a/host_vars/pulsar-QLD/pulsar-QLD.genome.edu.au.yml
+++ b/host_vars/pulsar-QLD/pulsar-QLD.genome.edu.au.yml
@@ -20,6 +20,9 @@ shared_mounts:
 pulsar_staging_dir: /mnt/tmp/files/staging
 pulsar_persistence_dir: /mnt/tmp/files/persistent_data
 
+# Set directory containing custom-indices data for pulsar-post-tasks role
+pulsar_custom_indices_src_dir: /mnt/tmp/custom-indices
+
 #Override the slurm roles - only install exec here as we have a dedicated queue server.
 #Slurm roles
 slurm_roles: ['exec']

--- a/roles/pulsar-post-tasks/tasks/main.yml
+++ b/roles/pulsar-post-tasks/tasks/main.yml
@@ -13,11 +13,19 @@
       mode: 0755
 - name: own the pulsar_custom_indices_dir as ubuntu
   file:
-      path: "{{ pulsar_custom_indices_dir }}"
+      path: "{{ pulsar_custom_indices_src_dir|d(pulsar_custom_indices_dir) }}"
       owner: ubuntu
       group: ubuntu
       state: directory
       mode: 0750
+- name: Symlink custom indices directory
+  file:
+      src: "{{ pulsar_custom_indices_src_dir }}"
+      dest: "{{ pulsar_custom_indices_dir }}"
+      state: link
+  become: yes
+  become_user: ubuntu
+  when: pulsar_custom_indices_src_dir is defined
 - name: create singularity cache dir
   file:
       path: "{{ pulsar_dependencies_dir }}/singularity"


### PR DESCRIPTION
Add variable pulsar_custom_indices_src_dir, only create symlink if this exists

This also adds it as /mnt/tmp/custom-indices on pulsar-QLD.  Not sure if this fits with the architecture of the DR site.. we may want /mnt/custom-indices to be its own 2T volume instead.