### PR TITLE
define hosts_template_file for galaxy_etca

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -3,6 +3,9 @@ galaxy_gid: 10010
 
 use_internal_ips: true
 
+# cloud-init template for /etc/hosts
+hosts_template_file: "/etc/cloud/templates/hosts.debian.tmpl"
+
 influx_url: stats.usegalaxy.org.au
 grafana_server_url: "https://{{ influx_url }}:8086"
 


### PR DESCRIPTION
Fix cloud init config issue causing /etc/hosts to be wiped on reboot, by defining `hosts_template_file` as `/etc/cloud/templates/hosts.debian.tmpl` for galaxy etca.
