### PR TITLE
Add pRESTO tool section

### DIFF
--- a/files/galaxy/config/tool_conf.xml
+++ b/files/galaxy/config/tool_conf.xml
@@ -206,6 +206,8 @@
     </section>
     <section id="bb_tools" name="BB Tools">
     </section>
+    <section id="presto" name="pRESTO">
+    </section>
     <label id="statistics_and_visualisation" text="STATISTICS AND VISUALISATION"/>
     <section id="stats" name="Statistics">
         <tool file="stats/gsummary.xml"/>


### PR DESCRIPTION
A user has requested presto tools from IUC. Galaxy Europe does not have these. Galaxy Main does, in their own section named pRESTO.