### PR TITLE
[moving day] enable postfix-mail-relay and slg.galaxy_stats roles in galaxy playbook ready for move to production

### DIFF
--- a/galaxy_playbook.yml
+++ b/galaxy_playbook.yml
@@ -48,10 +48,10 @@
     - geerlingguy.nfs
     - galaxyproject.gxadmin
     - pg-post-tasks
-    # - postfix-mail-relay # commented out until galaxy etca is production galaxy
+    - postfix-mail-relay
     # - remote-pulsar-cron # commented out until galaxy etca is production galaxy
     # - delete-tmp-jwds-cron # commented out until galaxy etca is production galaxy, also needs to be enabled
-    # - slg.galaxy_stats # commented out until galaxy etca is production galaxy
+    - slg.galaxy_stats
     - galaxy-pg-cleanup
     - galaxyproject.tiaas2
   post_tasks:


### PR DESCRIPTION
Note that postfix-mail-relay role utilises variables defined in `host_vars/galaxy.usegalaxy.org.au.yml`. These were defined in PR [#1572](https://github.com/usegalaxy-au/infrastructure/pull/1572). The variables for the slg.galaxy_stats roles, also defined in `host_vars/galaxy.usegalaxy.org.au.yml `were done in PR [#1422](https://github.com/usegalaxy-au/infrastructure/pull/1422)
