### PR TITLE
add sam_pileup to conda environments list

### DIFF
--- a/one-offs/conda_envs/conda_environments.yml
+++ b/one-offs/conda_envs/conda_environments.yml
@@ -238,3 +238,8 @@ miniconda_conda_environments:
         packages:
         - lofreq=2.1.5
         - samtools=1.15 # added
+    # toolshed.g2.bx.psu.edu/repos/devteam/sam_pileup/sam_pileup/1.1.3
+    __samtools@0.1.16:
+        packages:
+        - samtools=0.1.16
+        - ncurses=5.9 # added


### PR DESCRIPTION
Add amendment for sam_pileup conda environment to a list of conda environments that require extra packages