### PR TITLE
Add x-clacks-overhead

### DIFF
--- a/templates/nginx/galaxy-dev.j2
+++ b/templates/nginx/galaxy-dev.j2
@@ -20,6 +20,8 @@ server {
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
+        
+        add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70)';
     }
 
     # Static files can be more efficiently served by Nginx. Why send the

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -20,6 +20,8 @@ server {
         uwsgi_pass 127.0.0.1:8080;
         uwsgi_param UWSGI_SCHEME $scheme;
         include uwsgi_params;
+        
+        add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70)';
     }
 
     location ~ ^/api/dataset_collections/([^/]+)/download/?$ {
@@ -41,6 +43,8 @@ server {
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
+        
+        add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70)';
     }
 
     location ~ ^/api/dataset_collections/([^/]+)/download/?$ {


### PR DESCRIPTION
This adds a non-standard header, that was inspired by the Discworld series, and is used on other sites. There a series of towers are used to constantly re-transmit the memory of a lost son, throughout a network. Inspired by this many servers serve a similar header with memories of lost comrades (including Sir Terry Pratchett, the author).

Simon was a huge fan of the Discworld series as well, having read them multiple times over, and I think this is a good way to remember him.

> In Sir Terry's novel "Going Postal", the story explains that the
> inventor of the Clacks - a man named Robert Dearheart, lost his only son
> in a suspicious workplace accident, and in order to keep the memory of
> his son alive, he transmitted his son's name as a special operational
> signal through the Clacks to forever preserve his memory:

https://xclacksoverhead.org/home/about