### PR TITLE
Galaxy slurm update and memory corrections

### DIFF
--- a/group_vars/aarnet_slurm.yml
+++ b/group_vars/aarnet_slurm.yml
@@ -11,52 +11,52 @@ slurm_nodes:
   - name: aarnet-w1
     NodeAddr: "{{ hostvars['aarnet-w1']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w2
     NodeAddr: "{{ hostvars['aarnet-w2']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w3
     NodeAddr: "{{ hostvars['aarnet-w3']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w4
     NodeAddr: "{{ hostvars['aarnet-w4']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w5
     NodeAddr: "{{ hostvars['aarnet-w5']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w6
     NodeAddr: "{{ hostvars['aarnet-w6']['internal_ip'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: aarnet-w7
     NodeAddr: "{{ hostvars['aarnet-w7']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w8
     NodeAddr: "{{ hostvars['aarnet-w8']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: aarnet-w9
     NodeAddr: "{{ hostvars['aarnet-w9']['internal_ip'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: aarnet-w10
     NodeAddr: "{{ hostvars['aarnet-w10']['internal_ip'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: aarnet-queue
     NodeAddr: "{{ hostvars['aarnet-queue']['internal_ip'] }}"
@@ -66,7 +66,7 @@ slurm_nodes:
   - name: aarnet
     NodeAddr: "{{ hostvars['aarnet']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
 
 slurm_partitions:

--- a/group_vars/galaxy_etca_slurm.yml
+++ b/group_vars/galaxy_etca_slurm.yml
@@ -11,52 +11,52 @@ slurm_nodes:
   - name: galaxy-w1
     NodeAddr: "{{ hostvars['galaxy-w1']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w2
     NodeAddr: "{{ hostvars['galaxy-w2']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w3
     NodeAddr: "{{ hostvars['galaxy-w3']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w4
     NodeAddr: "{{ hostvars['galaxy-w4']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w5
     NodeAddr: "{{ hostvars['galaxy-w5']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w6
     NodeAddr: "{{ hostvars['galaxy-w6']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w7
     NodeAddr: "{{ hostvars['galaxy-w7']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
   - name: galaxy-w8
     NodeAddr: "{{ hostvars['galaxy-w8']['internal_ip'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: galaxy-w9
     NodeAddr: "{{ hostvars['galaxy-w9']['internal_ip'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: galaxy-w10
     NodeAddr: "{{ hostvars['galaxy-w10']['internal_ip'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: galaxy-queue
     NodeAddr: "{{ hostvars['galaxy-queue']['internal_ip'] }}"
@@ -66,7 +66,7 @@ slurm_nodes:
   - name: galaxy
     NodeAddr: "{{ hostvars['galaxy']['internal_ip'] }}"
     CPUs: 16
-    RealMemory: 62815
+    RealMemory: 64000
     State: UNKNOWN
 
 slurm_partitions:
@@ -84,15 +84,6 @@ slurm_partitions:
     State: UP
     MaxTime: "10:00:00"
 
-slurm_config:
-  #SlurmDBd includes
-  AccountingStorageType: accounting_storage/slurmdbd
-  AccountingStorageHost: "{% if ansible_hostname == 'galaxy-queue' %}localhost{% else %}galaxy-queue{% endif %}"
-  JobAcctGatherType: jobacct_gather/linux
-  ControlMachine: galaxy-queue
-  # SCHEDULING
-  SchedulerType: sched/backfill
-  SelectType: select/cons_res
-  SelectTypeParameters: CR_CPU_Memory,CR_LLN
+slurm_controller_host: galaxy-queue
 
 slurm_munge_key: files/keys/munge.key

--- a/group_vars/pulsar_QLD/pulsar-QLD_slurm.yml
+++ b/group_vars/pulsar_QLD/pulsar-QLD_slurm.yml
@@ -9,42 +9,42 @@ slurm_nodes:
   - name: pulsar-QLD
     NodeAddr: "{{ hostvars['pulsar-QLD']['ansible_ssh_host'] }}"
     CPUs: 8
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w0
     NodeAddr: "{{ hostvars['pulsar-QLD-w0']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w1
     NodeAddr: "{{ hostvars['pulsar-QLD-w1']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w2
     NodeAddr: "{{ hostvars['pulsar-QLD-w2']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w3
     NodeAddr: "{{ hostvars['pulsar-QLD-w3']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w4
     NodeAddr: "{{ hostvars['pulsar-QLD-w4']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w5
     NodeAddr: "{{ hostvars['pulsar-QLD-w5']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-QLD-w6
     NodeAddr: "{{ hostvars['pulsar-QLD-w6']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
 
 slurm_partitions:

--- a/group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
+++ b/group_vars/pulsar_mel2/pulsar-mel2_slurm.yml
@@ -9,42 +9,42 @@ slurm_nodes:
     - name: pulsar-mel2
       NodeAddr: "{{ hostvars['pulsar-mel2']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w1
       NodeAddr: "{{ hostvars['pulsar-mel2-w1']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w2
       NodeAddr: "{{ hostvars['pulsar-mel2-w2']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w3
       NodeAddr: "{{ hostvars['pulsar-mel2-w3']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w4
       NodeAddr: "{{ hostvars['pulsar-mel2-w4']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w5
       NodeAddr: "{{ hostvars['pulsar-mel2-w5']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w6
       NodeAddr: "{{ hostvars['pulsar-mel2-w6']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-mel2-w7
       NodeAddr: "{{ hostvars['pulsar-mel2-w7']['ansible_ssh_host'] }}"
       CPUs: 8
-      RealMemory: 32116
+      RealMemory: 32000
       State: UNKNOWN
 
 slurm_partitions:

--- a/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_slurm.yml
@@ -8,37 +8,37 @@ slurm_nodes:
   - name: pulsar-mel3
     NodeAddr: "{{ hostvars['pulsar-mel3']['ansible_ssh_host'] }}"
     CPUs: 8
-    RealMemory: 32112
+    RealMemory: 32000
     State: UNKNOWN
   - name: pulsar-mel3-w1
     NodeAddr: "{{ hostvars['pulsar-mel3-w1']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-mel3-w2
     NodeAddr: "{{ hostvars['pulsar-mel3-w2']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
   - name: pulsar-mel3-w3
     NodeAddr: "{{ hostvars['pulsar-mel3-w3']['ansible_ssh_host'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: pulsar-mel3-w4
     NodeAddr: "{{ hostvars['pulsar-mel3-w4']['ansible_ssh_host'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: pulsar-mel3-w5
     NodeAddr: "{{ hostvars['pulsar-mel3-w5']['ansible_ssh_host'] }}"
     CPUs: 32
-    RealMemory: 125812
+    RealMemory: 128000
     State: UNKNOWN
   - name: pulsar-mel3-w6
     NodeAddr: "{{ hostvars['pulsar-mel3-w6']['ansible_ssh_host'] }}"
     CPUs: 16
-    RealMemory: 64318
+    RealMemory: 64000
     State: UNKNOWN
 
 slurm_partitions:

--- a/group_vars/pulsar_nci_training/pulsar-nci-training_slurm.yml
+++ b/group_vars/pulsar_nci_training/pulsar-nci-training_slurm.yml
@@ -10,67 +10,67 @@ slurm_nodes:
     - name: pulsar-nci-training
       NodeAddr: "{{ hostvars['pulsar-nci-training']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 16008
+      RealMemory: 16000
       State: UNKNOWN
     - name: pulsar-nci-training-w0
       NodeAddr: "{{ hostvars['pulsar-nci-training-w0']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w1
       NodeAddr: "{{ hostvars['pulsar-nci-training-w1']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w2
       NodeAddr: "{{ hostvars['pulsar-nci-training-w2']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w3
       NodeAddr: "{{ hostvars['pulsar-nci-training-w3']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w4
       NodeAddr: "{{ hostvars['pulsar-nci-training-w4']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w5
       NodeAddr: "{{ hostvars['pulsar-nci-training-w5']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w6
       NodeAddr: "{{ hostvars['pulsar-nci-training-w6']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w7
       NodeAddr: "{{ hostvars['pulsar-nci-training-w7']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w8
       NodeAddr: "{{ hostvars['pulsar-nci-training-w8']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w9
       NodeAddr: "{{ hostvars['pulsar-nci-training-w9']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w10
       NodeAddr: "{{ hostvars['pulsar-nci-training-w10']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
     - name: pulsar-nci-training-w11
       NodeAddr: "{{ hostvars['pulsar-nci-training-w11']['internal_ip'] }}"
       CPUs: 16
-      RealMemory: 48190
+      RealMemory: 48000
       State: UNKNOWN
 
 slurm_partitions:

--- a/group_vars/pulsar_paw/pulsar-paw_slurm.yml
+++ b/group_vars/pulsar_paw/pulsar-paw_slurm.yml
@@ -9,32 +9,32 @@ slurm_nodes:
     - name: pulsar-paw
       NodeAddr: "{{ hostvars['pulsar-paw']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 30500
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-paw-w1
       NodeAddr: "{{ hostvars['pulsar-paw-w1']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 32208
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-paw-w2
       NodeAddr: "{{ hostvars['pulsar-paw-w2']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 32208
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-paw-w3
       NodeAddr: "{{ hostvars['pulsar-paw-w3']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 32208
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-paw-w4
       NodeAddr: "{{ hostvars['pulsar-paw-w4']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 32208
+      RealMemory: 32000
       State: UNKNOWN
     - name: pulsar-paw-w5
       NodeAddr: "{{ hostvars['pulsar-paw-w5']['internal_ip'] }}"
       CPUs: 8
-      RealMemory: 32208
+      RealMemory: 32000
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -58,7 +58,7 @@ slurm_nodes:
     - name: pulsar-high-mem1
       NodeAddr: "{{ hostvars['pulsar-high-mem1']['ansible_ssh_host'] }}"
       CPUs: 126
-      RealMemory: 3937373
+      RealMemory: 3937300
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -58,7 +58,7 @@ slurm_nodes:
     - name: pulsar-high-mem1
       NodeAddr: "{{ hostvars['pulsar-high-mem1']['ansible_ssh_host'] }}"
       CPUs: 126
-      RealMemory: 4018565
+      RealMemory: 3937373
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -57,7 +57,7 @@ slurm_nodes:
     - name: pulsar-high-mem2
       NodeAddr: "{{ hostvars['pulsar-high-mem2']['ansible_ssh_host'] }}"
       CPUs: 126
-      RealMemory: 1958768
+      RealMemory: 1958700
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -57,7 +57,7 @@ slurm_nodes:
     - name: pulsar-high-mem2
       NodeAddr: "{{ hostvars['pulsar-high-mem2']['ansible_ssh_host'] }}"
       CPUs: 126
-      RealMemory: 2009282
+      RealMemory: 1958768
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/qld-pulsar-himem-0.yml
+++ b/host_vars/qld-pulsar-himem-0.yml
@@ -57,7 +57,7 @@ slurm_nodes:
     - name: qld-pulsar-himem-0
       NodeAddr: "{{ hostvars['qld-pulsar-himem-0']['ansible_ssh_host'] }}"
       CPUs: 240
-      RealMemory: 3937345
+      RealMemory: 3937300
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/qld-pulsar-himem-1.yml
+++ b/host_vars/qld-pulsar-himem-1.yml
@@ -57,7 +57,7 @@ slurm_nodes:
     - name: qld-pulsar-himem-1
       NodeAddr: "{{ hostvars['qld-pulsar-himem-1']['ansible_ssh_host'] }}"
       CPUs: 240
-      RealMemory: 3937345
+      RealMemory: 3937300
       State: UNKNOWN
 
 slurm_partitions:

--- a/host_vars/qld-pulsar-himem-2.yml
+++ b/host_vars/qld-pulsar-himem-2.yml
@@ -57,7 +57,7 @@ slurm_nodes:
     - name: qld-pulsar-himem-2
       NodeAddr: "{{ hostvars['qld-pulsar-himem-2']['ansible_ssh_host'] }}"
       CPUs: 240
-      RealMemory: 3937345
+      RealMemory: 3937300
       State: UNKNOWN
 
 slurm_partitions:


### PR DESCRIPTION
Based on Tim Wickberg's advice [here](https://bugs.schedmd.com/show_bug.cgi?id=3415) and yesterday's experience, set RealMemory for all slurm workers to something a little less than MemTotal. For the ordinary workers that can be a very round number: 32000, 64000 or 128000. The values have also been lowered a little for the high-memory and training nodes. They will still all have enough stated memory for the jobs being sent to them.