### PR TITLE
let phm2 test user run fgenesh on phm2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -157,7 +157,6 @@ destinations:
         - pulsar-high-mem2
       require:
         - pulsar
-        - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
         - offline
   pulsar-qld-high-mem0:
     inherits: _pulsar_destination

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
@@ -66,18 +66,16 @@ users:
           scheduling:
             accept:
               - pulsar
-              - high-mem
               - offline
             require:
               - pulsar-high-mem1
     phm2@genome.edu.au:
       inherits: test_user
       rules:
-        - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
+        - if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed') or any([tool.id == x for x in ['fgenesh']])
           scheduling:
             accept:
               - pulsar
-              - high-mem
               - offline
             require:
               - pulsar-high-mem2
@@ -99,7 +97,6 @@ users:
           scheduling:
             accept:
               - pulsar
-              - high-mem
               - offline
             require:
               - pulsar-qld-high-mem0
@@ -110,7 +107,6 @@ users:
           scheduling:
             accept:
               - pulsar
-              - high-mem
               - offline
             require:
               - pulsar-qld-high-mem1
@@ -121,7 +117,6 @@ users:
           scheduling:
             accept:
               - pulsar
-              - high-mem
               - offline
             require:
               - pulsar-qld-high-mem2


### PR DESCRIPTION
the pulsar test users are set up to run only toolshed tools on the pulsars and all other jobs go to local slurm. phm2 test user needs a workaround so that fgenesh it runs go to phm2.