### PR TITLE
galaxy singularity cache data to go to /mnt/singularity_data on dev

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -25,6 +25,13 @@
         owner: root
         group: galaxy
         mode: 0775
+    - name: create dir for galaxy's singularity cache
+      file:
+        state: directory
+        path: "{{ galaxy_user_singularity_cachedir }}"
+        owner: galaxy
+        group: galaxy
+        mode: 0700
   roles:
     - galaxyproject.repos
     - common

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -40,6 +40,10 @@ interactive_tools_server_name: "{{ hostname }}"
 
 galaxy_db_user_password: "{{ vault_dev_db_user_password }}"
 
+# singularity cache of galaxy user (this defaults to /home/galaxy/.singularity). Not to be confused with cache directory for built sif files in galaxy_config.galaxy.container_resolvers_conf
+galaxy_user_singularity_cachedir: /mnt/singularity_data
+galaxy_user_singularity_tmpdir: "{{ galaxy_user_singularity_cachedir }}/tmp"
+
 # ansible-galaxy
 galaxy_dynamic_job_rules_src_dir: files/galaxy/dynamic_job_rules/dev
 galaxy_dynamic_job_rules_dir: "{{ galaxy_root }}/dynamic_job_rules"
@@ -108,6 +112,8 @@ host_galaxy_config: # renamed from __galaxy_config
       preload: true
       environment:
         DRMAA_LIBRARY_PATH: "/usr/lib/slurm-drmaa/lib/libdrmaa.so.1"
+        SINGULARITY_CACHEDIR: "{{ galaxy_user_singularity_cachedir }}"
+        SINGULARITY_TMPDIR: "{{ galaxy_user_singularity_tmpdir }}"
     celery:
       enable: false
       enable_beat: false


### PR DESCRIPTION
Set value for SINGULARITY_CACHEDIR on dev so that space is not taken up in /home/galaxy/.singularity.

Every time a new tool is run with singularity it is causing a fair bit of space to be used on the head node root disk, so if this setup works I'll copy it on staging + production.

path name is '/mnt/singularity_data' so that it sits alongside '/mnt/docker_data' (the place that docker things go to instead of the root disk)