### PR TITLE
offline pulsar-QLD for volume migration

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -236,6 +236,7 @@ destinations:
       require:
         - pulsar
         - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
+        - offline # volume migration
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner


### PR DESCRIPTION
The 20T volume attached to pulsar-QLD-job-nfs needs to be migrated to a new volume. In the meantime, stop jobs going to pulsar-Qld.