### PR TITLE
Modernise default tool in etca tpv config

### DIFF
--- a/files/galaxy/dynamic_job_rules/load-testing/total_perspective_vortex/testing_tpv_config.yml
+++ b/files/galaxy/dynamic_job_rules/load-testing/total_perspective_vortex/testing_tpv_config.yml
@@ -5,12 +5,12 @@ global:
 
 tools:
   default:
+    context:
+      partition: main
     cores: 1
     mem: cores * 3.8
+    params: {}
     env: {}
-    params:
-      nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
-      submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)}"
     scheduling:
       reject:
         - offline


### PR DESCRIPTION
native spec now set in destinations, 'partition' needs to be defined in context