### PR TITLE
give up on telling htseq_count where to send its tmp files

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2138,7 +2138,7 @@ tools:
     mem: 30.7
     params:
       singularity_enabled: true
-      singularity_run_extra_arguments: '--env TMPDIR=/tmp'
+      tmp_dir: true
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
Get tmp files to be stored in the job working directory for htseq_count. Hopefully this will work. It would be preferable to work out how to set environment variables reliably for singularity jobs, but it is not worth spending any more time on this tool.