### PR TITLE
Use tmp_dir for sort1 tool

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2310,6 +2310,9 @@ tools:
       - pulsar-qld-high-mem1
       accept:
       - pulsar
+  sort1:
+    params:
+      tmp_dir: true
   tabular_to_csv:
     cores: 3
     mem: 11.5


### PR DESCRIPTION
Store tmp files in the job working directory for sort1 jobs.