### PR TITLE
Use fork of ansible-galaxy-subdomains until next release

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -64,4 +64,8 @@
 - name: usegalaxy_eu.flower
   version: 0.3.1-alpha
 - name: usegalaxy_eu.galaxy_subdomains
-  version: 0.0.11
+  # version: 0.0.12
+  # temporarily switched to CB's fork because released version is broken
+  # should be fine to switch back from version 0.0.13 onwards
+  src: https://github.com/cat-bro/ansible-galaxy-subdomains
+  version: 9f4d0185f018ea1e6ca176cb36c7027408f524ac


### PR DESCRIPTION
The current version of ansible-galaxy-subdomains has a bug that breaks galaxy.  Switch version in requirements.yml to a forked copy of the role with the bug fix until the next release of this role (0.0.13) or later.  I've made a PR to their repo and I'll switch this requirement back as soon as it is fixed. This only affects dev.