### PR TITLE
Increase max_connections for staging db

### DIFF
--- a/host_vars/staging-db.usegalaxy.org.au.yml
+++ b/host_vars/staging-db.usegalaxy.org.au.yml
@@ -1,7 +1,7 @@
 staging_galaxy_server_address: "{{ hostvars['staging']['ansible_ssh_host'] }}/32"
 
 postgresql_conf:
-  - max_connections: 50       # Decrease connection limit
+  - max_connections: 60       # 5/5/23: increased from 50 to 60
   - listen_addresses: "'*'"   # Allow remote connections
 
 postgresql_pg_hba_conf:


### PR DESCRIPTION
There have been problems with jobs on staging since upgrading to release 23.0. It is difficult to debug because the database  keeps running out of available connection slots.