### PR TITLE
temporarily direct all fastqc jobs to slurm

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -542,10 +542,10 @@ tools:
     env:
       SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-    scheduling:
-      accept:
-      - pulsar
-      - pulsar-quick
+    # scheduling: 17/1/24: temporarily run all fastqc jobs on slurm to alleviate pulsar transport congestion
+    #   accept:
+    #  - pulsar
+    #  - pulsar-quick
     rules:
     - if: |
         minimum_singularity_version = '0.72+galaxy1'


### PR DESCRIPTION
To prevent too much traffic to pulsar in the short term.