### PR TITLE
Increase number of postprocessing retries for pulsar

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -80,9 +80,9 @@ pulsar_yaml_config:
           preprocess_action_interval_start: 2
           preprocess_action_interval_step: 2
           preprocess_action_interval_max: 60
-          postprocess_action_max_retries: 10
-          postprocess_action_interval_start: 8
-          postprocess_action_interval_step: 8
+          postprocess_action_max_retries: 18
+          postprocess_action_interval_start: 2
+          postprocess_action_interval_step: 2
           postprocess_action_interval_max: 120
           min_polling_interval: 15
   dependency_resolution:


### PR DESCRIPTION
This increases the number of retries to 18 in the hope that a greater number of retries will increase the likelihood of large files being fully transferred back to galaxy.