### PR TITLE
remove recursive chown from pulsar-QLD-job-nfs playbook

### DIFF
--- a/pulsar-QLD-job-nfs_playbook.yml
+++ b/pulsar-QLD-job-nfs_playbook.yml
@@ -28,7 +28,6 @@
           path: "{{ galaxy_job_dir }}"
           owner: galaxy
           group: galaxy
-          recurse: yes
       - name: Reload exportfs
         command: exportfs -ra
         become: yes


### PR DESCRIPTION
the job working directories should be owned by ubuntu user. remove the recursive chown to pulsar which breaks jobs trying to be run on pulsar-QLD.
