### PR TITLE
IMPORT HISTORY tool needs tmp_dir: true parameter

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2266,6 +2266,9 @@ tools:
       execute: |
         from galaxy.jobs.mapper import JobNotReadyException
         raise JobNotReadyException()
+  __IMPORT_HISTORY__:
+    params:
+      tmp_dir: true
   alphafold_test:
     context:
       partition: azuregpu0


### PR DESCRIPTION
An IMPORT_HISTORY job has filled up the temp volume on one of the workers, so it needs to use the job working directory for temp space instead.