### PR TITLE
The full path to gunicorn is needed in the supervisor config for some…

### DIFF
--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -94,7 +94,7 @@ galaxy_config_file: /opt/galaxy/galaxy.yml
 host_galaxy_config: # renamed from __galaxy_config
   gravity:
     galaxy_root: /mnt/galaxy/galaxy-app
-    app_server: gunicorn
+    app_server: /mnt/galaxy/venv/bin/gunicorn
     gunicorn:
       # listening options
       bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"


### PR DESCRIPTION
… reason.