### PR TITLE
Remove max_quant_w8 partition and limit maxquant in tpv

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -270,16 +270,18 @@ tools:
     cores: 6
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant/.*:
     cores: 16
-    context:
-      partition: max_quant_w8
+    rules:
+    - if: |
+        user_limit = 2
+        total_limit = 4
+        helpers.concurrent_job_count_for_tool(app, tool, user) >= user_limit or helpers.concurrent_job_count_for_tool(app, tool) >= total_limit
+      execute: |
+        from galaxy.jobs.mapper import JobNotReadyException
+        raise JobNotReadyException()
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant_mqpar/.*:
     cores: 16
-    context:
-      partition: max_quant_w8
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant_mqpar/maxquant_mqpar/.*:
     cores: 16
-    context:
-      partition: max_quant_w8
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
     params:
       docker_enabled: true

--- a/group_vars/aarnet_slurm.yml
+++ b/group_vars/aarnet_slurm.yml
@@ -78,10 +78,6 @@ slurm_partitions:
     nodes: "aarnet-w7,aarnet-w5,aarnet-w4,aarnet-w8"
     Default: NO
     State: UP
-  - name: max_quant_w8
-    nodes: "aarnet-w8"
-    Default: NO
-    State: UP
   - name: interactive_tools
     nodes: "aarnet-w4,aarnet-w5"
     Default: NO


### PR DESCRIPTION
The slurm partition max_quant_w8 started off as a priority queue for maxquant because no other jobs could run there. When galaxy became more busy, the w8 worker was added to the main queue so it became difficult for maxquant jobs to get a place to run. This PR removes the max_quant_w8 partition and puts some limits on the maxquant tool in tpv to stop it from taking over slurm.

Note: this has no effect the local maxquant_test tool which is subject to different rules.