### PR TITLE
Increase memory for humann

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -128,7 +128,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-mel3
-        - pulsar-blast
+        # - pulsar-blast
       require:
         - pulsar
   pulsar-high-mem1:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1167,7 +1167,7 @@ tools:
     - id: humann_medium_input_rule
       if: 0.01 <= input_size < 10
       cores: 7
-      mem: 26.8
+      mem: 45
   toolshed.g2.bx.psu.edu/repos/iuc/humann2/humann2/.*:
     inherits: toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/.*
   toolshed.g2.bx.psu.edu/repos/iuc/hyphy_absrel/hyphy_absrel/.*:

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -496,7 +496,7 @@ job_conf_limits:
 
   - type: destination_total_concurrent_jobs
     id: pulsar-mel3
-    value: 20
+    value: 25
   - type: destination_user_concurrent_jobs
     id: pulsar-mel3
     value: 5
@@ -531,10 +531,7 @@ job_conf_limits:
 
   - type: destination_total_concurrent_jobs
     id: pulsar-QLD
-    value: 20
-  - type: destination_user_concurrent_jobs
-    id: pulsar-QLD
-    value: 5
+    value: 25
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-blast


### PR DESCRIPTION
Increase memory for medium humann jobs to 45 based on sacct data from older jobs. A user has sent in a ticket about a recent job being oom killed.

Remove user limit for jobs on pulsar-QLD.

Stop sending blast jobs to pulsar-mel3.