### PR TITLE
Set pulsar-QLD to offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -228,6 +228,7 @@ destinations:
         - pulsar-QLD
       require:
         - pulsar
+        - offline
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner


### PR DESCRIPTION
conda throws errors when trying to install new conda environments. Existing ones are OK but there are too many job failures from tools running that pulsar-QLD has not seen before, e.g. porechop. It seems that Galaxy is not too busy to take this offline overnight.