### PR TITLE
external volume refactor part 1

### DIFF
--- a/galaxy-handlers_playbook.yml
+++ b/galaxy-handlers_playbook.yml
@@ -32,7 +32,7 @@
         owner: root
         group: galaxy
         mode: 0775
-    - name: create dir for galaxy's singularity cache # TODO: Put this on volume
+    - name: create dir for galaxy's singularity cache
       file:
         state: directory
         path: "{{ item }}"
@@ -42,6 +42,13 @@
       with_items:
         - "{{ galaxy_user_singularity_cachedir }}"
         - "{{ galaxy_user_singularity_tmpdir }}"
+    - name: Create containing folders for external NFS file mounts
+      file:
+        state: directory
+        path: "{{ item }}"
+      with_items:
+        - "{{ qld_file_mounts_path }}"
+        - "{{ pawsey_file_mounts_path }}"
   roles:
         - mounts
         - geerlingguy.pip

--- a/galaxy-workers_playbook.yml
+++ b/galaxy-workers_playbook.yml
@@ -12,6 +12,13 @@
       - name: Attach volume to instance
         include_role:
           name: attached-volumes
+      - name: Create containing folders for external NFS file mounts
+        file:
+          state: directory
+          path: "{{ item }}"
+        with_items:
+          - "{{ qld_file_mounts_path }}"
+          - "{{ pawsey_file_mounts_path }}"
   roles:
       - common
       - insspb.hostname
@@ -21,9 +28,7 @@
       - galaxyproject.slurm
       - galaxyproject.cvmfs
       - dj-wasabi.telegraf
-    #   - gantsign.golang
-    #   - cyverse-ansible.singularity
-      - usegalaxy_eu.apptainer # see how this works as replacement for golang+cyverse/singularity
+      - usegalaxy_eu.apptainer
       - geerlingguy.docker
       - acl-on-startup
   post_tasks:

--- a/galaxy_playbook.yml
+++ b/galaxy_playbook.yml
@@ -28,6 +28,13 @@
         owner: root
         group: galaxy
         mode: 0775
+    - name: Create containing folders for external NFS file mounts
+      file:
+        state: directory
+        path: "{{ item }}"
+      with_items:
+        - "{{ qld_file_mounts_path }}"
+        - "{{ pawsey_file_mounts_path }}"
   roles:
     - common
     - mounts

--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -85,13 +85,24 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     fstype: nfs
     opts: 'noatime,defaults'
     state: "{{ 'mounted' if pawsey_file_mounts_available else 'absent_from_fstab' }}"
-  # QLD data volumes
-  - path: /mnt/files  # TODO: Switch off qld_file_mounts_available when not being used and change to "{{ qld_file_mounts_path }}/files"
+  # QLD data volumes legacy: remove these when current slurm jobs are no longer running
+  - path: /mnt/files
     src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
     fstype: nfs
     opts: 'noatime,defaults'
     state: "{{ 'mounted' if qld_file_mounts_available else 'absent_from_fstab' }}"
-  - path: /mnt/files2  # TODO: Switch off qld_file_mounts_available when not being used and change to "{{ qld_file_mounts_path }}/files2"
+  - path: /mnt/files2
+    src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
+    fstype: nfs
+    opts: 'noatime,defaults'
+    state: "{{ 'mounted' if qld_file_mounts_available else 'absent_from_fstab' }}"
+  # QLD data volumes (doubled up at first for the sake of singularity slurm jobs that are still running)
+  - path: "{{ qld_file_mounts_path }}/files"
+    src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
+    fstype: nfs
+    opts: 'noatime,defaults'
+    state: "{{ 'mounted' if qld_file_mounts_available else 'absent_from_fstab' }}"
+  - path: "{{ qld_file_mounts_path }}/files2"
     src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
     fstype: nfs
     opts: 'noatime,defaults'

--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -24,6 +24,13 @@ galaxy_db_reader_password: "{{ vault_galaxy_db_reader_password }}"
 galaxy_db_tiaasadmin_password: "{{ vault_galaxy_db_tiaasadmin_password }}"
 galaxy_db_tiaas_password: "{{ vault_galaxy_db_tiaas_password }}"
 
+# qld_file_mounts_available: set to true if /mnt/files, /mnt/files2 should be in the object store
+qld_file_mounts_available: True # assume true unless set to false
+pawsey_file_mounts_available: False # assume true unless set to false
+
+qld_file_mounts_path: /mnt/user-data-qld
+pawsey_file_mounts_path: /mnt/user-data-pawsey
+
 galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_handlers and workers
   # galaxy-misc-nfs
   - path: /mnt/tools
@@ -58,37 +65,37 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     opts: 'noatime,actimeo=0,defaults'
     state: mounted
   # pawsey data volumes
-  - path: /mnt/user-data
+  - path: /mnt/user-data  # TODO: Change to "{{ pawsey_file_mounts_path }}/user-data"
     src: "pawsey-user-nfs.usegalaxy.org.au:/mnt/user-data"
     fstype: nfs
     opts: 'noatime,defaults'
-    state: mounted
-  - path: /mnt/user-data-2
+    state: "{{ 'mounted' if pawsey_file_mounts_available else 'absent_from_fstab' }}"
+  - path: /mnt/user-data-2  # TODO: Change to "{{ pawsey_file_mounts_path }}/user-data-2"
     src: "pawsey-user-nfs.usegalaxy.org.au:/user-data-2"
     fstype: nfs
     opts: 'noatime,defaults'
-    state: mounted
-  - path: /mnt/user-data-3
+    state: "{{ 'mounted' if pawsey_file_mounts_available else 'absent_from_fstab' }}"
+  - path: /mnt/user-data-3  # TODO: Change to "{{ pawsey_file_mounts_path }}/user-data-3"
     src: "pawsey-user-nfs.usegalaxy.org.au:/user-data-3"
     fstype: nfs
     opts: 'noatime,defaults'
-    state: mounted
-  - path: /mnt/user-data-4
+    state: "{{ 'mounted' if pawsey_file_mounts_available else 'absent_from_fstab' }}"
+  - path: /mnt/user-data-4  # TODO: Change to "{{ pawsey_file_mounts_path }}/user-data-4"
     src: "pawsey-user-nfs.usegalaxy.org.au:/user-data-4"
     fstype: nfs
     opts: 'noatime,defaults'
-    state: mounted
+    state: "{{ 'mounted' if pawsey_file_mounts_available else 'absent_from_fstab' }}"
   # QLD data volumes
-  - path: /mnt/files
+  - path: /mnt/files  # TODO: Switch off qld_file_mounts_available when not being used and change to "{{ qld_file_mounts_path }}/files"
     src: "galaxy-aust-exports.genome.edu.au:/Q0028_files"
     fstype: nfs
     opts: 'noatime,defaults'
-    state: mounted
-  - path: /mnt/files2
+    state: "{{ 'mounted' if qld_file_mounts_available else 'absent_from_fstab' }}"
+  - path: /mnt/files2  # TODO: Switch off qld_file_mounts_available when not being used and change to "{{ qld_file_mounts_path }}/files2"
     src: "galaxy-aust-exports.genome.edu.au:/mnt/files2"
     fstype: nfs
     opts: 'noatime,defaults'
-    state: mounted
+    state: "{{ 'mounted' if qld_file_mounts_available else 'absent_from_fstab' }}"
 
 galaxy_worker_mounts:
   - path: /mnt/galaxy

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -2,10 +2,6 @@
 
 galaxy_config_file: /opt/galaxy/galaxy.yml
 
-# legacy_file_mounts_available: set to true if /mnt/files, /mnt/files2 should be in the object store
-legacy_file_mounts_available: True # assume true unless set to false
-pawsey_file_mounts_available: False # assume true unless set to false
-
 # variables for attaching mounted volume to application server
 attached_volumes: # TODO: check this
   - device: /dev/vdb
@@ -546,8 +542,11 @@ slurm_singularity_volumes_list_restricted:
   - /mnt/custom-indices:ro
   - /cvmfs/data.galaxyproject.org:ro
   - /tmp:rw
+  # - "{{ qld_file_mounts_path }}:ro"  # TODO: Add these unconditionally, remove conditions for including qld/pawsey paths in singularity_volumes
+  # - "{{ pawsey_file_mounts_path }}:ro"  # TODO: AND fix object store paths
+  # this dict should be called 'slurm_singularity_volumes_list' and the following 6 lines removed altogether
 
-legacy_singularity_volumes_list: "{{ ['/mnt/files:ro', '/mnt/files2:ro'] if legacy_file_mounts_available|d(True) else [] }}"
+legacy_singularity_volumes_list: "{{ ['/mnt/files:ro', '/mnt/files2:ro'] if qld_file_mounts_available|d(True) else [] }}"
 
 pawsey_singularity_volumes_list: "{{ ['/mnt/user-data:ro', '/mnt/user-data-2:ro', '/mnt/user-data-3:ro', '/mnt/user-data-4:ro'] if pawsey_file_mounts_available|d(True) else [] }}"
 

--- a/templates/galaxy/config/galaxy_object_store_conf.xml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.xml.j2
@@ -33,7 +33,7 @@
             <files_dir path="/mnt/user-data-3" />
         </backend>
 {% endif %}
-{% if legacy_file_mounts_available|d(True) %}
+{% if qld_file_mounts_available|d(True) %}
         <backend id="qldNFS1" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/files" />
         </backend>


### PR DESCRIPTION
The state of a mount point for an unavailable mount should be 'absent_from_fstab', controlled by the booleans `qld_file_mounts_available` or `pawsey_file_mounts_available`. These mount points need to move for better job safety (see issue #1660 ), so this PR is also creating empty folders for the mount points.