### PR TITLE
For gravity v1.x galaxy user needs GALAXY_CONFIG_FILE env variable set

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -121,6 +121,8 @@ galaxy_config_dir: "{{ galaxy_root }}/config"
 galaxy_conda_prefix: "{{ galaxy_tools_indices_dir }}/tool_dependencies/_conda"
 galaxy_conda_exec: mamba
 
+galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
+
 
 #########################################
 # group_galaxy_config contains variables for galaxy_config that can be overridden by variables in host_galaxy_config (defined in host_vars)

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -55,6 +55,14 @@
       shell: /bin/bash
   when: add_galaxy_user is defined and add_galaxy_user == true
 
+- name: Add GALAXY_CONFIG_FILE env var to galaxy user's .bashrc
+  lineinfile:
+      line: "export GALAXY_CONFIG_FILE={{ galaxy_config_file }}"
+      path: /home/galaxy/.bashrc
+      owner: galaxy
+      group: galaxy
+  when: galaxy_config_file is defined
+
 - name: Add ssl key if required
   include_tasks: ssl_key.yml
   when: create_ssh_key is defined and create_ssh_key == true


### PR DESCRIPTION
galaxy release_23.0 requires an upgraded version of gravity that fails to start galaxy without the $GALAXY_CONFIG_FILE env var set.