### PR TITLE
TPV: add bakta and vcf2maf, update rgrnastar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -243,6 +243,8 @@ tools:
       accept:
       - pulsar
     cores: 5
+  toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/.*:
+    cores: 8
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate_predict/funannotate_predict/.*:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/mummer_nucmer/mummer_nucmer/.*:
@@ -260,6 +262,8 @@ tools:
       cores: 5
   toolshed.g2.bx.psu.edu/repos/devteam/velvet/velveth/.*:
     cores: 2
+  toolshed.g2.bx.psu.edu/repos/iuc/vcf2maf/vcf2maf/.*:
+    cores: 6
   toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/.*:
     cores: 6
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant/.*:
@@ -1082,7 +1086,7 @@ tools:
         accept:
         - high-mem
   toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/.*:
-    cores: 8
+    cores: 12
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
Add bakta and vcf2maf as slurm only for now.  Update rgrnastar to use 12 cores/ 12*3.8G