### PR TITLE
override galaxyctl update handler in dev playbook

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -19,6 +19,13 @@
       environment:
         GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
         GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
+    - name: galaxyctl update
+      become: True
+      become_user: galaxy
+      command: "{{ galaxy_venv_dir }}/bin/galaxyctl update"
+      environment:
+        GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
+        GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
   pre_tasks:
     - name: Attach volume to instance
       include_role:


### PR DESCRIPTION
this is a quick fix. The proper solution is to have a gravity config file, which has not been an option with previous galaxy versions.