### PR TITLE
disable galaxy subdomains for dev release 23.1

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -55,7 +55,7 @@
     - role: galaxyproject.miniconda
       become: true
       become_user: galaxy
-    - usegalaxy_eu.galaxy_subdomains
+    #- usegalaxy_eu.galaxy_subdomains # broken in galaxy release_23.1
     - webhooks
     - nginx-upload-module
     - galaxyproject.nginx


### PR DESCRIPTION
task `usegalaxy_eu.galaxy_subdomains : Create main site` is broken in galaxy release_23.1 due to `static/style/base.css` no longer existing.