### PR TITLE
Give db params in stats role more specific variable names

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -9,6 +9,8 @@ group_packages:
 pip_virtualenv_command: /usr/bin/python3 -m virtualenv # usegalaxy_eu.certbot, usegalaxy_eu.tiaas2, galaxyproject.galaxy
 certbot_virtualenv_package_name: python3-virtualenv # usegalaxy_eu.certbot
 
+gxadmin_commit: 284f6dbcb22f15634287072d93c567b0195975d3
+
 # Postgres
 postgresql_objects_users:
   - name: galaxy

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -233,11 +233,11 @@ gxadmin_ubuntu_config_dir: /home/ubuntu/.config
 stats_dir: /home/ubuntu/stats_collection
 stats_instance: main
 sinfo_hostname: 'Galaxy-Main'
-db_server: "{{ hostvars['aarnet-db']['internal_ip'] }}"
-db_user: reader
+stats_db_server: "{{ hostvars['aarnet-db']['internal_ip'] }}"
+stats_db_user: reader
 influx_url: "stats.usegalaxy.org.au"
 influx_db_stats: "GA_server"
-db_password: "{{ vault_aarnet_db_reader_password }}"
+stats_db_password: "{{ vault_aarnet_db_reader_password }}"
 influx_salt: "{{ prod_queue_size_salt }}"
 add_daily_stats: true
 add_monthly_stats: true

--- a/roles/slg.galaxy_stats/defaults/main.yml
+++ b/roles/slg.galaxy_stats/defaults/main.yml
@@ -20,10 +20,10 @@ influx_db_queue: "queue-db"
 influx_db_stats: "stats-db"
 
 #Galaxy Database settings
-db_server: localhost
-database: galaxy
-db_user: galaxy
-db_port: 5432 
+stats_db_server: localhost
+stats_database: galaxy
+stats_db_user: galaxy
+stats_db_port: 5432 
 
 # Galaxy settings
 galaxy_root: /mnt/galaxy/galaxy-app/

--- a/roles/slg.galaxy_stats/templates/current_stats.sh.j2
+++ b/roles/slg.galaxy_stats/templates/current_stats.sh.j2
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash -l
 
 # [SLG 05-12-2018] Added some psql environment variables
-export PGHOST={{ db_server }}
-export PGDATABASE={{ database }}
-export PGUSER={{ db_user }}
-export PGPORT={{ db_port }}
-export PGPASSWORD={{ db_password }}
+export PGHOST={{ stats_db_server }}
+export PGDATABASE={{ stats_database }}
+export PGUSER={{ stats_db_user }}
+export PGPORT={{ stats_db_port }}
+export PGPASSWORD={{ stats_db_password }}
 
 # [SLG 04-02-2019] Added some environment vars for gxadmin
 export GALAXY_ROOT="{{ galaxy_root }}"

--- a/roles/slg.galaxy_stats/templates/daily_stats.sh.j2
+++ b/roles/slg.galaxy_stats/templates/daily_stats.sh.j2
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash -l
 
 # [SLG 05-12-2018] Added some psql environment variables
-export PGHOST={{ db_server }}
-export PGDATABASE={{ database }}
-export PGUSER={{ db_user }}
-export PGPORT={{ db_port }}
-export PGPASSWORD={{ db_password }}
+export PGHOST={{ stats_db_server }}
+export PGDATABASE={{ stats_database }}
+export PGUSER={{ stats_db_user }}
+export PGPORT={{ stats_db_port }}
+export PGPASSWORD={{ stats_db_password }}
 
 # [SLG 04-02-2019] Added some environment vars for gxadmin
 export GALAXY_ROOT="{{ galaxy_root }}"

--- a/roles/slg.galaxy_stats/templates/secret.yml.j2
+++ b/roles/slg.galaxy_stats/templates/secret.yml.j2
@@ -1,8 +1,8 @@
 ---
 salt: {{ influx_salt }}
-{% if db_password is defined %}
+{% if stats_db_password is defined %}
 pgconn:
-    main: postgres://{{ db_user }}:{{ db_password }}@{{ db_server }}:{{ db_port }}/{{ database }}
+    main: postgres://{{ stats_db_user }}:{{ stats_db_password }}@{{ stats_db_server }}:{{ stats_db_port }}/{{ stats_database }}
 {% endif %}
 influxdb:
     host: {{ influx_url }}


### PR DESCRIPTION
A variable called db_password is being set within the pg-post-tasks role and overriding 'db_password' the stats role variable.

This also adds a commit_id for gxadmin: this can probably be deleted later on or updated every now and then with releases.