### PR TITLE
send blast to pulsar-mel3 and offline pulsar-qld-blast

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -129,7 +129,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-mel3
-        # - pulsar-blast
+        - pulsar-blast
       require:
         - pulsar
   pulsar-high-mem1:
@@ -218,6 +218,7 @@ destinations:
       require:
         - pulsar
         - pulsar-blast
+        - offline
   pulsar-QLD:
     inherits: _pulsar_destination
     runner: pulsar-QLD_runner


### PR DESCRIPTION
Taking pulsar-qld-blast offline so that its underlying host can have updates applied.
Redirect blast jobs to pulsar-mel3