### PR TITLE
move SACCT_FORMAT for root user to common role

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -118,3 +118,8 @@
     enabled: false
   ignore_errors: True
 
+- name: set SACCT_FORMAT for root user
+  lineinfile:
+    path: /etc/environment
+    create: true
+    line: export SACCT_FORMAT="jobid%8,partition%9,jobname%30,alloccpus,elapsed,totalcpu,END,state,MaxRSS%12,ReqMem,NodeList%24"

--- a/roles/slurm-post-tasks/tasks/main.yml
+++ b/roles/slurm-post-tasks/tasks/main.yml
@@ -7,18 +7,3 @@
     validate: /usr/sbin/visudo -cf %s
   with_items:
     - /usr/bin/sacct
-- name: Remove some sudo rules for devs
-  lineinfile:
-    path: /etc/sudoers.d/devs
-    create: true
-    line: "%devs ALL=(ALL) NOPASSWD: {{ item }}"
-    validate: /usr/sbin/visudo -cf %s
-    state: absent
-  with_items:
-    - /usr/bin/scontrol
-    - /usr/bin/scancel
-- name: set SACCT_FORMAT for root user
-  lineinfile:
-    path: /etc/environment
-    create: true
-    line: export SACCT_FORMAT="jobid%8,partition%9,jobname%30,alloccpus,elapsed,totalcpu,END,state,MaxRSS%12,ReqMem,NodeList%24"


### PR DESCRIPTION
`sudo sacct` is available to all machine users, not just sudo users, on any VM with slurm installed (galaxy VM, worker nodes, all pulsar machines etc) but the environment variable setting the output to a useful format format has only been set on slurmcontroller VMs and has been missing from workers and galaxy web/handlers servers.