### PR TITLE
add docker and singularity tags to all dev destinations, add debug rule to default tool

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/default_tool.yml.j2
@@ -11,7 +11,14 @@ tools:  # test template variable for galaxy_root here {{ galaxy_root }}
     scheduling:
       reject:
         - offline
-    rules: []
+    rules:
+    - id: default_destination_debug_rule
+      if: 1 == 1
+      execute: |
+        log.debug("********** PRINTING ENTITY CORES AND MEM")
+        log.debug(f'cores: {str(entity.cores)}')
+        log.debug(f'mem: {str(entity.mem)}')
+
     rank: |
       final_destinations = helpers.weighted_random_sampling(candidate_destinations)
       final_destinations

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/destinations.yml.j2
@@ -13,6 +13,10 @@ destinations:
     #     params:
     #         docker_memory: '{mem}G'
     #         docker_sudo: false
+    scheduling:
+      accept:
+        - docker # to satisfy tools in shared db that have require: docker
+        - singularity # to satisfy tools in shared db that have require: singularity
   _slurm_destination:
     abstract: true
     params:


### PR DESCRIPTION
Destinations need to accept `singularity` and `docker` tags because some tools from the shared database require them