### PR TITLE
Add themes_conf.yml, enable themes on 23.0

### DIFF
--- a/files/galaxy/config/themes_conf.yml
+++ b/files/galaxy/config/themes_conf.yml
@@ -1,0 +1,76 @@
+blue:
+  masthead:
+    color: "#2c3143"
+    text:
+      color: "#f8f9fa"
+      hover: gold
+      active: white
+    link:
+      color: transparent
+      hover: transparent
+      active: "#181a24"
+    logo:
+      img: "/static/favicon.svg"
+      img-secondary: null
+
+lightblue:
+  masthead:
+    color: "#384E77"
+    text:
+      color: white
+      hover: "#E6F9AF"
+      active: white
+    link:
+      color: transparent
+      hover: transparent
+      active: "#18314F"
+    logo:
+      img: "/static/favicon.svg"
+
+pride:
+  masthead:
+      color: >
+        linear-gradient(120deg,
+          #3c476d 0px 130px,
+          #fdda0f 131px 139px,
+          #fff 140px 148px,
+          #f4b0c9 149px 157px,
+          #7ccee6 158px 166px,
+          #93540c 167px 175px,
+          #000 176px 184px,
+          transparent 185px),
+        linear-gradient(270deg,
+          #3c476d 0px 110px,
+          #3c476d00 110px),
+        linear-gradient(180deg,
+          #FE0000 16.66%,
+          #FD8C00 16.66% 33.32%,
+          #FFE500 33.32% 49.98%,
+          #119F0B 49.98% 66.64%,
+          #0644B3 66.64% 83.3%,
+          #C22EDC 83.3%)
+      text:
+        color: white
+        hover: gold
+        active: white
+      link:
+        color: "#3c476d"
+        hover: "#323a53"
+        active: "#6170a6"
+      logo:
+        img: "/static/favicon.svg"
+        img-secondary: null
+
+smoky:
+  masthead:
+    color: "#0C0F0A"
+    text:
+      color: white
+      hover: "#FBFF12"
+      active: white
+    link:
+      color: transparent
+      hover: transparent
+      active: "#FF206E"
+    logo:
+      img: "/static/favicon.svg"

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -185,7 +185,7 @@ group_galaxy_config:
     shed_tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data/shed_tool_data"
     tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data"
     tool_data_table_config_path: "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml"
-    themes_config_file: "{{ galaxy_config_dir }}/themes_conf.yml"
+    # themes_config_file: "{{ galaxy_config_dir }}/themes_conf.yml"
     library_import_dir: "{{ galaxy_tmp_dir }}/library_import_dir"
     cluster_files_directory: "{{ galaxy_tmp_dir }}/pbs"
 

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -185,7 +185,7 @@ group_galaxy_config:
     shed_tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data/shed_tool_data"
     tool_data_path: "{{ galaxy_tools_indices_dir }}/tool-data"
     tool_data_table_config_path: "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml"
-
+    themes_config_file: "{{ galaxy_config_dir }}/themes_conf.yml"
     library_import_dir: "{{ galaxy_tmp_dir }}/library_import_dir"
     cluster_files_directory: "{{ galaxy_tmp_dir }}/pbs"
 
@@ -297,6 +297,8 @@ group_galaxy_config_files:
     dest: "{{ galaxy_config_dir }}/file_sources_conf.yml"
   - src: "{{ galaxy_config_file_src_dir }}/config/oidc_config.xml"
     dest: "{{ galaxy_config_dir}}/oidc_config.xml"
+  - src: "{{ galaxy_config_file_src_dir }}/config/themes_conf.yml"
+    dest: "{{ galaxy_config_dir}}/themes_conf.yml"
 
 galaxy_config_files: "{{ group_galaxy_config_files + host_galaxy_config_files|d([]) }}"
 

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -161,6 +161,7 @@ host_galaxy_config: # renamed from __galaxy_config
     user_activation_on: true
     instance_resource_url: https://site.usegalaxy.org.au
     activation_email: <activation-noreply@usegalaxy.org.au>
+    themes_config_file: "{{ galaxy_config_dir }}/themes_conf.yml" # TODO: switch this on in galaxyservers.yml and it won't be needed here
 
 galaxy_handler_count: 2 ############# europe uses 5, this could be host specific
 


### PR DESCRIPTION
Add themes_conf.yml, copied from the sample file in galaxy code. We might need to edit the rainbow theme to stop the word 'Australia' overlapping with the stripes and being difficult to read.
