### PR TITLE
Cactus is failing tests with toil.batchSystems.abstractBatchSystem.Ins…

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -719,7 +719,7 @@ tools:
 
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
     context:
-      test_cores: 4
+      test_cores: 10
     cores: 60
     mem: 961
     params:


### PR DESCRIPTION
```
toil.batchSystems.abstractBatchSystem.InsufficientSystemResources: The job 'cactus_cons' kind-cactus_cons/instance-3opzywm0 v1 is requesting 16785870848 bytes of memory, more than the maximum of 15565000000 bytes of memory that SingleMachineBatchSystem was configured with, or enforced by --maxMemory. Scale is set to 1.0.
```