### PR TITLE
Update object store to use /mnt/user-data-6

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -118,7 +118,7 @@ galaxy_tus_upload_store: "{{ galaxy_tmp_dir }}/tus"
 
 galaxy_handler_count: 5
 
-galaxy_file_path: /mnt/user-data-5
+galaxy_file_path: /mnt/user-data-6
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"
@@ -370,6 +370,7 @@ slurm_singularity_volumes_list_restricted:
   - $job_directory:rw
   - $galaxy_root:ro
   - $tool_directory:ro
+  - /mnt/user-data-6:ro
   - /mnt/user-data-5:ro
   - /mnt/user-data-4:ro
   - /mnt/user-data-3:ro

--- a/templates/galaxy/config/aarnet_object_store_conf.xml.j2
+++ b/templates/galaxy/config/aarnet_object_store_conf.xml.j2
@@ -1,26 +1,29 @@
 <?xml version="1.0"?>
 <object_store type="hierarchical">
     <backends>
-        <backend id="aarnetNFS5" type="disk" order="0">
+        <backend id="aarnetNFS6" type="disk" order="0">
+            <files_dir path="/mnt/user-data-6" />
+        </backend>
+        <backend id="aarnetNFS5" type="disk" order="1">
             <files_dir path="/mnt/user-data-5" />
         </backend>
-        <backend id="perthNFS1" type="disk" order="1">
+        <backend id="perthNFS1" type="disk" order="2">
             <files_dir path="/mnt/user-data" />
         </backend>
-        <backend id="perthNFS2" type="disk" order="2">
+        <backend id="perthNFS2" type="disk" order="3">
             <files_dir path="/mnt/user-data-2" />
         </backend>
-        <backend id="perthNFS3" type="disk" order="3">
+        <backend id="perthNFS3" type="disk" order="4">
             <files_dir path="/mnt/user-data-3" />
         </backend>
-        <backend id="perthNFS4" type="disk" order="4">
+        <backend id="perthNFS4" type="disk" order="5">
             <files_dir path="/mnt/user-data-4" />
         </backend>
 {% if legacy_file_mounts_available|d(True) %}
-        <backend id="GPFS" type="disk" order="5">
+        <backend id="GPFS" type="disk" order="6">
             <files_dir path="/mnt/files" />
         </backend>
-        <backend id="NFS" type="disk" order="6">
+        <backend id="NFS" type="disk" order="7">
             <files_dir path="/mnt/files2" />
         </backend>
 {% endif %}


### PR DESCRIPTION
This is a routine change to update galaxy to use /mnt/user-data-6 (the new 50T volume) as the primary user data location.

The current volume is approaching 95% capacity.  Once this is merged, we will need to run the full aarnet playbook, restart galaxy and reload nginx. Implementing the change can wait until after today's Galaxy meeting.  I'll go through these changes with @jlqfab.