### PR TITLE
Updates for oom tools (19/10/23)

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1,15 +1,21 @@
 tools:
   ### Tools with resource updates being tested due to OOM errors ###
-  toolshed.g2.bx.psu.edu/repos/iuc/biom_convert/biom_convert/.*:
+  toolshed.g2.bx.psu.edu/repos/iuc/biom_convert/biom_convert/.*: # still waiting for evidence that this has made a difference (3/10/23)
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft_add/.*:
+  toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft_add/.*: # TODO: add to shared db and remove this entry (3/10/23)
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/iuc/dada2_dada/dada2_dada/.*:
+  toolshed.g2.bx.psu.edu/repos/iuc/dada2_dada/dada2_dada/.*: # still waiting for evidence that this has made a difference (3/10/23)
     cores: 2
     mem: 10
-  toolshed.g2.bx.psu.edu/repos/iuc/mlst/mlst/.*:
+  toolshed.g2.bx.psu.edu/repos/iuc/mlst/mlst/.*: # TODO: add to shared db and remove this entry (3/10/23)
+    mem: 8
+  toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgcmp/.*: # still waiting for evidence that this has made a difference (3/10/23)
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgcmp/.*:
+  toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/.*: # Added 3/10/23
+    mem: 12
+  toolshed.g2.bx.psu.edu/repos/peterjc/seq_select_by_id/seq_select_by_id/.*: # Added 3/10/23
+    mem: 12
+  toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina/docking/.*: # Added 3/10/23
     mem: 12
   toolshed.g2.bx.psu.edu/repos/artbio/cap3/cap3/.*:
     mem: 8
@@ -2466,18 +2472,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/rnateam/sortmerna/bg_sortmerna/.*:
     cores: 8
     mem: 30.7
-  toolshed.g2.bx.psu.edu/repos/saskia-hiltemann/krona_text/krona-text/.*:
-    cores: 7
-    mem: 26.8
-    rules:
-    - id: krona-text_small_input_rule
-      if: input_size < 0.02
-      cores: 1
-      mem: 3.8
-    - id: krona-text_medium_input_rule
-      if: 0.02 <= input_size < 2
-      cores: 5
-      mem: 19.1
   toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvetoptimiser/.*:
     cores: 4
     mem: 15.3

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -15,8 +15,6 @@ tools:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/peterjc/seq_select_by_id/seq_select_by_id/.*: # Added 3/10/23
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina/docking/.*: # Added 3/10/23
-    mem: 12
   toolshed.g2.bx.psu.edu/repos/artbio/cap3/cap3/.*:
     mem: 8
   ### ###

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2,13 +2,9 @@ tools:
   ### Tools with resource updates being tested due to OOM errors ###
   toolshed.g2.bx.psu.edu/repos/iuc/biom_convert/biom_convert/.*: # still waiting for evidence that this has made a difference (3/10/23)
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft_add/.*: # TODO: add to shared db and remove this entry (3/10/23)
-    mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/dada2_dada/dada2_dada/.*: # still waiting for evidence that this has made a difference (3/10/23)
     cores: 2
     mem: 10
-  toolshed.g2.bx.psu.edu/repos/iuc/mlst/mlst/.*: # TODO: add to shared db and remove this entry (3/10/23)
-    mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgcmp/.*: # still waiting for evidence that this has made a difference (3/10/23)
     mem: 12
   toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/.*: # Added 3/10/23

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1,17 +1,19 @@
 tools:
   ### Tools with resource updates being tested due to OOM errors ###
-  toolshed.g2.bx.psu.edu/repos/iuc/biom_convert/biom_convert/.*: # still waiting for evidence that this has made a difference (3/10/23)
+  toolshed.g2.bx.psu.edu/repos/iuc/biom_convert/biom_convert/.*: # not enough jobs to tell whether this has fixed oom issue (19/10/23)
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/iuc/dada2_dada/dada2_dada/.*: # still waiting for evidence that this has made a difference (3/10/23)
+  toolshed.g2.bx.psu.edu/repos/iuc/dada2_dada/dada2_dada/.*: # not enough jobs to tell whether this has fixed oom issue (19/10/23)
     cores: 2
     mem: 10
-  toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgcmp/.*: # still waiting for evidence that this has made a difference (3/10/23)
+  toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgcmp/.*: # not enough jobs to tell whether this has fixed oom issue (19/10/23)
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/.*: # Added 3/10/23
+  toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/.*:
     mem: 12
-  toolshed.g2.bx.psu.edu/repos/peterjc/seq_select_by_id/seq_select_by_id/.*: # Added 3/10/23
+  toolshed.g2.bx.psu.edu/repos/peterjc/seq_select_by_id/seq_select_by_id/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/artbio/cap3/cap3/.*:
+    mem: 8
+  toolshed.g2.bx.psu.edu/repos/bgruening/diffbind/diffbind/.*:
     mem: 8
   ### ###
   testtoolshed.g2.bx.psu.edu/repos/fubar/htseq_bams_to_count_matrix/htseqsams2mxlocal/.*:
@@ -2129,18 +2131,10 @@ tools:
     mem: 61.4
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_ustacks/stacks2_ustacks/.*:
     cores: 16
-    mem: 61.4
+    mem: 100
     scheduling:
       accept:
       - pulsar
-      - pulsar-quick
-    rules:
-    - id: rule_stacks2_ustacks_limit_concurrency
-      if: |
-        helpers.concurrent_job_count_for_tool(app, tool, user) >= 3  # concurrent jobs per user
-      execute: |
-        from galaxy.jobs.mapper import JobNotReadyException
-        raise JobNotReadyException()
   toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/.*:
     cores: 5
     mem: 19.1
@@ -2308,7 +2302,7 @@ tools:
       cores: 1
       mem: 3.8
     - id: unicycler_medium_input_rule
-      if: 0.05 <= input_size < 2
+      if: 0.05 <= input_size < 0.3
       cores: 8
       mem: 30.7
   toolshed.g2.bx.psu.edu/repos/iuc/vcf2maf/vcf2maf/.*:


### PR DESCRIPTION
Add entries for some more tools that have been using default allocations.  Remove entry for krona_text to use shared-db entry instead.

Update unicycler and stack2_ustacks entries. stacks2_ustacks does not need a concurrency limit anymore.