### PR TITLE
set phm1 and phm2 online, restrict destinations for mothur_cluster_split

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -45,7 +45,6 @@ destinations:
       require:
         - pulsar
         - high-mem
-        - offline
   pulsar-high-mem2:
     cores: 126
     mem: 1922.49
@@ -55,7 +54,6 @@ destinations:
       require:
         - pulsar
         - high-mem
-        - offline
   pulsar-qld-high-mem0:
     cores: 240
     mem: 3845.07

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1276,6 +1276,11 @@ tools:
       scheduling:
         accept:
         - high-mem
+        reject: # only allow it to run on pulsar-qld-high-mem0
+        - pulsar-high-mem1
+        - pulsar-high-mem2
+        - qld-pulsar-high-mem1
+        - qld-pulsar-high-mem2
   toolshed.g2.bx.psu.edu/repos/iuc/phyml/phyml/.*:
     cores: 120
     mem: 1922


### PR DESCRIPTION
mothur-cluster-split jobs would only be able to run on qld-pulsar-high-mem0