### PR TITLE
update galaxy to 23.1 and increase db connections

### DIFF
--- a/host_vars/galaxy-db.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-db.usegalaxy.org.au.yml
@@ -17,7 +17,7 @@ postgresql_conf:
   #   CPUs num: 8
   #   Connections num: 100
   #   Data Storage: san
-  - max_connections: 200
+  - max_connections: 300
   - listen_addresses: "'*'"   # Allow remote connections
   - data_directory: "'/data/production'"
   - shared_buffers: 8GB

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -32,7 +32,7 @@ nginx_ssl_servers:
 interactive_tools_server_name: "galaxy.usegalaxy.org.au"
 
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_commit_id: release_23.0
+galaxy_commit_id: release_23.1
 
 # TODO: check list concatenation with versions of ansible > 2.12
 shared_mounts: "{{ galaxy_server_and_worker_shared_mounts + galaxy_web_server_mounts }}" # sourced from galaxy_etca.yml


### PR DESCRIPTION
Production galaxy is at release 23.1 so new galaxy needs this too. Selenium tests are leading to the current max_connections value of 200 to be exceeded. This seems to be an issue specific to the selenium test users with hundreds of concurrent logins so a bandaid solution is ok: set max_connections to 300.