### PR TITLE
update alphafold test to use azuregpu0 partition

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1592,10 +1592,10 @@ tools:
       require:
         - pulsar-qld-high-mem0
   alphafold_test:
-    cores: 6
-    mem: 106
+    cores: 8
+    mem: 69
     context:
-      partition: azuregpu1
+      partition: azuregpu0
     params:
       docker_enabled: true
       docker_run_extra_arguments: "--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=16 --env ALPHAFOLD_AA_LENGTH_MAX=3000"


### PR DESCRIPTION
update alphafold_test tool for new cluster.  `azuregpu0` partition is for regular alphafold jobs and `azuregpu1` is now only for vet school jobs.