### PR TITLE
Add opts to roles that mount volumes

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -31,6 +31,7 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volB/user-data-test"
     fstype: nfs
     state: mounted
+    opts: 'actimeo=2,defaults'
   - path: /mnt/custom-indices
     src: "{{ hostvars['galaxy-misc-nfs']['internal_ip'] }}:/mnt/custom-indices"
     fstype: nfs

--- a/roles/attached-volumes/tasks/set_up_volume.yml
+++ b/roles/attached-volumes/tasks/set_up_volume.yml
@@ -57,6 +57,7 @@
         path: "{{ attached_volume.path }}"
         src: "{{ attached_volume.device }}{{ attached_volume.partition|d('') }}"
         fstype: "{{ attached_volume.fstype }}"
+        opts: "{{ attached_volume.opts|d('defaults') }}"
         state: mounted    
     when: num_parts2|int > 0
   when: attached_volume.device is defined and attached_volume.partition is defined and attached_volume.fstype is defined and attached_volume.path is defined

--- a/roles/mounts/tasks/main.yml
+++ b/roles/mounts/tasks/main.yml
@@ -13,9 +13,10 @@
 
 - name: Install shared mounts into fstab
   mount:
-      path: "{{ item['path'] }}"
-      state: "{{ item['state'] }}"
-      src: "{{ item['src'] }}"
-      fstype: "{{ item['fstype'] }}"
+      path: "{{ item.path }}"
+      state: "{{ item.state }}"
+      src: "{{ item.src }}"
+      fstype: "{{ item.fstype }}"
+      opts: "{{ item.opts|d('defaults') }}"
   become: yes
   with_items: "{{ shared_mounts }}"


### PR DESCRIPTION
Add 'opts' to ansible mount tasks.

So far we've been dealing 2-VM galaxy issue by setting actimeo=2 for the user data mount on the galaxy VM. This is not the only thing we could do here - we could be using noac and there are probably other options as well. I'm still curious as to how the current deployment doesn't have issues caused by nfs cache time, but then maybe it does, and some of the nfs/io bottlenecks are due to this.