### PR TITLE
amendments to dev tpv2 rules

### DIFF
--- a/dev_update_configs_playbook.yml
+++ b/dev_update_configs_playbook.yml
@@ -1,4 +1,4 @@
-- hosts: dev_handlers_server
+- hosts: dev_galaxy_server
   become: true
   vars_files:
       - group_vars/all.yml
@@ -10,12 +10,15 @@
       - secret_group_vars/ubuntu_maintenance_key
       - secret_group_vars/dev_secrets
   handlers:
-    - name: galaxy gravity restart
-      become: True
-      become_user: galaxy
-      command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
-      environment:
-        GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+  - name: galaxy gravity restart
+    debug:
+      msg: "restart it yrslf"
+    # - name: galaxy gravity restart
+    #   become: True
+    #   become_user: galaxy
+    #   command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
+    #   environment:
+    #     GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
   pre_tasks:
     - name: copy job_conf file
       template:

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/destinations.yml.j2
@@ -2,30 +2,34 @@ destinations:
   default:
     runner: slurm # abstract: this runner will be overridden
     abstract: true
-    tags:
-      - registered_user_concurrent_jobs_20
-    rules:
-      - if: params.get('singularity_enabled') # TODO: check that this is boolean and not string
-        params:
-            singularity_default_container_id: "{{ singularity_default_container_id }}"  
-      - if: params.get('docker_enabled')
-        params:
-            docker_memory: '{mem}G'
-            docker_sudo: false
+    # having rules on default abstract dest then rules on descendant abstract dest seems to prevent the descendant rules from applying
+    # rules:
+    #   - id: default_destination_singularity_rule
+    #     if: entity.params.get('singularity_enabled') # TODO: check that this is boolean and not string
+    #     params:
+    #         singularity_default_container_id: "{{ singularity_default_container_id }}"
+    #   - id: default_destination_docker_rule 
+    #     if: entity.params.get('docker_enabled')
+    #     params:
+    #         docker_memory: '{mem}G'
+    #         docker_sudo: false
   _slurm_destination:
-    inherits: default
     abstract: true
     params:
         nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
     rules:
-      - if: params.get('singularity_enabled')
+      - id: slurm_destination_singularity_rule
+        if: entity.params.get('singularity_enabled')
         params:
             singularity_volumes: "{{ slurm_singularity_volumes }}"
-      - if: params.get('docker_enabled')
+            singularity_default_container_id: "{{ singularity_default_container_id }}" # default dest
+      - id: slurm_destination_docker_rule
+        if: entity.params.get('docker_enabled')
         params:
             docker_volumes: "{{ slurm_docker_volumes }}"
+            docker_memory: '{mem}G' # default dest
+            docker_sudo: false # default dest
   _pulsar_destination:
-    inherits: default
     abstract: true
     params:
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
@@ -40,20 +44,35 @@ destinations:
       persistence_directory: /mnt/pulsar/files/persisted_data # TODO: this could be a variable
 
     rules:
-      - if: params.get('singularity_enabled')
+      - id: pulsar_destination_singularity_rule
+        if: entity.params.get('singularity_enabled')
         params:
             singularity_volumes: "{{ pulsar_singularity_volumes }}"
             container_resolvers: 
                 - type: explicit_singularity
                 - type: mulled_singularity
+            singularity_default_container_id: "{{ singularity_default_container_id }}" # default dest
         env:
           SINGULARITY_CACHEDIR: /mnt/pulsar/deps/singularity
           SINGULARITY_TMPDIR: /mnt/pulsar/deps/singularity/tmp
 
-      - if: params.get('docker_enabled')
+      - id: pulsar_destination_docker_rule
+        if: entity.params.get('docker_enabled')
         params:
             docker_volumes: "{{ pulsar_docker_volumes }}"
-            docker_set_user: '1000'    
+            docker_set_user: '1000'
+            docker_memory: '{mem}G' # default dest
+            docker_sudo: false # default dest
+      # - id: pulsar_destination_silly_rule # leave debugging rule in comments for now
+      #   if: 1 == 1
+      #   params:
+      #     hello_cat: HELLO
+      #   execute: |
+      #     log.debug("PRINTING ENTITY PARAMS")
+      #     for x in entity.params:
+      #       log.debug(str(x))
+      #       log.debug(str(entity.params.get(x)))
+  
   slurm:
     inherits: _slurm_destination
     tags:
@@ -64,7 +83,6 @@ destinations:
       accept:
         - slurm
   interactive_local:
-    inherits: default
     runner: local
     tags:
       - registered_user_concurrent_jobs_20
@@ -77,6 +95,11 @@ destinations:
       docker_auto_rm: true
       docker_set_user: ''
       docker_require_container: true
+      docker_memory: '{mem}G' # default dest
+      docker_sudo: false # default dest
+    scheduling:
+      require:
+        - interactive_local
   interactive_pulsar:
     inherits: interactive_local
     runner: pulsar_embedded
@@ -88,6 +111,9 @@ destinations:
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
       outputs_to_working_directory: false
       container_monitor_result: callback
+    scheduling:
+      require:
+        - interactive_pulsar
   pulsar_destination:
     inherits: _pulsar_destination
     runner: pulsar_au_01

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/vortex_config.yml
@@ -275,7 +275,6 @@ tools:
     cores: 8
     params:
       singularity_enabled: True
-      singularity_default_container_id: '/cvmfs/singularity.galaxyproject.org/all/python:3.8.3'
   toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/.*:
     # context:
     #   minimum_singularity_version: 5.0.0+galaxy0  # not working, ref https://github.com/galaxyproject/total-perspective-vortex/pull/32
@@ -346,7 +345,7 @@ users:
       - if: |
           'hifiadapterfilt' in tool.id
         cores: 16
-        mem: cores * 3.8
+        mem: cores * 2.5
   pulsar_user@usegalaxy.org.au:
     inherits: test_user
     rules:


### PR DESCRIPTION
Default destination is abstract (jobs cannot go there) and has rules that add params if singularity_enabled is true.
_pulsar_destination is abstract and has rules that add params if singularity_enabled is true.

For some reason the singularity rules for _pulsar_destination were not being applied to the job destination until I commented out the rules for the default destination.  So far I haven't been able to reproduce this in tpv tests, so there might be a typo in this config that I am missing.
