### PR TITLE
Allow eggnog to run on pulsar-mel2, pulsar-mel3

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -730,6 +730,11 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/.*:
     cores: 6
     mem: 23.0
+    scheduling:
+      accept:
+      - pulsar
+      reject:
+      - pulsar-QLD
   toolshed.g2.bx.psu.edu/repos/galaxyp/flashlfq/flashlfq/.*:
     scheduling:
       accept:


### PR DESCRIPTION
eggnog db has been copied to /mnt/custom-indices on mel2 and nci-training (it was already on mel3). Test jobs are OK.