### PR TITLE
Change only destination for mothur cs from phm0 to phm2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1280,7 +1280,7 @@ tools:
         - pulsar-high-mem1
         - pulsar-high-mem2
         - qld-pulsar-high-mem1
-        - qld-pulsar-high-mem2
+        - qld-pulsar-high-mem0
   toolshed.g2.bx.psu.edu/repos/iuc/phyml/phyml/.*:
     cores: 120
     mem: 1922


### PR DESCRIPTION
We set this up a couple of weeks ago so that mothur_cluster_split high mem jobs would go to qld 0.  I forgot that qld 0 was already the sole destination for maxquant test.

Send mothur_cluster_split jobs to phm2 instead.