### PR TITLE
update Makefile and role scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,14 @@ KEY_FILE?=~/.ssh/galaxy  # set env var KEY_FILE to override this (or symlink you
 run:
 	ansible-playbook -i hosts --key-file $(KEY_FILE) $(PLAYBOOK)_playbook.yml
 
-run-dev:
-	ansible-playbook -i hosts --key-file $(KEY_FILE) dev_playbook.yml
-
-run-staging:
-	ansible-playbook -i hosts --key-file $(KEY_FILE) staging_playbook.yml
-
-run-prod:
-	ansible-playbook -i hosts --key-file $(KEY_FILE) aarnet_playbook.yml
-
 install-roles:
 	ansible-galaxy install -p roles -r requirements.yml
+
+install-requirements:
+	ansible-galaxy install -r requirements.yml
+
+force-install-requirements:
+	ansible-galaxy install -r requirements.yml -f
 
 update-roles:
 	python scripts/update_roles.py

--- a/scripts/ansible-find-upgrades.py
+++ b/scripts/ansible-find-upgrades.py
@@ -8,7 +8,7 @@ import subprocess
 
 
 with open('requirements.yml', 'r') as handle:
-    desired = yaml.safe_load(handle)
+    desired = yaml.safe_load(handle).get('roles')
 
 for role in desired:
     if '://' in role.get('src', role.get('name')):

--- a/scripts/update_roles.py
+++ b/scripts/update_roles.py
@@ -12,7 +12,9 @@ Checks elements of requirements.yml against directories in 'roles' and makes a l
 of the roles with updated requirements.
 
 Calls ansible-galaxy install -p roles -r requirements_updated.yml --force
-where requirements_updated.yml contains only the roles that need to be force-installed 
+where requirements_updated.yml contains only the roles that need to be force-installed
+
+Note that this does not update collections, only the roles
 """
 
 roles_to_update = []
@@ -25,9 +27,9 @@ if not roles_dir in os.listdir(here):
 output_file = 'requirements_updated.yml'
 
 with open('requirements.yml') as handle:
-    requirements = yaml.safe_load(handle)
+    role_requirements = yaml.safe_load(handle).get('roles')
 
-for r in requirements:
+for r in role_requirements:
     try:
         name = r.get('name', r.get('src'))
         if not name:


### PR DESCRIPTION
Adding collections to requirements.yml had broken some processes since the file is now a yaml dict instead of a list.

Add `install-requirements` and `force-install-requirements` and remove `run-dev`, `run-staging` and `run-prod` since these are covered in the extremely useful catchall `run`.