### PR TITLE
Add cron job for deleting old jwds from pulsar-azure

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -355,6 +355,13 @@ rpc_pulsar_machines:
     keep_error_days: 7
     cron_hour: "18"
     cron_minute: "40"
+  - pulsar_name: pulsar-azure-0
+    pulsar_ip_address: "{{ hostvars['pulsar-azure-0']['ansible_ssh_host'] }}"
+    ssh_key: /home/ubuntu/.ssh/ubuntu_maintenance_key
+    delete_jwds: true
+    keep_error_days: 7
+    cron_hour: "18"
+    cron_minute: "50"
 
 extra_keys:
   - id: ubuntu_maintenance_key


### PR DESCRIPTION
ubuntu_maintenance_key public key has been added to pulsar-azure and this key will only be accepted for aarnet's IP.
