### PR TITLE
etca single galaxy VM

### DIFF
--- a/group_vars/galaxy_etca_slurm.yml
+++ b/group_vars/galaxy_etca_slurm.yml
@@ -69,11 +69,11 @@ slurm_nodes:
     RealMemory: 64000
     State: UNKNOWN
   ##& Include galaxy-handlers in slurm config for 2-VM galaxy server. Comment out when using a single VM for galaxy server
-  - name: galaxy-handlers
-    NodeAddr:  "{{ hostvars['galaxy-handlers']['internal_ip'] }}"
-    CPUs: 16
-    RealMemory: 64000
-    State: UNKNOWN
+  # - name: galaxy-handlers
+  #   NodeAddr:  "{{ hostvars['galaxy-handlers']['internal_ip'] }}"
+  #   CPUs: 16
+  #   RealMemory: 64000
+  #   State: UNKNOWN
 
 
 slurm_partitions:

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -121,26 +121,26 @@ host_galaxy_config_gravity:
     bind: "unix:{{ galaxy_mutable_config_dir }}/reports.sock"
     config_file: "{{ galaxy_config_dir }}/reports.yml"
   ##& handlers and celery are on galaxy-handlers VM with 2-VM galaxy server. Uncomment these entries when using a single VM
-  # celery:
-  #   concurrency: 2
-  #   loglevel: DEBUG
-  # handlers:
-  #   handler:
-  #     environment:
-  #       DRMAA_LIBRARY_PATH: "/usr/lib/slurm-drmaa/lib/libdrmaa.so.1"
-  #       SINGULARITY_CACHEDIR: "{{ galaxy_user_singularity_cachedir }}"
-  #       SINGULARITY_TMPDIR: "{{ galaxy_user_singularity_tmpdir }}"
-  #     processes: 5
-  #     pools:
-  #       - job-handlers
-  #       - workflow-schedulers
+  celery:
+    concurrency: 2
+    loglevel: DEBUG
+  handlers:
+    handler:
+      environment:
+        DRMAA_LIBRARY_PATH: "/usr/lib/slurm-drmaa/lib/libdrmaa.so.1"
+        SINGULARITY_CACHEDIR: "{{ galaxy_user_singularity_cachedir }}"
+        SINGULARITY_TMPDIR: "{{ galaxy_user_singularity_tmpdir }}"
+      processes: 5
+      pools:
+        - job-handlers
+        - workflow-schedulers
 
 host_galaxy_config: # renamed from __galaxy_config
   gravity: "{{ host_galaxy_config_gravity }}"
 
   galaxy:
     ##& amqp_internal_connection for 2-VM galaxy server. Comment this out when out when using a single VM
-    amqp_internal_connection: "pyamqp://galaxy_queues:{{ vault_rabbitmq_password_galaxy_prod }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:5671//galaxy/galaxy_queues?ssl=1"
+    # amqp_internal_connection: "pyamqp://galaxy_queues:{{ vault_rabbitmq_password_galaxy_prod }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:5671//galaxy/galaxy_queues?ssl=1"
     admin_users: "{{ machine_users | selectattr('email', 'defined') | selectattr('roles', 'contains', 'galaxy_admin') | map(attribute='email') | join(',') }},{{ bpa_email }}"
     brand: "E T C A"
     database_connection: "postgresql://galaxy:{{ galaxy_db_user_password }}@{{ hostvars['galaxy-db']['internal_ip'] }}:5432/galaxy"
@@ -173,18 +173,20 @@ host_galaxy_config: # renamed from __galaxy_config
     # cookie_domain: usegalaxy.org.au # TODO: switch from null to usegalaxy.org.au when etca is production site
     cookie_domain: null
 
-    celery_conf:
-      result_backend: "redis://:{{ vault_redis_requirepass }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:6379/0"
-      # result_backend: "{{ redis_connection_string }}"
-      task_routes:
-        galaxy.fetch_data: disabled
-        # galaxy.fetch_data: galaxy.external
-        galaxy.set_job_metadata: galaxy.external
+    ##& comment out celery_conf and enable_celery_tasks when using single VM
+    # celery_conf:
+    #   result_backend: "redis://:{{ vault_redis_requirepass }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:6379/0"
+    #   # result_backend: "{{ redis_connection_string }}"
+    #   task_routes:
+    #     galaxy.fetch_data: disabled
+    #     # galaxy.fetch_data: galaxy.external
+    #     galaxy.set_job_metadata: galaxy.external
 
-    # Offload long-running tasks to a Celery task queue. Activate this
-    # only if you have setup a Celery worker for Galaxy. For details, see
-    # https://docs.galaxyproject.org/en/master/admin/production.html
-    enable_celery_tasks: true
+    # # Offload long-running tasks to a Celery task queue. Activate this
+    # # only if you have setup a Celery worker for Galaxy. For details, see
+    # # https://docs.galaxyproject.org/en/master/admin/production.html
+    # enable_celery_tasks: true
+
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 


### PR DESCRIPTION
Try out selenium testing without galaxy-handlers VM for comparison. There are 4 blocks commented out or uncommented to enable this. I think that's all that is needed.

We then need to run galaxy_update_slurm_playbook and galaxy_playbook.