### PR TITLE
increase timeout for gunicorn restarts from 10 to 30 minutes

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -100,8 +100,8 @@ host_galaxy_config_gravity:
       workers: 2
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
-      timeout: 600
-      restart_timeout: 600
+      timeout: 1800
+      restart_timeout: 1800
       preload: true
       environment:
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
@@ -112,8 +112,8 @@ host_galaxy_config_gravity:
       workers: 2
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
-      timeout: 600
-      restart_timeout: 600
+      timeout: 1800
+      restart_timeout: 1800
       preload: true
       environment:
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"


### PR DESCRIPTION
Restarts of gunicorn processes regularly take more than 10 minutes, causing the "galaxyctl graceful" rolling restart to return a bad value which stop the playbook.