### PR TITLE
Error retry values for slurm job runner

### DIFF
--- a/templates/galaxy/config/aarnet_job_conf.yml.j2
+++ b/templates/galaxy/config/aarnet_job_conf.yml.j2
@@ -9,6 +9,8 @@ runners:
     workers: 4
   slurm:
     load: galaxy.jobs.runners.slurm:SlurmJobRunner
+    invalidjobexception_retries: 5
+    internalexception_retries: 5
   pulsar_rest:
     load: galaxy.jobs.runners.pulsar:PulsarRESTJobRunner
   pulsar_mel2_runner:

--- a/templates/galaxy/config/dev_job_conf.yml.j2
+++ b/templates/galaxy/config/dev_job_conf.yml.j2
@@ -9,6 +9,8 @@ runners:
     workers: 4
   slurm:
     load: galaxy.jobs.runners.slurm:SlurmJobRunner
+    invalidjobexception_retries: 5
+    internalexception_retries: 5
   pulsar_embedded:
     load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
     pulsar_config: "{{ galaxy_config_dir }}/pulsar_app.yml"

--- a/templates/galaxy/config/staging_job_conf.yml.j2
+++ b/templates/galaxy/config/staging_job_conf.yml.j2
@@ -9,6 +9,8 @@ runners:
     workers: 4
   slurm:
     load: galaxy.jobs.runners.slurm:SlurmJobRunner
+    invalidjobexception_retries: 5
+    internalexception_retries: 5
   pulsar_au_01:
     load: galaxy.jobs.runners.pulsar:PulsarMQJobRunner
     amqp_url: "pyamqp://galaxy_au:{{ vault_rabbitmq_password_galaxy_au_staging }}@staging-queue.usegalaxy.org.au:5671//pulsar/galaxy_au?ssl=1"


### PR DESCRIPTION
The number of retries for InvalidJobException and InternalException defaults to 0, which is why the jobs failed so quickly this morning with this error in the handler logs
```
galaxy.jobs.runners.drmaa WARNING 2022-10-23 21:39:04,495 [pN:handler_0,p:2426728,tN:SlurmRunner.monitor_thread] (4912303/674752) unable to check job status because of InternalException exception for 1 consecutive tries: code 1: slurm_load_jobs error: Resource temporarily unavailable,job_id: 674752
galaxy.jobs.runners.drmaa WARNING 2022-10-23 21:39:04,495 [pN:handler_0,p:2426728,tN:SlurmRunner.monitor_thread] (4912303/674752) job will now be finished OK
```

 I've copied params from Galaxy Main's job conf where they set the value to 5 for each kind of error.
