### PR TITLE
disable celery tasks on dev

### DIFF
--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -125,7 +125,7 @@ host_galaxy_config: # renamed from __galaxy_config
     amqp_internal_connection: "pyamqp://galaxy_queues:{{ vault_rabbitmq_password_galaxy_dev }}@dev-queue.usegalaxy.org.au:5671//galaxy/galaxy_queues?ssl=1"
     brand: "Australia Dev"
     database_connection: "postgresql://galaxy:{{ vault_dev_db_user_password }}@dev-db.usegalaxy.org.au:5432/galaxy"
-    enable_celery_tasks: true
+    # enable_celery_tasks: true # 18/5/23: Switched off due to upload jobs remaining in new state
     id_secret: "{{ vault_dev_id_secret }}"
     file_path: "{{ galaxy_file_path }}"
     object_store_config_file: "{{ galaxy_config_dir }}/object_store_conf.xml"


### PR DESCRIPTION
This was working on dev for 6 months or so: some small jobs such as uploads would be handled by celery instead of passed to slurm workers. Switching it off because jobs upload jobs are remaining in new state indefinitely. This is not used on staging/production.