### PR TITLE
Update small job size threshold for unicycler

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1145,7 +1145,7 @@ tools:
       - pulsar
       - pulsar-training-large
     rules:
-    - if: 0.2 <= input_size < 2
+    - if: 0.05 <= input_size < 2
       cores: 8
     - if: input_size >= 2
       cores: 16


### PR DESCRIPTION
There are some jobs running with input size just under 0.2G (the current threshold) and they are running for hours with default resources. They should probably be in the 8 core/8*3.8G mem bracket.