### PR TITLE
Update slurm destination max allowed mem in tpv

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml
@@ -1,7 +1,7 @@
 destinations:
   slurm:
     cores: 32
-    mem: 121.25
+    mem: 123.8
     scheduling:
       accept:
         - slurm


### PR DESCRIPTION
Slurm destination's max allowed mem in tpv is 121.25, less than 121.6 mem set for a 32 core job (32 x 3.8)

The new value is based on MemAvailable for aarnet-w10