### PR TITLE
Update ansible role versions for galaxyproject.galaxy and galaxyproject.pulsar

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ collections:
 
 roles:
 - name: galaxyproject.galaxy
-  version: 0.10.15
+  version: 0.10.19
 - name: galaxyproject.nginx
   version: 0.7.1
 - name: galaxyproject.postgresql
@@ -31,7 +31,7 @@ roles:
 - src: galaxyproject.repos
   version: 0.0.3
 - src: galaxyproject.pulsar
-  version: 1.0.8
+  version: 1.0.11
 - src: dj-wasabi.telegraf
   version: 0.14.0
 - src: galaxyproject.gxadmin


### PR DESCRIPTION
galaxyproject.galaxy role has a [change](https://github.com/galaxyproject/ansible-galaxy/compare/0.10.15...0.10.19) which is the ability to use the role for subdomains, deprecating the usegalaxy_eu.subdomains role.  I'm assuming that this is backwards compatible and we can keep using the subdomains role for now.

galaxyproject.pulsar [changes](https://github.com/galaxyproject/ansible-pulsar/compare/1.0.8...1.0.11) not much: config files are no longer read-only by default and restart handlers should work now.