### PR TITLE
Remove SlurmctldPidFile from default slurmdbd config block

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -232,3 +232,10 @@ singularity_go_path: "{{ golang_install_dir }}"
 
 # docker
 docker_install_compose: false
+
+# slurmdbd
+__slurmdbd_config_default:
+  AuthType: auth/munge
+  DbdPort: 6819
+  SlurmUser: "{{ __slurm_user_name }}"
+  LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"


### PR DESCRIPTION
The key 'SlurmctldPidFile' was not being added to slurmdbd config from the 3-year-old pasted slurm role. It is now being added from the current version of the role. It actually breaks slurmdbd for version 19.05 as well as on the newer version we have installed on the galaxy VMs. Until this is fixed in the role we need to override it.

The default variable coming from the role is
```
__slurmdbd_config_default:
  AuthType: auth/munge
  DbdPort: 6819
  SlurmUser: "{{ __slurm_user_name }}"
  SlurmctldPidFile: "{{ __slurm_run_dir ~ '/slurmdbd.pid' if __slurm_debian else omit }}"
  LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"
``` 