### PR TITLE
pulsar sentry dsn default to empty string + reinstate sentry_dsn on galaxy

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -108,7 +108,7 @@ pulsar_yaml_config:
   amqp_publish_retry_interval_start: 10
   amqp_publish_retry_interval_step: 10
   amqp_publish_retry_interval_max: 60
-  sentry_dsn: "{{ vault_sentry_url_pulsar_production if ansible_hostname in groups['production_pulsars'] else omit }}"
+  sentry_dsn: "{{ vault_sentry_url_pulsar_production if ansible_hostname in groups['production_pulsars'] else None }}"
 
 pulsar_conda_prefix: "{{ pulsar_dependencies_dir }}/_conda"
 miniconda_prefix: "{{ pulsar_conda_prefix }}"

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -191,7 +191,7 @@ host_galaxy_config: # renamed from __galaxy_config
     user_activation_on: true
     activation_email: <activation-noreply@usegalaxy.org.au>
 
-    #sentry_dsn: "{{ vault_sentry_url_galaxy_production }}"  # commented out, waiting for change in 23.1 to reduce severity of startup logs
+    sentry_dsn: "{{ vault_sentry_url_galaxy_production }}"
 
     celery_conf:
       result_backend: "redis://:{{ vault_redis_requirepass }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:6379/0"


### PR DESCRIPTION
If a pulsar is not a production pulsar it can have `sentry_dsn: ''` which is OK - tested on pulsar-nci-test.