### PR TITLE
kombu should be greater than 5.2.0 on pulsar

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -67,7 +67,7 @@ pulsar_optional_dependencies:
   - psutil
   - pycurl
   - drmaa
-  - kombu
+  - kombu>=5.2.0
 
 install_drmaa: true
 pulsar_drmaa_library_path: /usr/lib/slurm-drmaa/lib/libdrmaa.so.1


### PR DESCRIPTION
pulsar-app does not require this but it logs frequent recommendations to update kombu to at least 5.2.0