### PR TITLE
Fix mail template

### DIFF
--- a/files/galaxy/config/activation-email.html
+++ b/files/galaxy/config/activation-email.html
@@ -27,10 +27,6 @@ Template begins here >>>>>>
 <head>
   <meta charset="utf-8">
   <title>Galaxy account activation</title>
-
-  <!-- Load custom font from Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
Remove broken/redundant gfonts links. Email clients can't use these and it affects spam score.