### PR TITLE
Send kraken2 and antismash to high memory pulsars, reduce some high memory allocations

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -837,7 +837,7 @@ tools:
       mem: 15.3
   toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/.*:
     cores: 20
-    mem: 200
+    mem: 320
     params:
       singularity_enabled: true
     scheduling:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1194,7 +1194,7 @@ tools:
       cores: 16
       mem: 61.4
   toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
-    cores: 1
+    cores: 16
     mem: 200
     params:
       singularity_enabled: true

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -33,6 +33,12 @@ tools:
       if: input_size < 0.1
       cores: 1
       mem: 3.8
+  toolshed.g2.bx.psu.edu/repos/bgruening/antismash/antismash/.*:
+    params:
+      singularity_enabled: true
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/bgruening/augustus/augustus/.*:
     cores: 8
     mem: 30.7
@@ -830,8 +836,10 @@ tools:
       cores: 4
       mem: 15.3
   toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/.*:
-    cores: 120
-    mem: 1922
+    cores: 20
+    mem: 200
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -890,8 +898,8 @@ tools:
       cores: 8
       mem: 30.7
   toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/[^3].*:
-    cores: 60
-    mem: 961
+    cores: 16
+    mem: 150
     scheduling:
       accept:
       - pulsar
@@ -929,8 +937,8 @@ tools:
       cores: 8
       mem: 30.7
   toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/.*:
-    cores: 60
-    mem: 961
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1097,8 +1105,10 @@ tools:
     cores: 16
     mem: 61.4
   toolshed.g2.bx.psu.edu/repos/iuc/hyphy_gard/hyphy_gard/.*:
-    cores: 120
-    mem: 1922
+    cores: 20
+    mem: 200
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1169,8 +1179,8 @@ tools:
       cores: 2
       mem: 7.6
   toolshed.g2.bx.psu.edu/repos/iuc/khmer_abundance_distribution_single/khmer_abundance_distribution_single/.*:
-    cores: 120
-    mem: 1922
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1184,8 +1194,10 @@ tools:
       cores: 16
       mem: 61.4
   toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
-    cores: 16
-    mem: 61.4
+    cores: 1
+    mem: 200
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1245,8 +1257,10 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/.*:
-    cores: 120
-    mem: 1922
+    cores: 20
+    mem: 200
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1319,8 +1333,10 @@ tools:
       cores: 5
       mem: 19.1
   toolshed.g2.bx.psu.edu/repos/iuc/minimap2/minimap2/.*:
-    cores: 120
-    mem: 1922
+    cores: 30
+    mem: 480.5
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1731,8 +1747,10 @@ tools:
       cores: 1
       mem: 3.8
   toolshed.g2.bx.psu.edu/repos/iuc/raven/raven/.*:
-    cores: 120
-    mem: 1922
+    cores: 20
+    mem: 200
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar
@@ -1843,8 +1861,8 @@ tools:
       cores: 5
       mem: 19.1
   toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_seq/.*:
-    cores: 120
-    mem: 1922
+    cores: 20
+    mem: 200
     scheduling:
       accept:
       - pulsar
@@ -1858,8 +1876,10 @@ tools:
       cores: 4
       mem: 15.3
   toolshed.g2.bx.psu.edu/repos/iuc/shasta/shasta/.*:
-    cores: 120
-    mem: 1922
+    cores: 20
+    mem: 200
+    params:
+      singularity_enabled: true
     scheduling:
       accept:
       - pulsar

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -488,23 +488,23 @@ job_conf_limits:
 
   - type: destination_total_concurrent_jobs
     id: pulsar-high-mem1
-    value: 4
+    value: 6
 
   - type: destination_total_concurrent_jobs
     id: pulsar-high-mem2
-    value: 4
+    value: 6
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-high-mem0
-    value: 6
+    value: 10
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-high-mem1
-    value: 6
+    value: 10
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-high-mem2
-    value: 6
+    value: 10
 
   - type: destination_total_concurrent_jobs
     id: pulsar-QLD


### PR DESCRIPTION
Send all kraken2 jobs to high memory pulsars because of a large db in cvmfs that is either new or people have only now started using it.

Antismash can run on pulsar and would also go to high memory pulsars.

Reduce allocations for some tools. Tools targeted for this are ones that have had 120 cpu / 2TB allocations. This is not across the board, some have been left as they are. It's necessary to reduce some of these because the high memory pulsars are prone to bottlenecks and a greater number of tools are going to need to run there.