### PR TITLE
manage galaxy backups with markers

### DIFF
--- a/roles/slg.db-backup/defaults/main.yml
+++ b/roles/slg.db-backup/defaults/main.yml
@@ -25,6 +25,7 @@ weekly_backup_day: 6  #Weekly backups will run on this day of the week
 retention_day: 6       #Keep daily backups for this many days (6 days)
 retention_week: 21     #Keep weekly backups for this many days (21 days = 3 weeks)
 retention_month: 92    #Keep monthly backups for this many days (92 days ~ 3 months)
+retention_disk: 7      # keep backups on local disk for this many days
 
 connection_string: "postgres://{{ db_user }}:{{ db_password }}@{{ db_server }}:{{ db_port }}/{{ psql_db }}"
 

--- a/roles/slg.db-backup/templates/galaxy-backup-db.sh.j2
+++ b/roles/slg.db-backup/templates/galaxy-backup-db.sh.j2
@@ -141,7 +141,14 @@ set -o nounset
 set +e
 
 echo '  Uploading to swift: '$backup_filename >> $LOGFILE
-swift --quiet --retries 5 --timeout 120 upload --segment-size 2000000000 --segment-threads 1 ${SWIFT_BACKUP_CONTAINER} ${backup_filename} || echo '  swift upload failed for: '$backup_filename >> $LOGFILE
+swift --quiet --retries 5 --timeout 120 upload --segment-size 2000000000 --segment-threads 1 ${SWIFT_BACKUP_CONTAINER} ${backup_filename}
+# if upload was successful create marker file, otherwise log error
+if [ $? -eq 0 ]; then
+    touch ${backup_filename_swift}
+    echo '  created swift marker file: '$backup_filename_swift >> $LOGFILE
+else
+    echo '  swift upload failed for: '$backup_filename >> $LOGFILE
+fi
 
 for fm in $(<swift_search_file.tmp)
     do

--- a/roles/slg.db-backup/templates/galaxy-backup-db.sh.j2
+++ b/roles/slg.db-backup/templates/galaxy-backup-db.sh.j2
@@ -42,6 +42,7 @@ WEEKLY_BACKUP_DAY={{ weekly_backup_day }}  #Weekly backups will run on this day 
 RETENTION_DAY={{ retention_day }}       #Keep daily backups for this many days (6 days)
 RETENTION_WEEK={{ retention_week }}     #Keep weekly backups for this many days (21 days = 3 weeks)
 RETENTION_MONTH={{ retention_month }}    #Keep monthly backups for this many days (92 days ~ 3 months)
+DISK_RETENTION_DAYS={{ retention_disk }} # keep backups on local disk for this many days
 
 {% if use_slack == true and slack_galaxy_log_webhook is defined %}
 post_to_slack() {
@@ -80,6 +81,7 @@ cd $BACKUP_DIR
 #create the backup filename
 
 backup_filename=`date +"%d-%m-%Y"`'-'${PSQL_DB}${BACKUP_TYPE}'.sql.gz'
+backup_filename_swift="${backup_filename}.swift"
 
 PRELIM_OUTPUT="[$(date --iso-8601=seconds)] Starting database backup\n"
 PRELIM_OUTPUT+="  Month day: ${month_day}\n"
@@ -91,6 +93,9 @@ PRELIM_OUTPUT+="  Swift details: ${SWIFT_BACKUP_CONTAINER}\n"
 PRELIM_OUTPUT+="  Database: ${PSQL_DB}\n"
 PRELIM_OUTPUT+="  Retention: ${RETENTION_DAY_LOOKUP}\n"
 PRELIM_OUTPUT+="  Backup filename: ${backup_filename}\n"
+{% if use_swift == true %}
+PRELIM_OUTPUT+="  Backup swift marker filename: ${backup_filename_swift}\n"
+{% endif %}
 
 #Send prelim output to the logfile
 echo $PRELIM_OUTPUT >> $LOGFILE
@@ -106,20 +111,29 @@ pg_dump \
   {{ connection_string }} \
   | pigz > ${backup_filename}
 
-#delete anything that's too old!
-#put the filenames in a file so we can get rid of them from object store.
-if [ -f search_file.tmp ] ; then
-        rm search_file.tmp
+# get the filenames of old database backups on local disk for deletion
+if [ -f local_search_file.tmp ] ; then
+    rm local_search_file.tmp
 fi
-find -maxdepth 1 -name "*${BACKUP_TYPE}*" -mtime +$RETENTION_DAY_LOOKUP > search_file.tmp
-sed -i "s/\.\///" search_file.tmp
-echo '  Contents of search_file.tmp' >> $LOGFILE
-cat 'search_file.tmp' >> $LOGFILE
+find -maxdepth 1 -name "*.sql.gz" -mtime +$DISK_RETENTION_DAYS > local_search_file.tmp
+echo '  Contents of local_search_file.tmp' >> $LOGFILE
+cat 'local_search_file.tmp' >> $LOGFILE
 
 {% if use_swift == true %}
+# get the old swift marker filenames in a file so we can get rid of them from object store
+if [ -f swift_search_file.tmp ] ; then
+        rm swift_search_file.tmp
+fi
+find -maxdepth 1 -name "*${BACKUP_TYPE}*.swift" -mtime +$RETENTION_DAY_LOOKUP > swift_search_file.tmp
+sed -i "s/\.\///" swift_search_file.tmp
+echo '  Contents of swift_search_file.tmp' >> $LOGFILE
+cat 'swift_search_file.tmp' >> $LOGFILE
+
+echo "sourcing swift credential file ${SWIFT_CRED_FILE}" >> $LOGFILE
 . ${SWIFT_CRED_FILE}
 
 set +o nounset
+echo "sourcing venv ${VENV_LOCATION}/bin/activate" >> $LOGFILE
 source ${VENV_LOCATION}/bin/activate
 set -o nounset
 
@@ -128,26 +142,36 @@ set +e
 
 echo '  Uploading to swift: '$backup_filename >> $LOGFILE
 swift --quiet --retries 5 --timeout 120 upload --segment-size 2000000000 --segment-threads 1 ${SWIFT_BACKUP_CONTAINER} ${backup_filename} || echo '  swift upload failed for: '$backup_filename >> $LOGFILE
-{% endif %}
 
-for f in $(<search_file.tmp)
+for fm in $(<swift_search_file.tmp)
     do
-        echo $f
-        {% if use_swift == true %}
+        f="${fm%.*}" # strip final suffix from filename
+        echo "swift marker file $fm for database backup $f"
         echo '  Deleting on swift: '$f >> $LOGFILE
-        #delete cloud copy and log error if delete fails
-        swift --retries 5 --timeout 120 delete --object-threads 1 ${SWIFT_BACKUP_CONTAINER} $f || echo '  swift delete failed for: '$f >> $LOGFILE
-        {% endif %}
-        #delete local copy
-        rm $f || echo '  local delete failed for: '$f >> $LOGFILE
+        # delete cloud copy
+        swift --retries 5 --timeout 120 delete --object-threads 1 ${SWIFT_BACKUP_CONTAINER} $f
+        # delete marker file if swift delete successful, otherwise log error
+        if [ $? -eq 0 ]; then
+            echo '  Deleting swift marker file: '$fm >> $LOGFILE
+            rm $fm || echo '  local delete failed for swift marker file: '$fm >> $LOGFILE
+        else
+            echo '  swift delete failed for: '$f >> $LOGFILE
+        fi
     done
 
-{% if use_swift == true %}
 # restore exit on fail
 set -e
+
+rm swift_search_file.tmp
 {% endif %}
 
-rm search_file.tmp
+# cleanup local disk of old backups
+for f in $(<local_search_file.tmp); do
+    echo $f
+    echo '  Deleting from local disk: '$f >> $LOGFILE
+    rm $f || echo '  local delete failed for galaxy database backup file: '$f >> $LOGFILE
+done
+rm local_search_file.tmp
 
 POST_OUTPUT="[$(date --iso-8601=seconds)] Database backup complete."
 echo $POST_OUTPUT >> $LOGFILE

--- a/roles/slg.db-backup/templates/galaxy-backup-db.sh.j2
+++ b/roles/slg.db-backup/templates/galaxy-backup-db.sh.j2
@@ -148,6 +148,10 @@ if [ $? -eq 0 ]; then
     echo '  created swift marker file: '$backup_filename_swift >> $LOGFILE
 else
     echo '  swift upload failed for: '$backup_filename >> $LOGFILE
+    {% if use_slack == true and slack_galaxy_log_webhook is defined %}
+    # send swift upload fail notification to slack
+    post_to_slack "Swift operation failed: swift upload ${SWIFT_BACKUP_CONTAINER} ${backup_filename}"
+    {% endif %}
 fi
 
 for fm in $(<swift_search_file.tmp)
@@ -163,6 +167,10 @@ for fm in $(<swift_search_file.tmp)
             rm $fm || echo '  local delete failed for swift marker file: '$fm >> $LOGFILE
         else
             echo '  swift delete failed for: '$f >> $LOGFILE
+            {% if use_slack == true and slack_galaxy_log_webhook is defined %}
+            # send swift delete fail notification to slack
+            post_to_slack "Swift operation failed: swift delete ${SWIFT_BACKUP_CONTAINER} $f"
+            {% endif %}
         fi
     done
 


### PR DESCRIPTION
Currently galaxy database backups are kept on local disk and swift cloud storage until the configured backup expiry is reached, then both are deleted. As the size of galaxy database backups has increased, we are no longer able to keep all of the backups on local disk, but would like to still keep them on cloud storage.
This PR utilises marker files on local disk to indicate that these backups are stored on cloud. Local disk backups can be expired sooner (1 week) to keep the local disk from filling up, while cloud-based backups can be kept for the desired amount of time.

Note that prior to changing the current backup scheme, swift marker files for the existing database backups will need to be generated with timestamps matching the backups. This can be done manually as per the following commands
```
touch -d "2023-12-23 19:39:00" galaxy-backups/23-12-2023-galaxy-weekly.sql.gz.swift
touch -d "2023-12-30 19:40:00" galaxy-backups/30-12-2023-galaxy-weekly.sql.gz.swift
touch -d "2024-01-01 19:40:00" galaxy-backups/01-01-2024-galaxy-monthly.sql.gz.swift
touch -d "2024-01-06 19:41:00" galaxy-backups/06-01-2024-galaxy-weekly.sql.gz.swift
...
```