### PR TITLE
Adjust flye and training rule

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/roles.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/roles.yml
@@ -34,7 +34,7 @@ roles:
         for ent in filter(lambda x: isinstance(x, Tool), entities):
             value = list(ent.tags.filter(tag_value='pulsar-training-large'))
         value
-      cores: 8
+      cores: 16
       mem: cores * 2.9  # ratio for pulsar-nci-training
       scheduling:
         require:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -726,9 +726,9 @@ tools:
       - pulsar
       - pulsar-training-large
     rules:
-    - if: 0.15 <= input_size < 1
+    - if: 0.15 <= input_size < 0.5
       cores: 8
-    - if: 1 <= input_size < 10
+    - if: 0.5 <= input_size < 10
       cores: 16
     - if: input_size >= 10
       cores: 120


### PR DESCRIPTION
Adjust tpv config so that 0.5-10G flye jobs have 16 cores and the pulsar-training-large jobs are given the minimum of 16 cores and the number of cores they would have outside of training groups.

The pulsar-training-large change from 8 to 16 cores is a temporary fix for today's workshop.  There are ways the roles.yml config could be changed to make it more flexible but I favoured this solution for now because it won't break anything.