### PR TITLE
Set tmp_dir: true for alphafold

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -635,6 +635,7 @@ tools:
     cores: 8
     mem: 69
     params:
+      tmp_dir: true
       docker_enabled: true
       docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
     rules:


### PR DESCRIPTION
From a recent bug report it looks like alphafold jobs sometimes run out of space in /tmp on the cyclecloud workers. This change moves temp space to the job working directory in the 1T volume.