### PR TITLE
helixer tries to write to home

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -275,7 +275,7 @@ destinations:
     rules:
       - id: pulsar_destination_docker_rule
         params:
-            docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
+            docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/home:rw,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3066,7 +3066,8 @@ tools:
     mem: 69
     params:
       docker_enabled: true
-      docker_run_extra_arguments: --gpus all --env HOME=$working_directory
+      docker_run_extra_arguments: --gpus all
+      docker_volumes: $job_directory/home:rw
     scheduling:
       require:
       - pulsar

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3066,7 +3066,7 @@ tools:
     mem: 69
     params:
       docker_enabled: true
-      docker_run_extra_arguments: --gpus all
+      docker_run_extra_arguments: --gpus all --env HOME=$working_directory
     scheduling:
       require:
       - pulsar

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3067,7 +3067,6 @@ tools:
     params:
       docker_enabled: true
       docker_run_extra_arguments: --gpus all
-      docker_volumes: $job_directory/home:rw
     scheduling:
       require:
       - pulsar

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3071,4 +3071,4 @@ tools:
     scheduling:
       require:
       - pulsar
-      - pulsar-azure-gpu
+      - pulsar-azure-1-gpu


### PR DESCRIPTION
It looks like helixer tries to write to $HOME, can I set it like this? Or should I add a `docker_volumes` ?

```
Traceback (most recent call last):
  File "/usr/local/bin/fetch_helixer_models.py", line 32, in <module>
    main(args.lineage, best_only=not args.all)
  File "/usr/local/bin/fetch_helixer_models.py", line 21, in main
    fetch_and_organize_models(models)
  File "/usr/local/lib/python3.8/dist-packages/helixer/core/data.py", line 22, in fetch_and_organize_models
    os.makedirs(model_path)
  File "/usr/lib/python3.8/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.8/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.8/os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
OSError: [Errno 30] Read-only file system: '/mnt/pulsar/files/staging/7989114/home/.local'
```
