### PR TITLE
Update pulsar-app version to 0.15.3

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -41,7 +41,7 @@ nfs_exports:
     - "/mnt/pulsar  *(rw,async,no_root_squash,no_subtree_check)"
 
 # Pulsar
-pulsar_package_version: '0.15.2'
+pulsar_package_version: '0.15.3'
 
 pulsar_root: /mnt/pulsar
 pulsar_server_dir: /mnt/pulsar/server


### PR DESCRIPTION
There is a bug in the current version (0.15.2) that causes pulsar to stop working every now and then.

pulsar-azure and pulsar-qld-blast are still on the old version (0.14.13) because the 0.14.* -> 0.15.* update needs to happen when no jobs are running.

Updating from 0.15.2 to 0.15.3 is not expected to harm running jobs.