### PR TITLE
Add GALAXY_CONFIG_FILE env var to playbook handlers and gxctl

### DIFF
--- a/aarnet_update_configs_playbook.yml
+++ b/aarnet_update_configs_playbook.yml
@@ -15,12 +15,14 @@
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
     - name: galaxy handler restart
       become: True
       become_user: galaxy
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl handler_0 handler_1 handler_2 handler_3 handler_4"
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
   tasks:
     - name: copy job_conf file
       template:

--- a/dev-handler_playbook.yml
+++ b/dev-handler_playbook.yml
@@ -19,6 +19,7 @@
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
   pre_tasks:
     - name: create dir for gravity configuration
       file:

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -18,6 +18,7 @@
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
   pre_tasks:
     - name: Attach volume to instance
       include_role:

--- a/dev_update_configs_playbook.yml
+++ b/dev_update_configs_playbook.yml
@@ -16,7 +16,8 @@
       become_user: galaxy
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
       environment:
-        GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}" 
+        GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}" 
   pre_tasks:
     - name: copy job_conf file
       template:

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -15,6 +15,7 @@
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl graceful"
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
   pre_tasks:
     - name: Attach volume to instance
       include_role:

--- a/staging_update_configs_playbook.yml
+++ b/staging_update_configs_playbook.yml
@@ -15,6 +15,7 @@
       command: "{{ galaxy_venv_dir }}/bin/galaxyctl restart handler_0 handler_1 handler_2"
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
   pre_tasks:
     - name: copy job_conf file
       template:


### PR DESCRIPTION
For 23.0, everything that restarts galaxy needs `GALAXY_CONFIG_FILE` set