### PR TITLE
Use process_manager: systemd for staging

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -133,7 +133,8 @@ host_galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/aarnet_job_conf.yml.j2"
     dest: "{{ galaxy_config_dir }}/job_conf.yml"
   - src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2" ## File cannot be created at dest on first run of playbook
-    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
+    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py" # TODO: release_23.0 use other path
+    # dest: "{{ galaxy_server_dir }}/lib/galaxy/tool_util/toolbox/filters/ga_filters.py" # TODO: release_23.0 use this path
 
 host_galaxy_config: # renamed from __galaxy_config
   gravity:

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -79,7 +79,7 @@ host_galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/dev_job_conf.yml.j2"
     dest: "{{ galaxy_config_dir}}/job_conf.yml"
   - src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2"
-    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
+    dest: "{{ galaxy_server_dir }}/lib/galaxy/tool_util/toolbox/filters/ga_filters.py"
   - src: "{{ galaxy_config_file_src_dir }}/config/web-gravity.yml"
     dest: /opt/galaxy/web-gravity.yml
 

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -68,7 +68,7 @@ host_galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/staging_job_conf.yml.j2"
     dest: "{{ galaxy_config_dir}}/job_conf.yml"
   - src: "{{ galaxy_config_template_src_dir }}/toolbox/filters/ga_filters.py.j2"
-    dest: "{{ galaxy_server_dir }}/lib/galaxy/tools/toolbox/filters/ga_filters.py"
+    dest: "{{ galaxy_server_dir }}/lib/galaxy/tool_util/toolbox/filters/ga_filters.py"
 
 host_galaxy_config_files:
   - src: "{{ galaxy_config_file_src_dir }}/config/oidc_config.xml"
@@ -80,7 +80,9 @@ galaxy_handler_count: 2 ############# europe uses 5, this could be host specific
 
 host_galaxy_config: # renamed from __galaxy_config
   gravity:
-    galaxy_root: /mnt/galaxy/galaxy-app
+    process_manager: systemd
+    galaxy_root: "{{ galaxy_server_dir }}"
+    galaxy_user: "{{ galaxy_user.name }}"
     app_server: gunicorn
     virtualenv: "{{ galaxy_venv_dir }}"
     gunicorn:
@@ -109,6 +111,10 @@ host_galaxy_config: # renamed from __galaxy_config
         pools:
           - job-handlers
           - workflow-schedulers
+    tusd:
+      enable: true
+      tusd_path: /usr/local/sbin/tusd
+      upload_dir: "{{ galaxy_tus_upload_store }}"
 
   galaxy:
     admin_users: "{{ machine_users | selectattr('email', 'defined') | selectattr('roles', 'contains', 'galaxy_admin') | map(attribute='email') | join(',') }}"
@@ -138,17 +144,17 @@ host_galaxy_config: # renamed from __galaxy_config
     # TUS
     tus_upload_store: "{{ galaxy_tus_upload_store }}"
 
-# TUS
-tusd_instances:
-  - name: main
-    user: "{{ galaxy_user.name }}"
-    group: "galaxy"
-    args:
-      - "-host=localhost"
-      - "-port={{ galaxy_tusd_port }}"
-      - "-upload-dir={{ galaxy_tus_upload_store }}"
-      - "-hooks-http=https://{{ hostname }}/api/upload/hooks"
-      - "-hooks-http-forward-headers=X-Api-Key,Cookie"
+# # TUS # it will be done without this? CB 18/5/23
+# tusd_instances:
+#   - name: main
+#     user: "{{ galaxy_user.name }}"
+#     group: "galaxy"
+#     args:
+#       - "-host=localhost"
+#       - "-port={{ galaxy_tusd_port }}"
+#       - "-upload-dir={{ galaxy_tus_upload_store }}"
+#       - "-hooks-http=https://{{ hostname }}/api/upload/hooks"
+#       - "-hooks-http-forward-headers=X-Api-Key,Cookie"
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -144,18 +144,6 @@ host_galaxy_config: # renamed from __galaxy_config
     # TUS
     tus_upload_store: "{{ galaxy_tus_upload_store }}"
 
-# # TUS # it will be done without this? CB 18/5/23
-# tusd_instances:
-#   - name: main
-#     user: "{{ galaxy_user.name }}"
-#     group: "galaxy"
-#     args:
-#       - "-host=localhost"
-#       - "-port={{ galaxy_tusd_port }}"
-#       - "-upload-dir={{ galaxy_tus_upload_store }}"
-#       - "-hooks-http=https://{{ hostname }}/api/upload/hooks"
-#       - "-hooks-http-forward-headers=X-Api-Key,Cookie"
-
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 


### PR DESCRIPTION
Use process_manager: systemd for staging: no longer using supervisor.

tusd is listed in the gravity section instead of it having a service set up by the ansible role. Gravity sets up the service galaxy-tusd and the old service tusd-main has been stopped and should be removed.

The path for the toolbox_filters folder in the galaxy codebase has changed mid-release.