### PR TITLE
add writable-tmpfs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1621,25 +1621,23 @@ tools:
       singularity_enabled: True
 
   # protk tools
-  toolshed.g2.bx.psu.edu/repos/iracooke/protk-galaxytools/.*:
-    cores: 1
-    params:
-      singularity_enabled: True
-
   toolshed.g2.bx.psu.edu/repos/iracooke/protk_proteogenomics/.*:
     cores: 1
     params:
       singularity_enabled: True
+      singularity_run_extra_arguments: '--writable-tmpfs'
 
   toolshed.g2.bx.psu.edu/repos/iracooke/tpp_prophets/.*:
     cores: 1
     params:
       singularity_enabled: True
+      singularity_run_extra_arguments: '--writable-tmpfs'
 
   toolshed.g2.bx.psu.edu/repos/iracooke/xtandem/.*:
     cores: 1
     params:
       singularity_enabled: True
+      singularity_run_extra_arguments: '--writable-tmpfs'
 
   # test tools
   maxquant_test:


### PR DESCRIPTION
Error is `Read-only file system @ rb_sysopen`.  These tools need `writable-tmpfs`   so their installation directories don't appear read only. We did this on dev too.

https://github.com/usegalaxy-au/infrastructure/pull/1173