### PR TITLE
Remove bad config keys from galaxy slurm config

### DIFF
--- a/group_vars/galaxy_etca_slurm.yml
+++ b/group_vars/galaxy_etca_slurm.yml
@@ -90,10 +90,7 @@ slurm_config:
   AccountingStorageHost: "{% if ansible_hostname == 'galaxy-queue' %}localhost{% else %}galaxy-queue{% endif %}"
   JobAcctGatherType: jobacct_gather/linux
   ControlMachine: galaxy-queue
-  SlurmctldPidFile: /run/slurmctld.pid
-  SlurmdPidFile: /run/slurmd.pid
   # SCHEDULING
-  FastSchedule: 2
   SchedulerType: sched/backfill
   SelectType: select/cons_res
   SelectTypeParameters: CR_CPU_Memory,CR_LLN

--- a/host_vars/galaxy-queue.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-queue.usegalaxy.org.au.yml
@@ -153,6 +153,13 @@ mariadb_password_root: "{{ vault_production_mariadb_password_root }}"
 
 #Slurmdbd
 
+__slurmdbd_config_default: # overriding this to remove deprecated SlurmctldPidFile (using this key breaks it)
+  AuthType: auth/munge
+  DbdPort: 6819
+  SlurmUser: "{{ __slurm_user_name }}"
+  # SlurmctldPidFile: "{{ __slurm_run_dir ~ '/slurmdbd.pid' if __slurm_debian else omit }}"
+  LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"
+
 slurmdbd_config:
   AuthType: auth/munge
   AuthInfo: /var/run/munge/munge.socket.2
@@ -162,7 +169,6 @@ slurmdbd_config:
   StoragePass: "{{ slurm_database_user_password }}"
   StorageType: accounting_storage/mysql
   StorageUser: "{{ slurm_database_user }}"
-  LogFile: /var/log/slurm-llnl/slurmdbd.log
   PidFile: /run/slurmdbd.pid
   SlurmUser: slurm
 


### PR DESCRIPTION
Remove deprecated keys from slurm_config (these will also be removed with Nuwan's change #1374 )

Remove incorrect key for logfile in dbd conf and also override `__slurmdbd_config_default` because SlurmctldPidFile key should not be there and breaks everything.  TODO: figure out under what circumstances that key should not be included and PR a change to the ansible-slurm role.