### PR TITLE
Add w10 to training partition and increase concurrent job limit for slurm-training

### DIFF
--- a/group_vars/aarnet_slurm.yml
+++ b/group_vars/aarnet_slurm.yml
@@ -75,7 +75,7 @@ slurm_partitions:
     Default: YES
     State: UP
   - name: training
-    nodes: "aarnet-w7,aarnet-w5,aarnet-w4,aarnet-w8"
+    nodes: "aarnet-w7,aarnet-w5,aarnet-w4,aarnet-w8,aarnet-w10"
     Default: NO
     State: UP
   - name: interactive_tools

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -462,7 +462,7 @@ job_conf_limits:
 
   - type: destination_total_concurrent_jobs
     id: slurm-training
-    value: 28
+    value: 40
   - type: destination_user_concurrent_jobs
     id: slurm-training
     value: 4


### PR DESCRIPTION
The slurm training queue is full and there is another workshop starting.  Limits can be increased since the capacity of the slurm cluster is much higher than when these were set.