### PR TITLE
dependency_resolution none for eggnog

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -748,6 +748,7 @@ tools:
     mem: 23.0
     params:
       singularity_enabled: true
+      dependency_resolution: 'none'
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
On pulsar the conda environment still seems to be used for eggnog. This may fix it.