### PR TITLE
Don't let jenkins trigger a job handler restart with TPV changes

### DIFF
--- a/galaxy_update_configs_playbook.yml
+++ b/galaxy_update_configs_playbook.yml
@@ -46,7 +46,7 @@
         mode: 0644
       with_items: "{{ galaxy_dynamic_job_rules }}"
       when: not item.endswith(".j2")
-      notify: restart handlers
+      # notify: restart handlers  # 8/11/23: Temporarily turn off notification of restart handlers while galaxy process restarts are slow
     - name: Install dynamic job rules (template)
       template:
         src: "{{ galaxy_dynamic_job_rules_src_dir }}/{{ item }}"
@@ -56,4 +56,4 @@
         regex: '\.j2$'
       with_items: "{{ galaxy_dynamic_job_rules }}"
       when: item.endswith(".j2")
-      notify: restart handlers
+      # notify: restart handlers  # 8/11/23: Temporarily turn off notification of restart handlers while galaxy process restarts are slow


### PR DESCRIPTION
This is for safety while restart speeds are unresolved. This playbook is run when tpv changes are merged.