### PR TITLE
Add singularity cache folder creation to dev handlers playbook, clean up post tasks

### DIFF
--- a/dev-handler_playbook.yml
+++ b/dev-handler_playbook.yml
@@ -11,11 +11,13 @@
     - secret_group_vars/stats_server_vault
     - secret_group_vars/dev_secrets
     - secret_group_vars/sentry_vault
-  # handlers:
-  #   - name: Restart Galaxy
-  #     systemd:
-  #       name: galaxy
-  #       state: restarted
+  handlers:
+    - name: galaxy gravity restart
+      become: True
+      become_user: galaxy
+      command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
+      environment:
+        GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
   pre_tasks:
     - name: Attach volume to instance
       include_role:
@@ -27,6 +29,13 @@
         owner: root
         group: galaxy
         mode: 0775
+    - name: create dir for galaxy's singularity cache # this is still on the root disk, it's a test of moving the singularity cache
+      file:
+        state: directory
+        path: "{{ galaxy_user_singularity_cachedir }}"
+        owner: galaxy
+        group: galaxy
+        mode: 0700
   roles:
     - galaxyproject.repos
     - common
@@ -62,51 +71,21 @@
     - dj-wasabi.telegraf
     #- login-override
     - usegalaxy_eu.flower
+    - acl-on-startup
   post_tasks:
-    # - name: Ensure object store paths exist
-    #   file:
-    #     state: directory
-    #     path: "{{ item }}"
-    #     owner: galaxy
-    #     group: galaxy
-    #   with_items:
-    #     - /mnt/galaxy/data
-    #     - /mnt/galaxy/data-2
-    #     - /mnt/galaxy/data-3
-    # - name: Make local_tool directory group-writable by machine users
-    #   file:
-    #     path: /mnt/galaxy/local_tools
-    #     owner: root
-    #     group: devs
-    #     mode: 0775
-    #     state: directory
-    # - name: Clone galaxy-local-tools
-    #   git:
-    #     repo: https://github.com/usegalaxy-au/galaxy-local-tools
-    #     dest: "{{ galaxy_server_dir }}/tools/galaxy-local-tools"
-    #     update: yes
-    # - name: Ensure data_fetch tmp directory exists
-    #   file:
-    #     path: "{{ galaxy_tmp_dir }}/data_fetch"
-    #     owner: "{{ galaxy_user.name }}"
-    #     group: "{{ galaxy_user.name }}"
-    #     state: directory
+    - name: Make local_tool directory group-writable by machine users
+      file:
+        path: /mnt/galaxy/local_tools
+        owner: root
+        group: devs
+        mode: 0775
+        state: directory
     - name: Install slurm-drmaa
       package:
         name: slurm-drmaa1
-    # - name: Workaround content-length header bug in webdav through forcible update to newer version
-    #   pip:
-    #     name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
-    #     state: forcereinstall
-    #     virtualenv: "{{ galaxy_venv_dir }}"
-    # - name: Reload exportfs
-    #   command: exportfs -ra
-    #   become: yes
-    #   become_user: root
-    # - name: set acl for galaxy user on docker.sock
-    #   acl:
-    #     path: /var/run/docker.sock
-    #     entity: "{{ galaxy_user.name }}"
-    #     etype: user
-    #     permissions: rw
-    #     state: present
+    - name: Workaround content-length header bug in webdav through forcible update to newer version
+      pip:
+        name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
+        state: forcereinstall
+        virtualenv: "{{ galaxy_venv_dir }}"
+

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -12,8 +12,12 @@
     - secret_group_vars/dev_secrets
     - secret_group_vars/sentry_vault
   handlers:
-    - name: Restart Galaxy
-      shell: "echo hi"
+    - name: galaxy gravity restart
+      become: True
+      become_user: galaxy
+      command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
+      environment:
+        GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
   pre_tasks:
     - name: Attach volume to instance
       include_role:
@@ -61,10 +65,7 @@
     - pg-post-tasks
     - remote-pulsar-cron
     - galaxy-pg-cleanup
-
-    # - usegalaxy_eu.tiaas2
     - galaxyproject.tiaas2
-    # - dev-tiaas2
     - geerlingguy.docker
     - usegalaxy_eu.gie_proxy
     - dj-wasabi.telegraf
@@ -87,17 +88,6 @@
         group: devs
         mode: 0775
         state: directory
-    - name: Clone galaxy-local-tools
-      git:
-        repo: https://github.com/usegalaxy-au/galaxy-local-tools
-        dest: "{{ galaxy_server_dir }}/tools/galaxy-local-tools"
-        update: yes
-    - name: Ensure data_fetch tmp directory exists
-      file:
-        path: "{{ galaxy_tmp_dir }}/data_fetch"
-        owner: "{{ galaxy_user.name }}"
-        group: "{{ galaxy_user.name }}"
-        state: directory
     - name: Install slurm-drmaa
       package:
         name: slurm-drmaa1
@@ -110,10 +100,4 @@
       command: exportfs -ra
       become: yes
       become_user: root
-    - name: set acl for galaxy user on docker.sock
-      acl:
-        path: /var/run/docker.sock
-        entity: "{{ galaxy_user.name }}"
-        etype: user
-        permissions: rw
-        state: present
+


### PR DESCRIPTION
Add singularity cache dir creation to the dev-handlers playbook.  This is just another path on the root disk but will show whether moving the cache works.

Also updated dev and dev-handler playbooks: Reenable handlers, stop cloning galaxy-local-tools, remove check for data_fetch tmp directory as this is not needed, remove post task to set acl in favour of acl-on-startup role