### PR TITLE
declare additional packages in galaxyservers and pin watchdog

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -124,6 +124,17 @@ galaxy_conda_exec: mamba
 
 galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 
+tpv_version: "2.3.2"
+
+tpv_packages: |
+  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
+
+additional_packages:
+  - redis
+  - flower
+  - watchdog==2.2.1
+
+galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 
 #########################################
 # group_galaxy_config contains variables for galaxy_config that can be overridden by variables in host_galaxy_config (defined in host_vars)

--- a/host_vars/aarnet.usegalaxy.org.au.yml
+++ b/host_vars/aarnet.usegalaxy.org.au.yml
@@ -33,13 +33,6 @@ interactive_tools_server_name: "usegalaxy.org.au"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_23.0
 
-# total perspective vortex
-tpv_version: "2.2.4"
-
-# workaround to maintain correct tpv version (release_22.05)
-galaxy_additional_venv_packages: |
-  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
-
 # Mounts for various connections:
 shared_mounts: # TODO: /mnt/custom-indices from aarnet-misc-nfs
   - path: /mnt/ghost-galaxy-app

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -6,13 +6,9 @@ add_hosts_handlers: yes
 galaxy_login_checksum_expected: fd733fa7ea21a22f6f99a095f8c2646b
 
 # total perspective vortex
-tpv_version: "2.2.4"
+# tpv_version: "2.2.4"
 # tpv_repo: https://github.com/usegalaxy-au/total-perspective-vortex
 # tpv_commit_id: d8e336b1cc889237c155d0ad318051c36e5636e6
-
-# workaround to maintain correct tpv version (release_22.05)
-galaxy_additional_venv_packages: |
-  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
 
 # variables for attaching mounted volume to application server
 attached_volumes:

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -34,19 +34,6 @@ interactive_tools_server_name: "galaxy.usegalaxy.org.au"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_23.0
 
-# total perspective vortex # TODO: put this in galaxyservers.yml once aarnet-production is on release_23.0
-tpv_version: "2.3.1"
-
-# use galaxy_additional_venv_packages instead of install-tpv role
-tpv_packages: |
-  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
-
-celery_packages:
-  - redis
-  - flower
-
-galaxy_additional_venv_packages: "{{ tpv_packages + celery_packages }}"
-
 # TODO: check list concatenation with versions of ansible > 2.12
 shared_mounts: "{{ galaxy_server_and_worker_shared_mounts + galaxy_web_server_mounts }}" # sourced from galaxy_etca.yml
 

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -6,13 +6,6 @@ attached_volumes:
     path: /mnt
     fstype: ext4
 
-# total perspective vortex
-tpv_version: "2.2.4"
-
-# workaround to maintain correct tpv version (release_22.05)
-galaxy_additional_venv_packages: |
-  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
-
 certbot_domains:
   - "{{ hostname }}"
   - "*.interactivetoolentrypoint.interactivetool.{{ hostname }}"


### PR DESCRIPTION
Set galaxy_additional_venv_packages within galaxyservers.yml instead of host variables. Add 'watchdog==2.2.1' since the job handlers on etca had a memory leak with the latest version (3.0.0)