### PR TITLE
update variables and roles for release 23.1

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -346,6 +346,7 @@ tiaas_group: tiaas
 tiaas_version: main
 tiaas_admin_user: admin
 tiaas_admin_pass: "{{ tiaas_password }}"
+tiaas_galaxy_stylesheet: "{{ galaxy_server_dir }}/static/dist/base.css"
 
 # Interactive Tools
 docker_install_compose: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -64,7 +64,9 @@
 - name: usegalaxy_eu.flower
   version: 1.0.2
 - name: usegalaxy_eu.galaxy_subdomains
-  version: 0.0.13
+  src: https://github.com/cat-bro/ansible-galaxy-subdomains
+  version: make_a_variable_of_base_css_path
+  # version: 0.0.13
 - src: usegalaxy_eu.apptainer
   version: 0.0.1
 - src: usegalaxy_eu.rabbitmqserver


### PR DESCRIPTION
tiaas and subdomains roles refer to a base.css file that is no longer part of the codebase. The tiaas role has a way of parameterising this but it will never be fixed in the subdomains role* so we are using my fork of it for now.

*galaxyproject.galaxy role will absorb functionality of subdomains role instead.