### PR TITLE
Try setting env var for htseq_count through `singularity_run_extra_arguments`

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2135,6 +2135,7 @@ tools:
     mem: 30.7
     params:
       singularity_enabled: true
+      singularity_run_extra_arguments: '--env TMPDIR=/tmp'
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
Previous attempts to fix htseq_count with environment variables have failed. This might work but it is annoying if we can no longer set env variables for singularity jobs.