### PR TITLE
Add `pulsar-quick` tag to tools where jobs are likely to complete in less than a day

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -232,6 +232,7 @@ destinations:
       require:
         - pulsar
         - offline  # on loan to etca
+        - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -101,6 +101,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/.*:
     cores: 7
     mem: 26.8
@@ -109,6 +110,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/.*:
     cores: 9
     mem: 34.5
@@ -117,6 +119,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/.*:
     cores: 8
     mem: 30.7
@@ -125,6 +128,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: deeptools_plot_fingerprint_small_input_rule
       if: input_size < 0.5
@@ -314,6 +318,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: bowtie2_small_input_rule
       if: input_size < 0.1
@@ -329,6 +334,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: bwa_small_input_rule
       if: input_size < 0.25
@@ -344,6 +350,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: bwa_mem_small_input_rule
       if: input_size < 0.25
@@ -423,12 +430,14 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer/.*:
     cores: 8
     mem: 30.7
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: fastq_paired_end_deinterlacer_small_input_rule
       if: input_size < 1
@@ -440,6 +449,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: fastq_paired_end_interlacer_small_input_rule
       if: input_size < 0.02
@@ -468,6 +478,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: fastqc_small_input_rule
       if: input_size < 0.01
@@ -845,6 +856,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: abricate_small_input_rule
       if: input_size < 0.005
@@ -1179,6 +1191,7 @@ tools:
       - pulsar-paw
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_variants/ivar_variants/.*:
     cores: 8
     mem: 30.7
@@ -1187,6 +1200,7 @@ tools:
       - pulsar-paw
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/.*:
     cores: 3
     mem: 11.5
@@ -1263,6 +1277,7 @@ tools:
       - pulsar-paw
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/.*:
     cores: 3
     mem: 11.5
@@ -1274,6 +1289,7 @@ tools:
       - pulsar-paw
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgdiff/.*:
     cores: 5
     mem: 19.1
@@ -1374,6 +1390,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: minimap2_small_input_rule
       if: input_size < 0.5
@@ -1696,6 +1713,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: pilon_small_input_rule
       if: input_size < 4
@@ -1822,6 +1840,7 @@ tools:
       accept:
       - pulsar
       - pulsar-training-large
+      - pulsar-quick
     rules:
     - id: rule_rna_star_limit_concurrency
       if: |
@@ -1935,6 +1954,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: shovill_small_input_rule
       if: input_size < 0.015
@@ -1955,6 +1975,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: snippy_small_input_rule
       if: input_size < 0.015
@@ -2165,6 +2186,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: htseq_count_small_input_rule
       if: input_size < 0.2
@@ -2258,6 +2280,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: trimmomatic_small_input_rule
       if: input_size < 0.015


### PR DESCRIPTION
pulsar-QLD is offline to be available to Sydney galaxy but Sydney galaxy does not need it this week. This is an attempt to mark some tools as quick so that pulsar-QLD can be brought back to production in a limited capacity, to run jobs that we expect to complete in reasonable time.