### PR TITLE
TPV adjustments

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -11,6 +11,8 @@ tools:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_bdgcmp/.*:
     mem: 12
+  toolshed.g2.bx.psu.edu/repos/artbio/cap3/cap3/.*:
+    mem: 8
   ### ###
   testtoolshed.g2.bx.psu.edu/repos/fubar/htseq_bams_to_count_matrix/htseqsams2mxlocal/.*:
     cores: 3
@@ -71,8 +73,6 @@ tools:
       cores: 2
       mem: 7.6
   toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina/docking/.*:
-    cores: 1
-    mem: 3.8
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/.*:
@@ -1848,8 +1848,8 @@ tools:
     rules:
     - id: quast_small_input_rule
       if: input_size < 1
-      cores: 1
-      mem: 3.8
+      cores: 2
+      mem: 10
   toolshed.g2.bx.psu.edu/repos/iuc/raven/raven/.*:
     cores: 20
     mem: 200
@@ -2644,8 +2644,10 @@ tools:
       cores: 1
       mem: 3.8
   wig_to_bigWig:
-    cores: 5
     mem: 19.1
+    scheduling:
+      accept:
+        - training-exempt # these jobs are exempt from training rules that would reduce allocated memory
   cellranger:
     cores: 6
     mem: 20


### PR DESCRIPTION
Give some tools more memory. Give wig_to_bigWig the 'training-exempt' tag so that these jobs will not be treated as training jobs and will have enough memory to run.