### PR TITLE
set pulsar-mel2 offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -108,6 +108,7 @@ destinations:
         - pulsar-mel2
       require:
         - pulsar
+        - offline
   pulsar-paw:
     inherits: _pulsar_destination
     runner: pulsar-paw_runner


### PR DESCRIPTION
Both pulsar-mel3 and pulsar-mel2 now offline. That leaves only pulsar-QLD for regular-sized slurm jobs for 20 or so tools (pulsar-quick tag), the rest will have to run on slurm for now.