### PR TITLE
fix path for proteomics.yml on dev

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -100,7 +100,7 @@ host_galaxy_config_files:
     dest: "{{ galaxy_config_dir }}/mail/activation-email.txt"
   - src: "{{ galaxy_config_file_src_dir }}/config/local_tool_data_table_conf.xml"
     dest: "{{ galaxy_config_dir }}/local_tool_data_table_conf.xml"
-  - src: "{{ galaxy_config_file_src_dir }}/tool_panel_filters/proteomics.yml"
+  - src: "{{ galaxy_config_file_src_dir }}/config/tool_panel_filters/proteomics.yml"
     dest: "{{ galaxy_toolbox_filters_dir }}/proteomics.yml"
 
 galaxy_config_file: /opt/galaxy/galaxy.yml


### PR DESCRIPTION
Fix path for file to copy for proteomics tool panel filtering

@neoformit you were saying this change did not work as expected the other day - maybe the playbook was not rebased.