### PR TITLE
move docker-data to attached volume on galaxy-handlers

### DIFF
--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -79,3 +79,7 @@ extra_keys:
   - id: internal_hop_key
     type: public
     from: "{{ hostvars['galaxy-backup']['internal_ip'] }},{{ hostvars['galaxy']['internal_ip'] }},{{ hostvars['galaxy-queue']['internal_ip'] }}"
+
+# override docker-data location
+docker_daemon_options:
+  data-root: /pvol/docker-data


### PR DESCRIPTION
docker-data has been going to /mnt/docker-data which is just part of the root disk on the galaxy-handlers VM. Move it to /pvol which is larger.