### PR TITLE
Update galaxyproject.tiaas2 requirement

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -40,7 +40,7 @@
 - src: usegalaxy_eu.tiaas2
   version: 0.0.9
 - src: galaxyproject.tiaas2
-  version: 2.1.1
+  version: 2.1.2
 # - src: https://github.com/neoformit/ansible-tiaas2
 #   name: dev-tiaas2
 #   version: tiaas-3


### PR DESCRIPTION
Update galaxyproject tiaas2 requirement to 2.12.  It's important that we merge this and `ansible-galaxy install -p roles -r requirements.yml -f` before the playbook is next run.  @neoformit would like to be nearby when we run this.