### PR TITLE
More proteomics lab configuration

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -55,7 +55,7 @@
     - role: galaxyproject.miniconda
       become: true
       become_user: galaxy
-    #- usegalaxy_eu.galaxy_subdomains # broken in galaxy release_23.1 - missing static/style/base.css
+    - usegalaxy_eu.galaxy_subdomains
     - webhooks
     - nginx-upload-module
     - galaxyproject.nginx

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -394,7 +394,6 @@ galaxy_subsites:
     brand: Proteomics lab
     iframe: "https://site.usegalaxy.org.au/landing/proteomics"
     wallpaper: false
-    tool_sections: []
     custom_css: |
       #masthead .navbar-nav>li.active {
         background: #402668 !important;

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -26,6 +26,7 @@ certbot_domains:
   - "{{ hostname }}"
   - "*.interactivetoolentrypoint.interactivetool.{{ hostname }}"
   - "genome.{{ hostname }}"
+  - "proteomics.{{ hostname }}"
 certbot_dns_provider: cloudflare
 certbot_dns_credentials:
   api_token: "{{ vault_dns_cloudflare_gvl_api_token }}"


### PR DESCRIPTION
- Re-enable subdomains role in dev playbook
- Add `proteomics.dev.gvl.org.au` to `certbot_domains`
- Remove redundant `tool_sections` declaration in proteomics lab subdomain conf