### PR TITLE
add pulsar-QLD to ETCA for load testing

### DIFF
--- a/files/galaxy/dynamic_job_rules/load-testing/total_perspective_vortex/testing_tpv_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/load-testing/total_perspective_vortex/testing_tpv_destinations.yml.j2
@@ -121,6 +121,5 @@ destinations:
         - pulsar-QLD
       require:
         - pulsar
-        - offline
 
 

--- a/host_vars/pulsar-QLD/pulsar-QLD.genome.edu.au.yml
+++ b/host_vars/pulsar-QLD/pulsar-QLD.genome.edu.au.yml
@@ -40,7 +40,7 @@ ssl_email: "help@genome.edu.au"
 #host specific pulsar settings
 
 rabbitmq_password_galaxy_au: "{{ vault_rabbitmq_password_galaxy_QLD_prod }}"
-pulsar_queue_url: "aarnet-queue.usegalaxy.org.au"
+pulsar_queue_url: "galaxy-queue.usegalaxy.org.au"
 pulsar_rabbit_username: "galaxy_QLD"
 pulsar_rabbit_vhost: "/pulsar/galaxy_QLD"
 


### PR DESCRIPTION
add pulsar-QLD to ETCA galaxy as an active destination for load testing. Note that it has already been set offline in the aarnet TPV.