### PR TITLE
galaxy user nfs update

### DIFF
--- a/galaxy-user-nfs_playbook.yml
+++ b/galaxy-user-nfs_playbook.yml
@@ -8,9 +8,9 @@
     - host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
     - secret_group_vars/stats_server_vault
   pre_tasks:
-    - name: Attach volumes to instance
-      include_role:
-        name: attached-volumes
+    # - name: Attach volumes to instance # handle user nfs mounting manually
+    #   include_role:
+    #     name: attached-volumes
     - name: Ensure galaxy nfs user data directories exist
       file:
         path: "{{ item }}"

--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -25,6 +25,7 @@ galaxy_db_tiaasadmin_password: "{{ vault_galaxy_db_tiaasadmin_password }}"
 galaxy_db_tiaas_password: "{{ vault_galaxy_db_tiaas_password }}"
 
 galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_handlers and workers
+  # galaxy-misc-nfs
   - path: /mnt/tools
     src: "{{ hostvars['galaxy-misc-nfs']['internal_ip'] }}:/mnt/tools"
     fstype: nfs
@@ -33,6 +34,29 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     src: "{{ hostvars['galaxy-misc-nfs']['internal_ip'] }}:/mnt/custom-indices"
     fstype: nfs
     state: mounted
+  # galaxy-job-nfs
+  - path: /mnt/tmp
+    src: "{{ hostvars['galaxy-job-nfs']['internal_ip'] }}:/mnt/tmp"
+    fstype: nfs
+    state: mounted
+    opts: 'actimeo=0,defaults'
+  # galaxy-user-nfs
+  - path: /mnt/user-data-volA # 150T volume
+    src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volA"
+    fstype: nfs
+    opts: 'actimeo=0,defaults'
+    state: mounted
+  - path: /mnt/user-data-volB # 50T volume
+    src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volB"
+    fstype: nfs
+    opts: 'actimeo=0,defaults'
+    state: mounted
+  - path: /mnt/user-data-volC # 42T volume
+    src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volC"
+    fstype: nfs
+    opts: 'actimeo=0,defaults'
+    state: mounted
+  # pawsey data volumes
   - path: /mnt/user-data
     src: "pawsey-user-nfs.usegalaxy.org.au:/mnt/user-data"
     fstype: nfs
@@ -49,26 +73,7 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     src: "pawsey-user-nfs.usegalaxy.org.au:/user-data-4"
     fstype: nfs
     state: mounted
-#   - path: /mnt/user-data-5
-#     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/user-data5"
-#     fstype: nfs
-#     opts: 'actimeo=0,defaults'
-#     state: mounted
-#   - path: /mnt/user-data-6
-#     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/user-data6"
-#     fstype: nfs
-#     opts: 'actimeo=0,defaults'
-#     state: mounted
-#   - path: /mnt/user-data-7
-#     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/user-data7"
-#     fstype: nfs
-#     opts: 'actimeo=0,defaults'
-#     state: mounted
-  - path: /mnt/tmp
-    src: "{{ hostvars['galaxy-job-nfs']['internal_ip'] }}:/mnt/tmp"
-    fstype: nfs
-    state: mounted
-    opts: 'actimeo=0,defaults'
+  # QLD data volumes
   - path: /mnt/files
     src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
     fstype: nfs

--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -7,7 +7,7 @@ nfs_user_data_7_dir: "{{ volA_path }}/user-data-7"
 nfs_data08_dir: "{{ volA_path }}/data08"
 
 nfs_user_data_6_dir: "{{ volB_path }}/user-data-6"
-nfs_user_data09_dir: "{{ volB_path }}/data09"
+nfs_data09_dir: "{{ volB_path }}/data09"
 nfs_user_data10_dir: "{{ volC_path }}/data10"
 
 attached_volumes:
@@ -29,7 +29,7 @@ nfs_dirs:
   - "{{ nfs_user_data_7_dir }}"
   - "{{ nfs_data08_dir }}"
   - "{{ nfs_user_data_6_dir }}"
-  - "{{ nfs_user_data09_dir }}"
+  - "{{ nfs_data09_dir }}"
   - "{{ nfs_user_data10_dir }}"
 
 nfs_exports:

--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -1,28 +1,38 @@
-nfs_user_data_test_dir: /mnt/volB/user-data-test
+volA_path: /mnt/volA
+volB_path: /mnt/volB
+volC_path: /mnt/volC
+
+nfs_user_data_5_dir: "{{ volA_path }}/user-data-5"
+nfs_user_data_7_dir: "{{ volA_path }}/user-data-7"
+nfs_data08_dir: "{{ volA_path }}/data08"
+
+nfs_user_data_6_dir: "{{ volB_path }}/user-data-6"
+nfs_user_data09_dir: "{{ volB_path }}/data09"
+nfs_user_data10_dir: "{{ volC_path }}/data10"
 
 attached_volumes:
   - device: /dev/vdb
     partition: 1
-    path: /mnt/volB
+    path: "{{ volA_path }}" # contains user-data-5, user-data-7, data08
+    fstype: ext4
+  - device: /dev/vdc
+    partition: 1
+    path: "{{ volB_path }}" # contains user-data-6, data09
+    fstype: ext4
+  - device: /dev/vdd
+    partition: 1
+    path: "{{ volC_path }}" # contains data10
     fstype: ext4
 
 nfs_dirs:
-  - "{{ nfs_user_data_test_dir }}"
-
-# nfs_user_data_dir: /mnt/user-data
-# nfs_user_data_2_dir: /mnt/user-data2
-# nfs_user_data_3_dir: /mnt/user-data3
-# nfs_user_data_4_dir: /mnt/user-data4
-# nfs_user_data_5_dir: /mnt/user-data5
-# nfs_user_data_6_dir: /user-data6
-# nfs_user_data_7_dir: /mnt/user-data7
+  - "{{ nfs_user_data_5_dir }}"
+  - "{{ nfs_user_data_7_dir }}"
+  - "{{ nfs_data08_dir }}"
+  - "{{ nfs_user_data_6_dir }}"
+  - "{{ nfs_user_data09_dir }}"
+  - "{{ nfs_user_data10_dir }}"
 
 nfs_exports:
-  - "{{ nfs_user_data_test_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_2_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_3_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_4_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_5_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_6_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
-#   - "{{ nfs_user_data_7_dir }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ volA_path }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ volB_path }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"
+  - "{{ volC_path }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"


### PR DESCRIPTION
Do not attach volumes in playbook because this once went wrong years ago, even though the role has now been fixed.

Export the 3 volumes as /mnt/volA, /mnt/volB, /mnt/volC to be attached to galaxy, handlers and workers as /mnt/user-data-volA etc so we don't end up with arbitrarily many mounted subfolders.
