### PR TITLE
List gx_it_proxy as a service on dev, staging and reduce number of job handlers on staging

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -64,7 +64,7 @@
     - galaxy-pg-cleanup
     - galaxyproject.tiaas2
     - geerlingguy.docker
-    - usegalaxy_eu.gie_proxy
+    # - usegalaxy_eu.gie_proxy
     - dj-wasabi.telegraf
     - postfix-mail-relay
     #- login-override

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -333,6 +333,9 @@ docker_install_compose: false
 docker_users:
   - "{{ galaxy_user.name }}"
 
+gie_proxy_ip: 127.0.0.1
+gie_proxy_port: 8000
+# all gie variables below can be removed if galaxy-gie-proxy role is no longer being run
 gie_proxy_dir: "{{ galaxy_root }}/gie-proxy/proxy"
 gie_proxy_git_version: main
 gie_proxy_setup_nodejs: nodeenv

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -119,6 +119,13 @@ host_galaxy_config_gravity:
       DRMAA_LIBRARY_PATH: "/usr/lib/slurm-drmaa/lib/libdrmaa.so.1"
       SINGULARITY_CACHEDIR: "{{ galaxy_user_singularity_cachedir }}"
       SINGULARITY_TMPDIR: "{{ galaxy_user_singularity_tmpdir }}"
+  gx_it_proxy:
+    enable: true
+    version: '>=0.0.5'  # default from galaxy.yml.sample
+    ip: "{{ gie_proxy_ip }}"
+    port: "{{ gie_proxy_port }}"
+    sessions: "{{ gie_proxy_sessions_path }}"
+    verbose: true
   celery:
     enable: false
     enable_beat: false

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -108,7 +108,7 @@ host_galaxy_config: # renamed from __galaxy_config
           DRMAA_LIBRARY_PATH: "/usr/lib/slurm-drmaa/lib/libdrmaa.so.1"
           SINGULARITY_CACHEDIR: "{{ galaxy_user_singularity_cachedir }}"
           SINGULARITY_TMPDIR: "{{ galaxy_user_singularity_tmpdir }}"
-        processes: 3
+        processes: 2
         pools:
           - job-handlers
           - workflow-schedulers
@@ -116,6 +116,13 @@ host_galaxy_config: # renamed from __galaxy_config
       enable: true
       tusd_path: /usr/local/sbin/tusd
       upload_dir: "{{ galaxy_tus_upload_store }}"
+    gx_it_proxy:
+      enable: true
+      version: '>=0.0.5'  # default from galaxy.yml.sample
+      ip: "{{ gie_proxy_ip }}"
+      port: "{{ gie_proxy_port }}"
+      sessions: "{{ gie_proxy_sessions_path }}"
+      verbose: true
     reports:
       enable: true
       url_prefix: /reports

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -57,7 +57,7 @@
     - geerlingguy.docker
     - acl-on-startup
     - galaxyproject.gxadmin
-    - usegalaxy_eu.gie_proxy
+    # - usegalaxy_eu.gie_proxy
     - dj-wasabi.telegraf
     - pg-post-tasks
     - postfix-mail-relay


### PR DESCRIPTION
It seems that the gie-proxy role is no longer required and gravity will start this up as a service.