### PR TITLE
Correct mothur rule, set qphm2 offline to reboot

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -82,6 +82,7 @@ destinations:
       require:
         - pulsar
         - high-mem
+        - offline
   pulsar-nci-training:
     cores: 16
     mem: 47.07

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1282,8 +1282,8 @@ tools:
         reject: # only allow it to run on pulsar-qld-high-mem0
         - pulsar-high-mem1
         - pulsar-high-mem2
-        - qld-pulsar-high-mem1
-        - qld-pulsar-high-mem0
+        - pulsar-qld-high-mem1
+        - pulsar-qld-high-mem0
   toolshed.g2.bx.psu.edu/repos/iuc/purge_dups/purge_dups/.*:
     cores: 8
     scheduling:


### PR DESCRIPTION
The rule for mothur had the wrong tags, so jobs have been going to all three qphms. Set qphm2 to offline to be rebooted, since nothing is running there.