### PR TITLE
Set TMPDIR environment variable in destinations.yml.j2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -8,6 +8,9 @@ destinations:
       accept:
         - docker # to satisfy tools in shared db that have require: docker
         - singularity # to satisfy tools in shared db that have require: singularity
+    env:
+      TEMP: /tmp
+      TMPDIR: /tmp
   _slurm_destination:
     abstract: true
     params:


### PR DESCRIPTION
A htseq job has filled up /var/tmp on one of the QLD workers. A lot of tool wrappers use `${TMPDIR:-/tmp}` but htseq_count's wrapper has no default.