### PR TITLE
upgrade total-perspective-vortex to 1.4.1

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -32,7 +32,7 @@ galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_22.05
 
 # total perspective vortex
-tpv_version: "1.2.0"
+tpv_version: "1.4.1"
 
 # Mounts for various connections:
 shared_mounts: # TODO: /mnt/custom-indices from aarnet-misc-nfs


### PR DESCRIPTION
There's a draft PR to upgrade to 2.x which is not ready yet. An update to 1.4.1 is needed sooner to fix a bug.