### PR TITLE
pulsar-qld offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -233,6 +233,7 @@ destinations:
       require:
         - pulsar
         - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
+        - offline
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner


### PR DESCRIPTION
Taking pulsar-QLD offline so that its underlying host can have updates applied.
