### PR TITLE
Give kraken2 training-exempt tag to allow it to run on slurm or pulsar-mel3

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1176,7 +1176,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-training-large
+      - training-exempt
       reject:
       - pulsar-QLD
     rules:


### PR DESCRIPTION
waiting on info about whether the problem jobs work for non-training users