### PR TITLE
Deploy genomes lab to AARNet

### DIFF
--- a/aarnet_playbook.yml
+++ b/aarnet_playbook.yml
@@ -45,7 +45,7 @@
       become: true
       become_user: galaxy
     # - usegalaxy_eu.galaxy_systemd
-    # - usegalaxy_eu.galaxy_subdomains
+    - usegalaxy_eu.galaxy_subdomains
     - nginx-upload-module
     - galaxyproject.nginx
     - galaxyproject.tusd
@@ -65,7 +65,7 @@
     - slg.galaxy_stats
     - galaxy-pg-cleanup
     - galaxyproject.tiaas2
-    # - webhooks
+    - webhooks
   post_tasks:
     - name: Make local_tool directory group-writable by machine users
       file:

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -610,10 +610,10 @@ galaxy_subsites:
         background: #3a3e87;
       }
       #masthead a.navbar-brand::after {
-          content: "Australia - Genomes Lab";
+        content: "Australia - Genomes Lab";
       }
-      #masthead a.navbar-brand .navbar-text {
-          display: none;
+      #masthead .navbar-text {
+        display: none;
       }
 
 webhook_plugins:

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -609,6 +609,16 @@ galaxy_subsites:
       #masthead {
         background: #3a3e87;
       }
+      #masthead a.navbar-brand::after {
+          content: "Australia - Genomes Lab";
+      }
+      #masthead a.navbar-brand .navbar-text {
+          display: none;
+      }
 
 webhook_plugins:
   - subdomain_switcher
+  # These ones aren't in the playbook as they are included in the galaxy repo:
+  - demo
+  - gtn
+  - news

--- a/host_vars/dev.usegalaxy.org.au.yml
+++ b/host_vars/dev.usegalaxy.org.au.yml
@@ -362,9 +362,22 @@ galaxy_subsites:
       - "phylogenetics"
       - "multiple_alignments"
     custom_css: |
+      #masthead .navbar-nav>li.active {
+        background: #2c3067;
+      }
       #masthead {
-        background: linear-gradient(20deg, rgb(7, 40, 98) 0%, rgb(69, 122, 184) 48%, rgba(165,204,210,0.9676562309265136) 74%, rgb(228, 195, 131) 92%, rgb(203, 119, 79) 100%);
+        background: #3a3e87;
+      }
+      #masthead a.navbar-brand::after {
+          content: "Australia - Genomes Lab";
+      }
+      #masthead a.navbar-brand .navbar-text {
+          display: none;
       }
 
 webhook_plugins:
   - subdomain_switcher
+  # These ones aren't in the playbook as they are included in the galaxy repo:
+  - demo
+  - gtn
+  - news

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -253,10 +253,10 @@ galaxy_subsites:
         background: #3a3e87;
       }
       #masthead a.navbar-brand::after {
-          content: "Australia - Genomes Lab";
+        content: "Australia - Genomes Lab";
       }
-      #masthead a.navbar-brand .navbar-text {
-          display: none;
+      #masthead .navbar-text {
+        display: none;
       }
 
 webhook_plugins:

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -235,7 +235,7 @@ galaxy_subsite_default_welcome: "https://site.usegalaxy.org.au"
 galaxy_subsite_dir: /mnt/galaxy/subsites
 galaxy_subsites:
   - name: genome
-    brand: Genomes lab
+    brand: Genomes Lab
     iframe: "https://site.usegalaxy.org.au/landing/genome"
     wallpaper: false # If wallpaper is true, then files/subsites/{name}.png will be copied to /static/dist/{name}.png, and can be used exactly like that in the CSS.
     tool_sections:
@@ -252,9 +252,16 @@ galaxy_subsites:
       #masthead {
         background: #3a3e87;
       }
+      #masthead a.navbar-brand::after {
+          content: "Australia - Genomes Lab";
+      }
+      #masthead a.navbar-brand .navbar-text {
+          display: none;
+      }
 
 webhook_plugins:
+  - subdomain_switcher
+  # These ones aren't in the playbook as they are included in the galaxy repo:
   - demo
   - gtn
   - news
-  - subdomain_switcher

--- a/host_vars/staging.usegalaxy.org.au.yml
+++ b/host_vars/staging.usegalaxy.org.au.yml
@@ -254,4 +254,7 @@ galaxy_subsites:
       }
 
 webhook_plugins:
+  - demo
+  - gtn
+  - news
   - subdomain_switcher

--- a/roles/webhooks/defaults/main.yml
+++ b/roles/webhooks/defaults/main.yml
@@ -1,3 +1,3 @@
-webhook_plugins: [] # webhook dir names to install
-webhook_plugins_src_dir: "galaxy/webhooks"
+webhook_plugins: ['demo', 'gtn', 'news'] # webhook dir names to install
+webhook_plugins_src_dir: "templates/galaxy/webhooks"
 webhook_plugins_dest_dir: "{{ galaxy_server_dir }}/config/plugins/webhooks"

--- a/roles/webhooks/tasks/copy_webhooks.yml
+++ b/roles/webhooks/tasks/copy_webhooks.yml
@@ -21,4 +21,4 @@
     mode: 0644
   with_fileglob:
     - "{{ webhook_plugins_src_dir }}/{{ webhook_name }}/*"
-  notify: galaxy gravity restart
+  notify: restart galaxy

--- a/roles/webhooks/tasks/copy_webhooks.yml
+++ b/roles/webhooks/tasks/copy_webhooks.yml
@@ -6,6 +6,12 @@
     group: root
     mode: 0755
 
+- name: list discovered webhook templates
+  debug:
+    msg: "{{ item }}"
+  with_fileglob:
+    - "{{ webhook_plugins_src_dir }}/{{ webhook_name }}/*"
+
 - name: template webhook files
   template:
     src: "{{ item }}"
@@ -15,3 +21,4 @@
     mode: 0644
   with_fileglob:
     - "{{ webhook_plugins_src_dir }}/{{ webhook_name }}/*"
+  notify: restart galaxy

--- a/roles/webhooks/tasks/copy_webhooks.yml
+++ b/roles/webhooks/tasks/copy_webhooks.yml
@@ -21,4 +21,4 @@
     mode: 0644
   with_fileglob:
     - "{{ webhook_plugins_src_dir }}/{{ webhook_name }}/*"
-  notify: restart galaxy
+  notify: galaxy gravity restart

--- a/roles/webhooks/tasks/main.yml
+++ b/roles/webhooks/tasks/main.yml
@@ -15,4 +15,4 @@
     state: absent
   with_items: "{{ existing_webhook_plugin_dirs.stdout_lines }}"
   when: "item not in webhook_plugins"
-  notify: galaxy gravity restart
+  notify: restart galaxy

--- a/roles/webhooks/tasks/main.yml
+++ b/roles/webhooks/tasks/main.yml
@@ -15,4 +15,4 @@
     state: absent
   with_items: "{{ existing_webhook_plugin_dirs.stdout_lines }}"
   when: "item not in webhook_plugins"
-  notify: restart galaxy
+  notify: galaxy gravity restart

--- a/roles/webhooks/tasks/main.yml
+++ b/roles/webhooks/tasks/main.yml
@@ -15,3 +15,4 @@
     state: absent
   with_items: "{{ existing_webhook_plugin_dirs.stdout_lines }}"
   when: "item not in webhook_plugins"
+  notify: restart galaxy

--- a/templates/galaxy/webhooks/subdomain_switcher/config.yml.j2
+++ b/templates/galaxy/webhooks/subdomain_switcher/config.yml.j2
@@ -29,7 +29,7 @@ function: >
     }
 
     const listItems = SUBDOMAINS
-      .filter( site => site.url.strip('/') !== window.location.origin )
+      .filter( site => site.url.replace(/\/$/, '') !== window.location.origin )
       .map(site => `<li>
         <a class="dropdown-item" role="menuitem" href="${site.url}">${site.label}</a>
       </li>`);

--- a/templates/galaxy/webhooks/subdomain_switcher/styles.css.j2
+++ b/templates/galaxy/webhooks/subdomain_switcher/styles.css.j2
@@ -1,0 +1,1 @@
+/* Yes, an empty CSS file but it seems to be required */


### PR DESCRIPTION
This PR will deploy the "genomes lab" subdomain, the `webhooks` role and the `subdomain_switcher` webhook (masthead icon) to aarnet/prod. It also applies some updates to these roles on dev and staging.

Run the aarnet playbook with `--extra-vars "certbot_expand=true"` to force certbot to create a new certificate that includes the `genome.usegalaxy.org` domain.

The webhooks role will notify `restart galaxy` - please make sure that galaxy restarts for the `subdomain_switcher` webhook to take effect. It should look like this (live on staging):

![image](https://github.com/usegalaxy-au/infrastructure/assets/42562517/03141912-bb30-47e5-9d1c-16a4d88f30ea)
