### PR TITLE
Allow setting higher cores/mem for tool tests

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -8,6 +8,7 @@ tools:
     env: {}
     context:
       partition: main
+      test_cores: 1
     params:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -697,6 +697,8 @@ tools:
       cores: 8
   toolshed.g2.bx.psu.edu/repos/bgruening/flye/flye/.*:
     cores: 2
+    context:
+      test_cores: 2
     scheduling:
       accept:
       - pulsar
@@ -1517,6 +1519,8 @@ tools:
     
   # cactus suite
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
+    context:
+      test_cores: 4
     cores: 60
     mem: 961
     scheduling:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
@@ -41,7 +41,7 @@ users:
             dependency_resolution: none
     jenkins_bot@usegalaxy.org.au:
       inherits: test_user
-      cores: 1
+      cores: test_cores
       mem: cores * 3.8
       params:
         nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=main"


### PR DESCRIPTION
Add a context variable to the default tool `test_cores` which is 1 unless overridden.  There are only two tools I can think of that need this value to be >1