### PR TITLE
fix issue of destination of symlinks in home directories being chowned

### DIFF
--- a/roles/common/tasks/machine_users.yml
+++ b/roles/common/tasks/machine_users.yml
@@ -41,12 +41,13 @@
       state: present
     with_items: "{{ machine_users }}"
 
-  - name: Ensure that if there was a change of user's uid/gid then all contents of home directory are chowned
+  - name: Ensure that if there was a change of user's uid/gid then all contents of home directory are chowned - don't follow symlinks
     file:
       dest: "/home/{{ item.name }}"
       owner: "{{ item.name }}"
       group: "{{ item.name }}"
       recurse: yes
+      follow: false
     with_items: "{{ machine_users }}"
 
   # note: this assumes all VMs run Ubuntu - if not, then need to define a var containing OS-specific group

--- a/roles/common/tasks/machine_users.yml
+++ b/roles/common/tasks/machine_users.yml
@@ -4,14 +4,6 @@
   become_user: root
   block:
 
-  - name: Backup passwd and group files in case UID or GID are modified
-    copy:
-      src: "/etc/{{ item }}"
-      dest: "/etc/{{ item }}.{{ ansible_date_time.date }}"
-    loop:
-      - passwd
-      - group
-
   # FIX for deprecated code that added user files in /etc/sudoers.d/ - can be removed in future
   - name: delete /etc/sudoers.d/username files for machine users
     file:
@@ -39,15 +31,6 @@
       name: "{{ item.name }}"
       gid: "{{ item.uid }}"
       state: present
-    with_items: "{{ machine_users }}"
-
-  - name: Ensure that if there was a change of user's uid/gid then all contents of home directory are chowned - don't follow symlinks
-    file:
-      dest: "/home/{{ item.name }}"
-      owner: "{{ item.name }}"
-      group: "{{ item.name }}"
-      recurse: yes
-      follow: false
     with_items: "{{ machine_users }}"
 
   # note: this assumes all VMs run Ubuntu - if not, then need to define a var containing OS-specific group


### PR DESCRIPTION
Rather than removing the code block that chown's the contents of user directories, simply don't follow symlinks. This prevents the destination of the symlink from being chown-ed.