### PR TITLE
partition, format and mount 42TB volume on galaxy-user-nfs as /mnt/volB; move existing 500G volume to /mnt/volA; change NFS export to /mnt/volB/user-data-test

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -28,7 +28,7 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     fstype: nfs
     state: mounted
   - path: /mnt/user-data-test  # TEMPORARY
-    src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/user-data-test"
+    src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volB/user-data-test"
     fstype: nfs
     state: mounted
   - path: /mnt/custom-indices

--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -1,14 +1,14 @@
-nfs_user_data_test_dir: /mnt/user-data-test
+nfs_user_data_test_dir: /mnt/volB/user-data-test
 
 attached_volumes:
   - device: /dev/vdb
-    path: /mnt
+    path: /mnt/volA
     fstype: ext4
     partition: 1
-  # - device: /dev/vdc
-  #   partition: 1
-  #   path: /user-data6
-  #   fstype: ext4
+  - device: /dev/vdc
+    partition: 1
+    path: /mnt/volB
+    fstype: ext4
 
 nfs_dirs:
   - "{{ nfs_user_data_test_dir }}"


### PR DESCRIPTION
Adding 42T volume to galaxy-user-nfs as /mnt/volB
Moving existing 500G volume on galaxy-user-nfs from /mnt to /mnt/volA
Change NFS export to /mnt/volB/user-data-test
