### PR TITLE
Add toolbox filters for fgenesh and cellranger

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2543,5 +2543,5 @@ tools:
       singularity_enabled: true
     rules:
       - if: |
-          not user or not 'fgenesh' in [role.name for role in user.all_roles() if not role.deleted]
+          not user or not 'Fgenesh' in [role.name for role in user.all_roles() if not role.deleted]
         fail: Your account has not been given access to fgenesh. Contact help@genome.edu.au if you think this is in error.

--- a/templates/galaxy/toolbox/filters/ga_filters.py.j2
+++ b/templates/galaxy/toolbox/filters/ga_filters.py.j2
@@ -6,6 +6,14 @@ test_tools = [
         'id': 'maxquant_test',
         'role': 'maxquant_test',
     },
+    {
+        'id': 'fgenesh',
+        'role': 'Fgenesh',
+    },
+    {
+        'id': 'cellranger',
+        'role': 'cellranger',
+    },
 ]
 
 def hide_test_tools(context, tool):


### PR DESCRIPTION
This means nobody without a VM login (machine_users in all.yml) and members of the Fgenesh/cellranger groups can see these tools. The TPV rule is more strict and will not allow anybody outside the Fgenesh group to run fgenesh.