### PR TITLE
upgrade pulsar to 0.15.2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -154,7 +154,6 @@ destinations:
         - pulsar-high-mem2
       require:
         - pulsar
-        - offline
   pulsar-qld-high-mem0:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem0_runner

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -41,7 +41,7 @@ nfs_exports:
     - "/mnt/pulsar  *(rw,async,no_root_squash,no_subtree_check)"
 
 # Pulsar
-pulsar_package_version: '0.14.13'
+pulsar_package_version: '0.15.2'
 
 pulsar_root: /mnt/pulsar
 pulsar_server_dir: /mnt/pulsar/server

--- a/host_vars/qld-pulsar-himem-0.yml
+++ b/host_vars/qld-pulsar-himem-0.yml
@@ -91,3 +91,6 @@ extra_keys:
 # docker
 docker_daemon_options:
   data-root: /mnt/docker-data
+
+# stats role
+sinfo_hostname: 'pulsar-qld-himem-0' # TODO: fix hostnames, influx database so that this may be the same as the hostname and the destination ID

--- a/host_vars/qld-pulsar-himem-1.yml
+++ b/host_vars/qld-pulsar-himem-1.yml
@@ -91,3 +91,6 @@ extra_keys:
 # docker
 docker_daemon_options:
   data-root: /mnt/docker-data
+
+# stats role
+sinfo_hostname: 'pulsar-qld-himem-1' # TODO: fix hostnames, influx database so that this may be the same as the hostname and the destination ID

--- a/host_vars/qld-pulsar-himem-2.yml
+++ b/host_vars/qld-pulsar-himem-2.yml
@@ -91,3 +91,6 @@ extra_keys:
 # docker
 docker_daemon_options:
   data-root: /mnt/docker-data
+
+# stats role
+sinfo_hostname: 'pulsar-qld-himem-2' # TODO: fix hostnames, influx database so that this may be the same as the hostname and the destination ID

--- a/pulsar-QLD_playbook.yml
+++ b/pulsar-QLD_playbook.yml
@@ -45,7 +45,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Reload exportfs
       command: exportfs -ra

--- a/pulsar-high-mem1_playbook.yml
+++ b/pulsar-high-mem1_playbook.yml
@@ -36,7 +36,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -36,7 +36,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:

--- a/pulsar-mel2_playbook.yml
+++ b/pulsar-mel2_playbook.yml
@@ -44,7 +44,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Reload exportfs
       command: exportfs -ra

--- a/pulsar-mel3_playbook.yml
+++ b/pulsar-mel3_playbook.yml
@@ -44,7 +44,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Make sure link from /mnt/pulsar/files to /mnt/files exists
       file:

--- a/pulsar-nci-training_playbook.yml
+++ b/pulsar-nci-training_playbook.yml
@@ -47,7 +47,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Reload exportfs
       command: exportfs -ra

--- a/pulsar-qld-blast_playbook.yml
+++ b/pulsar-qld-blast_playbook.yml
@@ -26,7 +26,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:

--- a/pulsar-qld-high-mem_playbook.yml
+++ b/pulsar-qld-high-mem_playbook.yml
@@ -36,7 +36,7 @@
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks
-    # - slg.galaxy_stats
+    - slg.galaxy_stats
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:
@@ -68,15 +68,15 @@
           path: /lib/systemd/system/slurmd.service
           regexp: "^TasksMax="
           line: "TasksMax=5000"
-      when: "{{ inventory_hostname.endswith('himem-2') }}"
+      when: inventory_hostname.endswith('himem-2')
     - name: reload systemd manager configuration for changes to take effect
       systemd:
           state: restarted
           daemon_reload: yes
           name: slurmd
-      when: "{{ inventory_hostname.endswith('himem-2') }}"
+      when: inventory_hostname.endswith('himem-2')
     - name: Update max_map_count to 1,000,000 for maxquant on himem-1
       command:
         cmd: sysctl -w vm.max_map_count=1000000
-      when: "{{ inventory_hostname.endswith('himem-1') }}"
+      when: inventory_hostname.endswith('himem-1')
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -61,7 +61,7 @@
       path: /home/galaxy/.bashrc
       owner: galaxy
       group: galaxy
-  when: galaxy_config_file is defined
+  when: add_galaxy_user is defined and galaxy_config_file is defined
 
 - name: Add ssl key if required
   include_tasks: ssl_key.yml

--- a/roles/slg.galaxy_stats/defaults/main.yml
+++ b/roles/slg.galaxy_stats/defaults/main.yml
@@ -28,12 +28,12 @@ stats_db_port: 5432
 # Galaxy settings
 galaxy_root: /mnt/galaxy/galaxy-app/
 galaxy_config_dir: /mnt/galaxy/config/
-galaxy_config_file: "{{galaxy_config_dir}}/galaxy.yml"
+galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 galaxy_mutable_config_dir: /mnt/galaxy/var/
 galaxy_log_dir: /var/log/galaxy
 
 #sinfo format string
-sinfo_format: "%24n %.10C %.6t"
+sinfo_format: "%24n %.16C %.6t"
 sinfo_hostname: "{{ ansible_hostname }}"
 
 #variable to switch off posting to influx

--- a/roles/slg.galaxy_stats/templates/get_queue_size.py.j2
+++ b/roles/slg.galaxy_stats/templates/get_queue_size.py.j2
@@ -21,7 +21,7 @@ job_conf_path = '{{ galaxy_config_dir }}/job_conf.yml'
 secrets = yaml.safe_load(open(secrets_file, 'r'))
 SALT = secrets['salt']
 TOP_USAGE_LIMIT = 30
-PGCONNS = secrets['pgconn']
+PGCONNS = secrets.get('pgconn')
 
 time = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 


### PR DESCRIPTION
Pulsars have been upgraded except for pulsar-QLD, pulsar-qld-blast and pulsar-azure. Blast and azure are less critical because they do not have a wide range of tools running on them.

This PR also uncomments slg.galaxy_stats role on the pulsars.

Pulsar QLD is offline waiting for two long running jobs to finish before we can run the playbook there.