### PR TITLE
Add training-exempt tag for alphafold and interactive tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/roles.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/roles.yml
@@ -6,12 +6,17 @@ roles:
     rules:
     - if: |
         from tpv.core.entities import Tool
-        value = True  # assume rule matches, opt out if there is a pulsar tag
-        for ent in filter(lambda x: isinstance(x, Tool), entities):
-            value = not list(ent.tags.filter(tag_value='pulsar')) and not list(entity.tags.filter(tag_value='interactive_pulsar')) # tool has no pulsar tag and so runs on slurm
+        include_tags = []
+        exclude_tags = ['pulsar', 'training-exempt']
+        value = False
+        for ent in filter(lambda x: isinstance(x, Tool), entities):  # there should be exactly one of these
+            value = (
+              all([ent.tags.filter(tag_value=tag_name) for tag_name in include_tags])
+              and none([ent.tags.filter(tag_value=tag_name) for tag_name in exclude_tags])
+            )
         value
       cores: 2
-      mem: cores * 3.8  # TODO check multiplier
+      mem: cores * 3.8
       context:
         partition: training
       scheduling:
@@ -19,9 +24,14 @@ roles:
           - slurm
     - if: |
         from tpv.core.entities import Tool
+        include_tags = ['pulsar']
+        exclude_tags = ['pulsar-training-large', 'training-exempt']
         value = False
         for ent in filter(lambda x: isinstance(x, Tool), entities):
-            value = list(ent.tags.filter(tag_value='pulsar')) and not list(ent.tags.filter(tag_value='pulsar-training-large'))
+            value = (
+              all([ent.tags.filter(tag_value=tag_name) for tag_name in include_tags])
+              and none([ent.tags.filter(tag_value=tag_name) for tag_name in exclude_tags])
+            )
         value
       cores: 4
       mem: cores * 2.9  # ratio for pulsar-nci-training
@@ -30,9 +40,14 @@ roles:
           - pulsar  # require pulsar and training: only one place to go
     - if: |
         from tpv.core.entities import Tool
+        include_tags = ['pulsar-training-large']
+        exclude_tags = ['training-exempt']
         value = False
         for ent in filter(lambda x: isinstance(x, Tool), entities):
-            value = list(ent.tags.filter(tag_value='pulsar-training-large'))
+            value = (
+              all([ent.tags.filter(tag_value=tag_name) for tag_name in include_tags])
+              and none([ent.tags.filter(tag_value=tag_name) for tag_name in exclude_tags])
+            )
         value
       cores: 16
       mem: cores * 2.9  # ratio for pulsar-nci-training

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -40,6 +40,8 @@ tools:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=interactive_tools"
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition=interactive_tools"
     scheduling:
+      accept:
+        - training-exempt
       require:
         - interactive_pulsar
 
@@ -1518,6 +1520,8 @@ tools:
         context:
           partition: azuregpu0
         scheduling:
+          accept:
+            - training-exempt
           require:
             - pulsar
             - pulsar-azure-gpu
@@ -1639,6 +1643,8 @@ tools:
       docker_enabled: true
       docker_run_extra_arguments: --gpus all --env ALPHAFOLD_AA_LENGTH_MIN=16 --env ALPHAFOLD_AA_LENGTH_MAX=3000 --env ALPHAFOLD_DB=/data/v2.3
     scheduling:
+      accept:
+        - training-exempt
       require:
         - pulsar
         - pulsar-azure-gpu


### PR DESCRIPTION
Add a tag to prevent tools unsuitable for training destinations from being sent there. Instead the destination is unchanged regardless of whether the user is part of a training group.