### PR TITLE
Change path of Send tool, remove builtin tools causing errors in logs

### DIFF
--- a/files/galaxy/config/tool_conf.xml
+++ b/files/galaxy/config/tool_conf.xml
@@ -27,7 +27,7 @@
     </section>
     <section id="send" name="Send Data">
         <tool file="data_export/export_remote.xml" />
-        <tool file="cloud/send.xml"/>
+        <tool file="data_export/send.xml" />
     </section>
     <section id="collection_operations" name="Collection Operations">
         <tool file="${model_tools_path}/unzip_collection.xml"/>
@@ -151,9 +151,6 @@
     <section id="bacterial_typing" name="Bacterial Typing">
     </section>
     <section id="hgv" name="Phenotype Association">
-        <tool file="evolution/codingSnps.xml"/>
-        <tool file="evolution/add_scores.xml"/>
-        <tool file="phenotype_association/sift.xml"/>
         <tool file="phenotype_association/linkToGProfile.xml"/>
         <tool file="phenotype_association/linkToDavid.xml"/>
         <tool file="phenotype_association/ldtools.xml"/>


### PR DESCRIPTION
The Send Data -> Send tools is not displaying because the path has changed.

SIFT, PhylOP and aaChanges do not display and cause errors in the logs because their loc files cannot be found.  If we were to point them to the sample loc files from the code base, the tools would show up but they would be unusable because the sample loc files are empty.