### PR TITLE
Add user-data-7 to aarnet-user-nfs

### DIFF
--- a/aarnet-user-nfs_playbook.yml
+++ b/aarnet-user-nfs_playbook.yml
@@ -22,6 +22,7 @@
           - "{{ galaxy_nfs_user_data_4_dir }}"
           - "{{ galaxy_nfs_user_data_5_dir }}"
           - "{{ galaxy_nfs_user_data_6_dir }}"
+          - "{{ galaxy_nfs_user_data_7_dir }}"
 
   roles:
       - common
@@ -42,6 +43,7 @@
           - "{{ galaxy_nfs_user_data_4_dir }}"
           - "{{ galaxy_nfs_user_data_5_dir }}"
           - "{{ galaxy_nfs_user_data_6_dir }}"
+          - "{{ galaxy_nfs_user_data_7_dir }}"
       - name: Reload exportfs
         command: exportfs -ra
         become: yes

--- a/group_vars/aarnet_workers.yml
+++ b/group_vars/aarnet_workers.yml
@@ -46,12 +46,16 @@ shared_mounts: # TODO: /mnt/custom-indices from aarnet-misc-nfs
     src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data4"
     fstype: nfs
     state: mounted
-  - path: /mnt/user-data-5 # new file path for production aarnet
+  - path: /mnt/user-data-5
     src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data5"
     fstype: nfs
     state: mounted
   - path: /mnt/user-data-6 # new volume for production aarnet
     src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/user-data6"
+    fstype: nfs
+    state: mounted
+  - path: /mnt/user-data-7 # new file path sourced from /mnt volume on aarnet-user-nfs
+    src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data7"
     fstype: nfs
     state: mounted
   - path: /mnt/tmp

--- a/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/aarnet-user-nfs.usegalaxy.org.au.yml
@@ -1,6 +1,6 @@
 attached_volumes:
   - device: /dev/vdb
-    path: /mnt  # this will contain user-data, user-data-2/3/4 from perth.  
+    path: /mnt
     fstype: ext4
   - device: /dev/vdc
     partition: 1
@@ -11,8 +11,9 @@ galaxy_nfs_user_data_dir: /mnt/user-data
 galaxy_nfs_user_data_2_dir: /mnt/user-data2
 galaxy_nfs_user_data_3_dir: /mnt/user-data3
 galaxy_nfs_user_data_4_dir: /mnt/user-data4
-galaxy_nfs_user_data_5_dir: /mnt/user-data5  # new data path
+galaxy_nfs_user_data_5_dir: /mnt/user-data5
 galaxy_nfs_user_data_6_dir: /user-data6
+galaxy_nfs_user_data_7_dir: /mnt/user-data7
 
 nfs_exports:
   - "{{ galaxy_nfs_user_data_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
@@ -21,3 +22,4 @@ nfs_exports:
   - "{{ galaxy_nfs_user_data_4_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
   - "{{ galaxy_nfs_user_data_5_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
   - "{{ galaxy_nfs_user_data_6_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ galaxy_nfs_user_data_7_dir }} {{ hostvars['aarnet'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -72,12 +72,16 @@ shared_mounts: # TODO: /mnt/custom-indices from aarnet-misc-nfs
     src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data4"
     fstype: nfs
     state: mounted
-  - path: /mnt/user-data-5 # new file path for production aarnet
+  - path: /mnt/user-data-5
     src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data5"
     fstype: nfs
     state: mounted
   - path: /mnt/user-data-6 # new volume for production aarnet
     src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/user-data6"
+    fstype: nfs
+    state: mounted
+  - path: /mnt/user-data-7 # new file path sourced from /mnt volume on aarnet-user-nfs
+    src: "{{ hostvars['aarnet-user-nfs']['internal_ip'] }}:/mnt/user-data7"
     fstype: nfs
     state: mounted
   - path: /mnt/tmp


### PR DESCRIPTION
Add /mnt/user-data-7 to aarnet-user-nfs and its nfs exports, mount it on aarnet head and workers

When user-data-6 is 90-95% full, user-data-7 should be added as the first entry in the object store config