### PR TITLE
Add SINGULARITYENV_TMPDIR to destination env vars

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -11,6 +11,8 @@ destinations:
     env:
       TEMP: /tmp
       TMPDIR: /tmp
+      SINGULARITYENV_TEMP: /tmp
+      SINGULARITYENV_TMPDIR: /tmp
   _slurm_destination:
     abstract: true
     params:


### PR DESCRIPTION
Still trying to get TMPDIR set properly in htseq_count. It is running with singularity enabled.