### PR TITLE
Use galaxy_gravity_state_dir param in gxctl

### DIFF
--- a/roles/common/tasks/machine_users.yml
+++ b/roles/common/tasks/machine_users.yml
@@ -40,7 +40,7 @@
       block: |
         gxctl() {
           export gctl_args="$@"
-          export GRAVITY_STATE_DIR={{ galaxy_root }}/gravity
+          export GRAVITY_STATE_DIR={{ galaxy_gravity_state_dir }}
  
           sudo -H -Eu {{ galaxy_user.name }} bash -c '{{ galaxy_venv_dir }}/bin/galaxyctl $gctl_args' 
         }


### PR DESCRIPTION
gxctl no longer works on dev because the bash function is setting GRAVITY_STATE_DIR={{ galaxy_root }}/gravity instead of {{ galaxy_gravity_state_dir }}