### PR TITLE
Add rule for msconvert

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -265,6 +265,9 @@ tools:
     cores: 16
     context:
       partition: max_quant_w8
+  toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
+    params:
+      docker_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/barrnap/barrnap/.*:
     rules:
     - if: input_size >= 0.0003

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/vortex_config.yml
@@ -54,7 +54,10 @@ tools:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/hifiadapterfilt/hifiadapterfilt/.*:
     params:
-      singularity_enabled: True 
+      singularity_enabled: True
+  toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
+    params:
+      docker_enabled: true 
 
 destinations:
   slurm:


### PR DESCRIPTION
msconvert probably doesn't need anything above the default cores/ram but it must run with `docker_enabled: True`