### PR TITLE
Stop sending eggnog jobs to pulsar-mel2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -735,6 +735,7 @@ tools:
       - pulsar
       reject:
       - pulsar-QLD
+      - pulsar-mel2
   toolshed.g2.bx.psu.edu/repos/galaxyp/flashlfq/flashlfq/.*:
     scheduling:
       accept:


### PR DESCRIPTION
pulsar on pulsar-mel2 is behaving strangely with eggnog. Each submitted job results in the conda virtual environment being destroyed and recreated. Many jobs are being submitted and the virtual environment is liable to be destroyed at any time, so some of the jobs are failing. Worth debugging later. pulsar-mel3 is fine.