### PR TITLE
set tmp_dir: true for snippy

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1839,6 +1839,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy/.*:
     cores: 4
     mem: 15.3
+    params:
+      tmp_dir: true
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
snippy can create a bunch of samtools tmp files, too many for the 100G disk