### PR TITLE
make kraken require pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -604,7 +604,7 @@ tools:
     cores: 8
     mem: 100
     scheduling:
-      accept:
+      require:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/devteam/kraken2tax/Kraken2Tax/.*:
     cores: 1


### PR DESCRIPTION
This is to stop kraken jobs running on the larger slurm workers