### PR TITLE
cactus needs more ram

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1513,7 +1513,11 @@ tools:
   # cactus suite
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
     cores: 60
-    mem: 500
+    mem: 961
+    scheduling:
+      accept:
+        - pulsar
+        - high-mem
     params:
       singularity_enabled: True
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_export/cactus_export/.*:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1512,7 +1512,8 @@ tools:
     
   # cactus suite
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
-    cores: 16
+    cores: 60
+    mem: 500
     params:
       singularity_enabled: True
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_export/cactus_export/.*:


### PR DESCRIPTION
@igormakunin detected a cactus job running for >30 days on GA. I ran the same job on HPC and it finished in 3 days but used a lot more RAM than I had configured on GA.

For the record

```
Cores per node: 36
CPU Utilized: 49-05:39:43
CPU Efficiency: 67.84% of 72-13:51:36 core-walltime
Job Wall-clock time: 2-00:23:06
Memory Utilized: 117.82 GB
```