### PR TITLE
dont attach volumes to phm1 and phm2

### DIFF
--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -17,11 +17,6 @@ pulsar_queue_url: "aarnet-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_hm1"
 pulsar_rabbit_vhost: "/pulsar/galaxy_hm1"
 
-attached_volumes:
-  - device: /dev/dm-0
-    path: /mnt
-    fstype: ext4
-
 galaxy_uid: 10010
 galaxy_gid: 10010
 

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -17,11 +17,6 @@ pulsar_queue_url: "aarnet-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_hm2"
 pulsar_rabbit_vhost: "/pulsar/galaxy_hm2"
 
-attached_volumes:
-  - device: /dev/nvme0n1
-    path: /mnt
-    fstype: ext4
-
 galaxy_uid: 10010
 galaxy_gid: 10010
 

--- a/pulsar-high-mem1_playbook.yml
+++ b/pulsar-high-mem1_playbook.yml
@@ -8,9 +8,6 @@
     - secret_group_vars/stats_server_vault
     - secret_group_vars/ubuntu_maintenance_key
   pre_tasks:
-    - name: Attach volume to instance
-      include_role:
-        name: attached-volumes
     - name: Create pulsar deps path
       file:
         path: "{{ pulsar_dependencies_dir }}"

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -8,9 +8,6 @@
     - secret_group_vars/stats_server_vault
     - secret_group_vars/ubuntu_maintenance_key
   pre_tasks:
-    - name: Attach volume to instance
-      include_role:
-        name: attached-volumes
     - name: Create pulsar deps path
       file:
         path: "{{ pulsar_dependencies_dir }}"


### PR DESCRIPTION
The new pulsar-high-mem1 and pulsar-high-mem2 VMs have NVME ephemeral volumes attached to /dev/vdb and mounted as ext4 on /mnt. For this reason the `attached-volumes` role and `attached_volumes` host_vars need to be removed.