### PR TITLE
Fix gxctl function

### DIFF
--- a/roles/common/tasks/machine_users.yml
+++ b/roles/common/tasks/machine_users.yml
@@ -107,7 +107,7 @@
           export gctl_args="$@"
           export GRAVITY_STATE_DIR={{ galaxy_gravity_state_dir }}
  
-          sudo -H -Eu {{ galaxy_user.name }} bash -c '{{ galaxy_venv_dir }}/bin/galaxyctl $gctl_args' 
+          sudo -H -Eu {{ galaxy_user.name }} bash -c '. {{ galaxy_venv_dir }}/bin/activate && {{ galaxy_venv_dir }}/bin/galaxyctl $gctl_args' 
         }
       marker: "# {mark} MANAGED BY ANSIBLE - DO NOT MODIFY (gxctl)"
     with_items: "{{ machine_users | selectattr('roles', 'contains', 'sudo') | list + [{'name': 'ubuntu'}] }}"


### PR DESCRIPTION
It is not enough to run /mnt/galaxy/venv/bin/galaxyctl, the venv must be active where galaxyctl is run to pass it onto child processes.