### PR TITLE
Pin galaxy-app version in linting workflow

### DIFF
--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install total-perspective-vortex==$TPV_VERSION pyyaml galaxy-app
+        pip install total-perspective-vortex==$TPV_VERSION pyyaml galaxy-app==22.1.1
       env:
-        TPV_VERSION: '2.2.0'
+        TPV_VERSION: '2.2.4'
     - name: Check TPV files and job conf
       env:
         SETTING: github


### PR DESCRIPTION
tpv lint commands throws errors, probably due to a new version of galaxy-app released yesterday. Pin it to the previous version.