### PR TITLE
staging distributed object store

### DIFF
--- a/templates/galaxy/config/staging_object_store_conf.xml.j2
+++ b/templates/galaxy/config/staging_object_store_conf.xml.j2
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<object_store type="hierarchical">
-    <backends>
-        <backend id="staging_objects_1" type="disk" order="0">
+<object_store type="distributed" id="primary" order="0">
+    <backends search_for_missing="false">
+        <backend id="staging_objects_1" type="disk" weight="0" store_by="id">
             <files_dir path="/mnt/galaxy/data-2" />
         </backend>
-        <backend id="staging_objects_2" type="disk" order="1">
+        <backend id="staging_objects_2" type="disk"  weight="1" store_by="id">
             <files_dir path="/mnt/galaxy/data" />
         </backend>
     </backends>


### PR DESCRIPTION
Switch staging object store from hierarchical to distributed to assist with debugging an error with some tool outputs.