### PR TITLE
run mothur with docker for safety

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1405,6 +1405,10 @@ tools:
       if: 0.5 <= input_size < 20
       cores: 16
       mem: 61.4
+  toolshed.g2.bx.psu.edu/repos/iuc/mothur.*:
+    params:
+      docker_enabled: true
+      docker_run_extra_arguments: --pids-limit 10000 --ulimit fsize=1000000000 --env TERM=vt100
   toolshed.g2.bx.psu.edu/repos/iuc/mothur_align_seqs/mothur_align_seqs/.*:
     cores: 7
     mem: 26.8


### PR DESCRIPTION
mothur jobs will fail if any file in the working directory is bigger than 470G. It will also fail if too many pids are created.

[EDIT]: I previously wrote that this would not work if the  tool ID was not in our local config - have since tested this with dry run and it should work either way.