### PR TITLE
braker3 change container and remove test label

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1002,7 +1002,7 @@ tools:
     cores: 6
     mem: 4
     params:
-      singularity_container_id_override: docker://teambraker/braker3:v.1.0.4
+      singularity_container_id_override: docker://quay.io/bgruening/braker3:v.1.0.4
       singularity_enabled: true
     scheduling:
       require:

--- a/jenkins/update_labels/tool_labels.yml
+++ b/jenkins/update_labels/tool_labels.yml
@@ -6,8 +6,6 @@ deprecated:
 - toolshed.g2.bx.psu.edu/repos/devteam/cuffnorm/cuffnorm/*
 - toolshed.g2.bx.psu.edu/repos/devteam/cuffmerge/cuffmerge/*
 - toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/*
-test:
-- toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/*
 training-only:
 - toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvet/*
 - toolshed.g2.bx.psu.edu/repos/devteam/velvet/velvetg/*


### PR DESCRIPTION
Galaxy EU are currently using this container, as per https://github.com/usegalaxy-eu/infrastructure-playbook/blob/949da8e677b491508a6622f370e671de4e1733a9/files/galaxy/tpv/tools.yml#L1043

@cat-bro the toolshed has braker3 3.0.6_galaxy2, which i haven't tested on GA. Will it autoupdate once the test label is removed?