### PR TITLE
more scanpy scaled rules

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -731,7 +731,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/.*:
     mem: 2 + input_size * 7
     rules:
-    - id: anndata_ops
+    - id: anndata_ops_fail_rule
       if: input_size > 30
       fail: Too much data. Total input data must be less than 30GB.
     params:
@@ -1023,6 +1023,17 @@ tools:
     scheduling:
       accept:
       - pulsar
+  toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/.*:
+    mem: 2 + input_size * 7
+    params:
+      singularity_enabled: true
+    scheduling:
+      accept:
+        - pulsar  
+    rules:
+    - id: anndata_inspect_fail_rule
+      if: input_size > 30
+      fail: Too much data. Total input data must be less than 30GB.
   toolshed.g2.bx.psu.edu/repos/iuc/arriba/arriba/.*:
     params:
       singularity_enabled: true
@@ -2122,10 +2133,16 @@ tools:
       cores: 1
       mem: 3.8
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_plot/scanpy_plot/.*:
-    cores: 1
-    mem: 3.8
+    mem: 4 + input_size * 8
     params:
       singularity_enabled: true
+    scheduling:
+      accept:
+        - pulsar
+    rules:
+    - id: scanpy_plot_fail_rule
+      if: input_size > 30
+      fail: Too much data. Total input data must be less than 30GB.
   toolshed.g2.bx.psu.edu/repos/iuc/scanpy_remove_confounders/scanpy_remove_confounders/.*:
     cores: 9
     mem: 34.5


### PR DESCRIPTION
Add memory as a linear function of input size for iuc tools anndata_inspect and scanpy_plot