### PR TITLE
Allow pulsar blast jobs to go to pulsar-mel3

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -128,6 +128,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-mel3
+        - pulsar-blast
       require:
         - pulsar
   pulsar-high-mem1:


### PR DESCRIPTION
To alleviate the blast queue issue.

What we also need potentially is an alternative ranking function for these tools that will send jobs to a second destination *only* if the primary destination is full.

This is related to issue https://github.com/usegalaxy-au/infrastructure/issues/1427 and would be good to discuss with @nuwang and @bgruening 