### PR TITLE
Distributed object store conf for aarnet

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -568,6 +568,7 @@ slurm_singularity_volumes_list_restricted:
   - /mnt/user-data-5:ro
   - /mnt/user-data-4:ro
   - /mnt/user-data:ro
+  - /mnt/data08:ro
   - /mnt/custom-indices:ro
   - /cvmfs/data.galaxyproject.org:ro
   - /tmp:rw  # TODO: copy to galaxy etca files

--- a/templates/galaxy/config/aarnet_object_store_conf.xml.j2
+++ b/templates/galaxy/config/aarnet_object_store_conf.xml.j2
@@ -1,34 +1,43 @@
 <?xml version="1.0"?>
-<object_store type="hierarchical">
+<object_store type="distributed" id="primary" order="0">
     <backends>
-        <backend id="aarnetNFS7" type="disk" order="0">
+        <!-- New folder with storage by UUID on the 50T volume. Initially set weight=0. -->
+        <backend id="data09" weight="0" store_by="uuid">
+            <files_dir path="/mnt/user-data-6/data09" />
+        </backend>
+        <!-- New folder with storage by UUID on the 150T volume, weight=1 means it is the only
+        one that will be written to if all of the others have weight=0 -->
+        <backend id="data08" weight="1" store_by="uuid">
+            <files_dir path="/mnt/data08" />
+        </backend>
+        <backend id="aarnetNFS7" type="disk" order="0" store_by="id">
             <files_dir path="/mnt/user-data-7" />
         </backend>
-        <backend id="aarnetNFS6" type="disk" order="1">
+        <backend id="aarnetNFS6" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/user-data-6" />
         </backend>
-        <backend id="aarnetNFS5" type="disk" order="2">
+        <backend id="aarnetNFS5" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/user-data-5" />
         </backend>
 {% if pawsey_file_mounts_available|d(True) %}
-        <backend id="perthNFS1" type="disk" order="3">
+        <backend id="perthNFS1" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/user-data" />
         </backend>
-        <backend id="perthNFS4" type="disk" order="4">
+        <backend id="perthNFS4" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/user-data-4" />
         </backend>
-        <backend id="perthNFS2" type="disk" order="5">
+        <backend id="perthNFS2" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/user-data-2" />
         </backend>
-        <backend id="perthNFS3" type="disk" order="6">
+        <backend id="perthNFS3" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/user-data-3" />
         </backend>
 {% endif %}
 {% if legacy_file_mounts_available|d(True) %}
-        <backend id="qldNFS1" type="disk" order="7">
+        <backend id="qldNFS1" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/files" />
         </backend>
-        <backend id="qldNFS2" type="disk" order="8">
+        <backend id="qldNFS2" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/files2" />
         </backend>
 {% endif %}

--- a/templates/galaxy/config/aarnet_object_store_conf.xml.j2
+++ b/templates/galaxy/config/aarnet_object_store_conf.xml.j2
@@ -2,12 +2,12 @@
 <object_store type="distributed" id="primary" order="0">
     <backends>
         <!-- New folder with storage by UUID on the 50T volume. Initially set weight=0. -->
-        <backend id="data09" weight="0" store_by="uuid">
+        <backend id="data09" type="disk" weight="0" store_by="uuid">
             <files_dir path="/mnt/user-data-6/data09" />
         </backend>
         <!-- New folder with storage by UUID on the 150T volume, weight=1 means it is the only
         one that will be written to if all of the others have weight=0 -->
-        <backend id="data08" weight="1" store_by="uuid">
+        <backend id="data08" type="disk" weight="1" store_by="uuid">
             <files_dir path="/mnt/data08" />
         </backend>
         <backend id="aarnetNFS7" type="disk" order="0" store_by="id">


### PR DESCRIPTION
This can't be merged yet. Still to do:

(1) Set object store IDs for datasets and metadata files for all 'store_by="id"' backends (so far this has only been set for perthNFS1-4)
(2) Update aarnet-user-nfs playbook to create new folder `data008` alongside user-data5 and user-data7 in /mnt directory on aarnet-user-nfs and a new subdirectory `data009` of /user-data6
(3) Update aarnet and aarnet_workers shared_mounts variables to mount the new folder /mnt/data008

To switch to using this configuration:
Stop galaxy.
Set all dataset ids and metadata_file object_store_ids created since August to aarnetNFS7
Run aarnet_update_configs playbook
Start galaxy