### PR TITLE
switch back to data08

### DIFF
--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -125,7 +125,7 @@ galaxy_tus_upload_store: "{{ galaxy_tmp_dir }}/tus"
 
 galaxy_handler_count: 5
 
-galaxy_file_path: /mnt/user-data-6
+galaxy_file_path: /mnt/data08
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"

--- a/templates/galaxy/config/aarnet_object_store_conf.xml.j2
+++ b/templates/galaxy/config/aarnet_object_store_conf.xml.j2
@@ -2,11 +2,11 @@
 <object_store type="distributed" id="primary" order="0">
     <backends>
         <!-- New folder with storage by UUID on the 50T volume -->
-        <backend id="data09" type="disk" weight="1" store_by="uuid">
+        <backend id="data09" type="disk" weight="0" store_by="uuid">
             <files_dir path="/mnt/user-data-6/data09" />
         </backend>
         <!-- New folder with storage by UUID on the 150T volume -->
-        <backend id="data08" type="disk" weight="0" store_by="uuid">
+        <backend id="data08" type="disk" weight="1" store_by="uuid">
             <files_dir path="/mnt/data08" />
         </backend>
         <backend id="aarnetNFS7" type="disk" weight="0" store_by="id">


### PR DESCRIPTION
This switches the object store to write to data08 and updates nginx config so that the upload_store is within /mnt/data08 w.r.t. aarnet VM.

In the near future (maybe today) this needs to be merged, aarnet_playbook run and "sudo systemctl reload nginx" on aarnet.