### PR TITLE
comment out miniconda role

### DIFF
--- a/galaxy_playbook.yml
+++ b/galaxy_playbook.yml
@@ -33,9 +33,9 @@
     - mounts
     - geerlingguy.pip
     - galaxyproject.galaxy
-    - role: galaxyproject.miniconda
-      become: true
-      become_user: galaxy
+    # - role: galaxyproject.miniconda # this role is needed for a fresh installation, but for subsequent playbook runs can take far too much time. TODO: fix this somehow
+    #   become: true
+    #   become_user: galaxy
     - nginx-upload-module
     - galaxyproject.nginx
     - galaxyproject.tusd


### PR DESCRIPTION
The miniconda role can take a long time and is not really needed once it has been run once. It needs refactoring to prevent it from taking so long. Leave it out of the playbook roles until.