### PR TITLE
fix column names for getorganelle

### DIFF
--- a/files/galaxy/config/tool_data_table_conf.xml
+++ b/files/galaxy/config/tool_data_table_conf.xml
@@ -23,7 +23,7 @@
     </table>
     <!-- GetOrganelle -->
     <table name="getorganelle" comment_char="#" allow_duplicate_entries="False">
-        <columns>ID, value, path, version</columns>
+        <columns>value, name, path, db-version</columns>
         <file path="/mnt/tools/tool-data/getorganelle.loc" />
     </table>
 </tables>


### PR DESCRIPTION
Column names for getorganelle need to be 'value, name, path, db-version' because these are coming from the tool repository - each time a new revision of getorganelle is installed, the shed tool data table conf gets another entry with these column names.