### PR TITLE
take pulsar-paw offline for Pawsey maintenance

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -34,6 +34,7 @@ destinations:
       require:
         - pulsar-paw
         - pulsar
+        - offline
   pulsar-mel3:
     cores: 32
     mem: 122.86


### PR DESCRIPTION
Pulsar-paw needs to be taken offline prior to the Pawsey maintenance beginning Friday 8am AWST.
