### PR TITLE
Fix tiaas vars

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -234,8 +234,8 @@ tiaas_galaxy_db_pass: "{{ vault_aarnet_db_tiaas_password }}"
 tiaas_info:
   owner: "Galaxy Australia"
   owner_email: help@genome.edu.au
-  owner_site: "https://usegalaxy.org.au"
-  domain: "usegalaxy.org.au"
+  owner_site: "https://site.usegalaxy.org.au"
+  domain: "https://usegalaxy.org.au"
 tiaas_other_config: |
   EMAIL_HOST="localhost"
   EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -191,8 +191,8 @@ tiaas_galaxy_db_pass: "{{ vault_staging_db_tiaasadmin_password }}"
 tiaas_info:
   owner: "Galaxy Australia staging"
   owner_email: help@genome.edu.au
-  owner_site: "https://staging.usegalaxy.org.au"
-  domain: "staging.usegalaxy.org.au"
+  owner_site: "https://site.usegalaxy.org.au"
+  domain: "https://staging.usegalaxy.org.au"
 
 # Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable
 tiaas_disassociate_training_roles:


### PR DESCRIPTION
Prod TIaaS is not loading static files because the `tiaas_info.domain` variable has been set incorrectly (not your fault really, the name is misleading - fixed in new release).

[Take a look](https://usegalaxy.org.au/tiaas/) and you'll see that static files are not loading. I'm not sure why this stopped working now but this PR should fix it.