### PR TITLE
send kraken to high memory pulsars

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -571,8 +571,11 @@ tools:
     cores: 5
     mem: 19.1
   toolshed.g2.bx.psu.edu/repos/devteam/kraken/kraken/.*:
-    cores: 5
-    mem: 19.1
+    cores: 8
+    mem: 100
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/devteam/kraken2tax/Kraken2Tax/.*:
     cores: 1
     mem: 3.8


### PR DESCRIPTION
A number of kraken jobs are failing due to running out of memory. Slurm cluster is very busy so it makes sense to give kraken a high memory allocation.