### PR TITLE
Remove all file size rules for abyss

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -899,11 +899,6 @@ tools:
       accept:
       - pulsar
       - pulsar-training-large
-    rules:
-    - id: abyss-pe_small_input_rule
-      if: input_size < 1
-      cores: 16
-      mem: 61.4
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/.*:
     scheduling:
       accept:


### PR DESCRIPTION
All abyss jobs fail. Test jobs fail with 62GB RAM. Test jobs used to pass on nodes that had no more than 62GB total RAM so allowing all jobs to run on high memory pulsar with 320GB probably won't even help but it's worth a try.