### PR TITLE
Add apt key for influx to common role

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -5,6 +5,11 @@
     hosts_filename: "{{ hosts_template_file }}"
   when: hosts_template_file is defined
 
+- name: Add Influx apt repository key (pre ubuntu 22.04)
+  ansible.builtin.apt_key:
+    url: https://repos.influxdata.com/influxdata-archive_compat.key
+    state: present
+
 - name: Update the apt repos and base OS
   apt:
       upgrade: dist


### PR DESCRIPTION
From official instructions [here](https://github.com/influxdata/telegraf/blob/master/README.md#package-repository) plus Jeff Geerling's [post](https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible) recommended by JL