### PR TITLE
Revert "make bakta run with singularity"

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -245,8 +245,6 @@ tools:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/.*:
     cores: 8
-    params:
-      singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate_predict/funannotate_predict/.*:
     cores: 5
   toolshed.g2.bx.psu.edu/repos/iuc/mummer_nucmer/mummer_nucmer/.*:


### PR DESCRIPTION
Reverts usegalaxy-au/infrastructure#1123

The db downloaded using the conda environment may not be compatible with the version of amrfinderplus in the singularity container.