### PR TITLE
Remove notice restriction on tiias application

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -243,7 +243,7 @@ tiaas_other_config: |
   TIAAS_SEND_EMAIL_TO = "help@genome.edu.au"
   TIAAS_SEND_EMAIL_FROM = "tiaas-no-reply@usegalaxy.org.au"
   TIAAS_SEND_EMAIL_TO_REQUESTER = True
-  TIAAS_LATE_REQUEST_PREVENTION_DAYS = 7
+  TIAAS_LATE_REQUEST_PREVENTION_DAYS = 0
   TIAAS_GDPR_AUTO_REDACT = False
 
 # Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable


### PR DESCRIPTION
Igor has requested that the restriction on "days until event" to be removed on TIaaS submissions. We frequently have submissions for events that start tomorrow and we're OK with that.