### PR TITLE
dev tpv: work around galaxy requirement of version <2

### DIFF
--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -11,7 +11,8 @@ tpv_version: "2.0.1"
 # tpv_commit_id: d8e336b1cc889237c155d0ad318051c36e5636e6
 
 # workaround to maintain correct tpv version (release_22.05)
-galaxy_additional_venv_packages: ['total-perspective-vortex=={{ tpv_version }}']
+galaxy_additional_venv_packages: |
+  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
 
 # variables for attaching mounted volume to application server
 attached_volumes:

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -10,6 +10,9 @@ tpv_version: "2.0.1"
 # tpv_repo: https://github.com/usegalaxy-au/total-perspective-vortex
 # tpv_commit_id: d8e336b1cc889237c155d0ad318051c36e5636e6
 
+# workaround to maintain correct tpv version (release_22.05)
+galaxy_additional_venv_packages: ['total-perspective-vortex=={{ tpv_version }}']
+
 # variables for attaching mounted volume to application server
 attached_volumes:
   - device: /dev/vdb


### PR DESCRIPTION
this adds the tpv package to `galaxy_additional_venv_packages` to be installed straight after conditional dependencies in the galaxyproject.galaxy role. This means that during the playbook run the tpv version is put down to 1.4.1 then upgraded to 2.0.1 which is uncool but probably harmless.