### PR TITLE
Add mothur cluster split to hidden tools

### DIFF
--- a/jenkins/update_labels/hidden_tools.yml
+++ b/jenkins/update_labels/hidden_tools.yml
@@ -12,3 +12,4 @@ hidden_tool_ids:
 - toolshed.g2.bx.psu.edu/repos/vlefort/phyml/phyml/*
 - toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/jmoleditor/1.0.0
 - toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/*
+- toolshed.g2.bx.psu.edu/repos/iuc/mothur_cluster_split/mothur_cluster_split/*


### PR DESCRIPTION
Future people will need to either:
* encourage usegalaxy.* and GTN to move away from using mothur_cluster_split or
* unhide this tool with very specific limits in tpv so that jobs fail above the input size used in the GTN tutorial.