### PR TITLE
remove galaxy etca from influxdb 14d retention policy

### DIFF
--- a/host_vars/stats.usegalaxy.org.au.yml
+++ b/host_vars/stats.usegalaxy.org.au.yml
@@ -113,7 +113,7 @@ retention_policy_dbs:
   - 'pulsar-mel3'
   - 'pulsar-paw'
   - 'pulsar-nci-training'
-  - 'galaxy_etca'
+  #- 'galaxy_etca' # NOTE: manually set to use "forever" retention policy
   - 'aarnet'
   - 'pawsey'
   - 'pulsar-QLD'

--- a/host_vars/stats.usegalaxy.org.au.yml
+++ b/host_vars/stats.usegalaxy.org.au.yml
@@ -113,7 +113,6 @@ retention_policy_dbs:
   - 'pulsar-mel3'
   - 'pulsar-paw'
   - 'pulsar-nci-training'
-  #- 'galaxy_etca' # NOTE: manually set to use "forever" retention policy
   - 'aarnet'
   - 'pawsey'
   - 'pulsar-QLD'


### PR DESCRIPTION
galaxy_etca influx database has manually had a "forever" retention policy applied to it, to keep monitoring of etca tests. This change prevents the usual default retention of 14 days being applied when the stats playbook is run. When this data is no longer required, this change can be reverted and the retention policy changed to the standard 14 days.