### PR TITLE
Give big memory to smudgeplot, remove cores/mem for macs2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -756,6 +756,14 @@ tools:
     scheduling:
       prefer:
       - pulsar
+  toolshed.g2.bx.psu.edu/repos/galaxy-australia/smudgeplot/smudgeplot/.*:
+    cores: 8
+    mem: 500
+    params:
+      singularity_enabled: true
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_classification/cardinal_classification/.*:
     scheduling:
       accept:
@@ -1292,14 +1300,9 @@ tools:
       - pulsar
       - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgdiff/.*:
-    cores: 5
-    mem: 19.1
     scheduling:
       accept:
       - pulsar
-  toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/.*:
-    cores: 9
-    mem: 34.5
   toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/.*:
     cores: 8
     mem: 30.39


### PR DESCRIPTION
Remove cores/mem entries for macs2, because the local config seems to have been giving the tools more than they need, they are not multithreaded and the entries in the shared_db seem sensible. It is still the case that macs2_callpeak cannot run on pulsar.

Give smudgeplot 500G because it runs out of memory with 60G. If it uses substantially less than 500 this can be reduced.