### PR TITLE
fix regex in add_hosts.yml

### DIFF
--- a/roles/common/tasks/add_hosts.yml
+++ b/roles/common/tasks/add_hosts.yml
@@ -11,7 +11,7 @@
       become_user: root
       lineinfile:
           path: "{{ hosts_filename }}"
-          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}.*"
+          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}$"
           line: "{{ hostvars[item][ip_field] }}\t{{ item }}"
           state: present
           backup: yes
@@ -24,7 +24,7 @@
       become_user: root
       lineinfile:
           path: "{{ hosts_filename }}"
-          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}.*"
+          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}$"
           line: "{{ hostvars[item][ip_field] }}\t{{ item }}"
           state: present
           backup: yes
@@ -37,7 +37,7 @@
       become_user: root
       lineinfile:
           path: "{{ hosts_filename }}"
-          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}.*"
+          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}$"
           line: "{{ hostvars[item][ip_field] }}\t{{ item }}"
           state: present
           backup: yes
@@ -50,7 +50,7 @@
       become_user: root
       lineinfile:
           path: "{{ hosts_filename }}"
-          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}.*"
+          regexp: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\t{{ item }}$"
           line: "{{ hostvars[item][ip_field] }}\t{{ item }}"
           state: present
           backup: yes


### PR DESCRIPTION
The regex pattern was allowing 'x.x.x.x aarnet.*' to match entries for other hosts such as aarnet-queue