### PR TITLE
ignore missing apport systemd service in common role

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -99,4 +99,5 @@
     name: "apport"
     state: "stopped"
     enabled: false
+  ignore_errors: True
 


### PR DESCRIPTION
Some VMs (dev) don't have the apport service installed, so need to ignore errors when disabling apport service in common role.
