### PR TITLE
slurmdbd refactor

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -279,3 +279,33 @@ __slurmdbd_config_default: # this is not needed if this PR is merged: https://gi
   DbdPort: 6819
   SlurmUser: "{{ __slurm_user_name }}"
   LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"
+
+slurmdbd_config:
+  AuthType: auth/munge
+  AuthInfo: /var/run/munge/munge.socket.2
+  DbdHost: localhost
+  StorageHost: localhost
+  StorageLoc: "{{ slurm_database }}"
+  StoragePass: "{{ slurm_database_user_password }}"
+  StorageType: accounting_storage/mysql
+  StorageUser: "{{ slurm_database_user }}"
+  PidFile: /run/slurmdbd.pid
+  SlurmUser: slurm
+
+slurm_database_user: slurm
+slurm_database_user_password: "{{ mariadb_password_slurm }}"
+slurm_database: 'slurm_acct_db'
+
+#Mariadb for slurm accounting
+
+mariadb_root_pass: "{{ mariadb_password_root }}"
+mariadb_options:
+  innodb_buffer_pool_size: 1073741824
+  innodb_log_file_size: 67108864
+  innodb_lock_wait_timeout: 900
+mariadb_users:
+  - name: "{{ slurm_database_user }}"
+    password: "{{ slurm_database_user_password }}"
+    priv: '{{ slurm_database }}.*:ALL'
+mariadb_databases:
+  - name: '{{ slurm_database }}'

--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -1,38 +1,9 @@
 #Slurm roles
 slurm_roles: ['controller', 'exec', 'dbd']
 
-slurm_database_user: slurm
-slurm_database_user_password: "{{ vault_mariadb_password_slurm }}"
-slurm_database: 'slurm_acct_db'
-
 #Mariadb for slurm accounting
-
-mariadb_root_pass: "{{ vault_mariadb_password_root }}"
-mariadb_options:
-  innodb_buffer_pool_size: 1073741824
-  innodb_log_file_size: 67108864
-  innodb_lock_wait_timeout: 900
-mariadb_users:
-  - name: "{{ slurm_database_user }}"
-    password: "{{ slurm_database_user_password }}"
-    priv: '{{ slurm_database }}.*:ALL'
-mariadb_databases:
-  - name: '{{ slurm_database }}'
-
-#Slurmdbd
-
-slurmdbd_config:
-  AuthType: auth/munge
-  AuthInfo: /var/run/munge/munge.socket.2
-  DbdHost: localhost
-  StorageHost: localhost
-  StorageLoc: "{{ slurm_database }}"
-  StoragePass: "{{ slurm_database_user_password }}"
-  StorageType: accounting_storage/mysql
-  StorageUser: "{{ slurm_database_user }}"
-  LogFile: /var/log/slurm-llnl/slurmdbd.log
-  PidFile: /var/run/slurmdbd.pid
-  SlurmUser: slurm
+mariadb_password_root: "{{ vault_mariadb_password_root }}"
+mariadb_password_slurm: "{{ vault_mariadb_password_slurm }}"
 
 #NFS shares
 

--- a/host_vars/dev-queue.gvl.org.au.yml
+++ b/host_vars/dev-queue.gvl.org.au.yml
@@ -64,42 +64,10 @@ rabbitmq_password_galaxy_reservation_g2_xlarge_B: "{{ vault_rabbitmq_password_ga
 # Host specific Slurm settings
 slurm_roles: ['controller', 'dbd']
 
-slurm_database_user: slurm
-slurm_database_user_password: "{{ mariadb_password_slurm }}"
-slurm_database: 'slurm_acct_db'
-
 add_hosts_workers: yes
 add_hosts_handlers: yes
 add_hosts_galaxy: yes
 
 #Mariadb
-
-mariadb_root_pass: "{{ mariadb_password_root }}"
-mariadb_options:
-  innodb_buffer_pool_size: 1073741824
-  innodb_log_file_size: 67108864
-  innodb_lock_wait_timeout: 900
-mariadb_users:
-  - name: "{{ slurm_database_user }}"
-    password: "{{ slurm_database_user_password }}"
-    priv: '{{ slurm_database }}.*:ALL'
-mariadb_databases:
-  - name: '{{ slurm_database }}'
-
 mariadb_password_slurm: "{{ vault_mariadb_password_slurm }}"
 mariadb_password_root: "{{ vault_mariadb_password_root }}"
-
-#Slurmdbd
-
-slurmdbd_config:
-  AuthType: auth/munge
-  AuthInfo: /var/run/munge/munge.socket.2
-  DbdHost: localhost
-  StorageHost: localhost
-  StorageLoc: "{{ slurm_database }}"
-  StoragePass: "{{ slurm_database_user_password }}"
-  StorageType: accounting_storage/mysql
-  StorageUser: "{{ slurm_database_user }}"
-  LogFile: /var/log/slurm-llnl/slurmdbd.log
-  PidFile: /run/slurmdbd.pid
-  SlurmUser: slurm

--- a/host_vars/galaxy-queue.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-queue.usegalaxy.org.au.yml
@@ -136,50 +136,12 @@ rabbitmq_password_galaxy_azure_1: "{{ vault_rabbitmq_password_galaxy_azure_1_pro
 # Host specific Slurm settings
 slurm_roles: ["controller", "dbd"]
 
-slurm_database_user: slurm
-slurm_database_user_password: "{{ mariadb_password_slurm }}"
-slurm_database: "slurm_acct_db"
-
 add_hosts_workers: yes
 add_hosts_galaxy: yes
 
 #Mariadb
-
-mariadb_root_pass: "{{ mariadb_password_root }}"
-mariadb_options:
-  innodb_buffer_pool_size: 1073741824
-  innodb_log_file_size: 67108864
-  innodb_lock_wait_timeout: 900
-mariadb_users:
-  - name: "{{ slurm_database_user }}"
-    password: "{{ slurm_database_user_password }}"
-    priv: "{{ slurm_database }}.*:ALL"
-mariadb_databases:
-  - name: "{{ slurm_database }}"
-
 mariadb_password_slurm: "{{ vault_production_mariadb_password_slurm }}"
 mariadb_password_root: "{{ vault_production_mariadb_password_root }}"
-
-#Slurmdbd
-
-__slurmdbd_config_default: # overriding this to remove deprecated SlurmctldPidFile (using this key breaks it)
-  AuthType: auth/munge
-  DbdPort: 6819
-  SlurmUser: "{{ __slurm_user_name }}"
-  # SlurmctldPidFile: "{{ __slurm_run_dir ~ '/slurmdbd.pid' if __slurm_debian else omit }}"
-  LogFile: "{{ __slurm_log_dir ~ '/slurmdbd.log' if __slurm_debian else omit }}"
-
-slurmdbd_config:
-  AuthType: auth/munge
-  AuthInfo: /var/run/munge/munge.socket.2
-  DbdHost: localhost
-  StorageHost: localhost
-  StorageLoc: "{{ slurm_database }}"
-  StoragePass: "{{ slurm_database_user_password }}"
-  StorageType: accounting_storage/mysql
-  StorageUser: "{{ slurm_database_user }}"
-  PidFile: /run/slurmdbd.pid
-  SlurmUser: slurm
 
 # Variables for nginx and eu rabbitmq role
 

--- a/host_vars/pulsar-QLD/pulsar-QLD-queue.genome.edu.au.yml
+++ b/host_vars/pulsar-QLD/pulsar-QLD-queue.genome.edu.au.yml
@@ -46,41 +46,9 @@
 # Host specific Slurm settings
 slurm_roles: ['controller', 'dbd']
 
-slurm_database_user: slurm
-slurm_database_user_password: "{{ mariadb_password_slurm }}"
-slurm_database: 'slurm_acct_db'
-
 add_hosts_workers: yes
 add_hosts_galaxy: yes
 
 #Mariadb
-
-mariadb_root_pass: "{{ mariadb_password_root }}"
-mariadb_options:
-  innodb_buffer_pool_size: 1073741824
-  innodb_log_file_size: 67108864
-  innodb_lock_wait_timeout: 900
-mariadb_users:
-  - name: "{{ slurm_database_user }}"
-    password: "{{ slurm_database_user_password }}"
-    priv: '{{ slurm_database }}.*:ALL'
-mariadb_databases:
-  - name: '{{ slurm_database }}'
-
 mariadb_password_slurm: "{{ vault_mariadb_password_slurm }}"
 mariadb_password_root: "{{ vault_mariadb_password_root }}"
-
-#Slurmdbd
-
-slurmdbd_config:
-  AuthType: auth/munge
-  AuthInfo: /var/run/munge/munge.socket.2
-  DbdHost: localhost
-  StorageHost: localhost
-  StorageLoc: "{{ slurm_database }}"
-  StoragePass: "{{ slurm_database_user_password }}"
-  StorageType: accounting_storage/mysql
-  StorageUser: "{{ slurm_database_user }}"
-  LogFile: /var/log/slurm-llnl/slurmdbd.log
-  PidFile: /run/slurmdbd.pid
-  SlurmUser: slurm

--- a/host_vars/staging-queue.gvl.org.au.yml
+++ b/host_vars/staging-queue.gvl.org.au.yml
@@ -31,40 +31,8 @@ rabbitmq_password_galaxy_au: "{{ vault_rabbitmq_password_galaxy_au_staging }}"
 # Host specific Slurm settings
 slurm_roles: ['controller', 'dbd']
 
-slurm_database_user: slurm
-slurm_database_user_password: "{{ mariadb_password_slurm }}"
-slurm_database: 'slurm_acct_db'
-
 add_hosts_workers: yes
 
 #Mariadb
-
-mariadb_root_pass: "{{ mariadb_password_root }}"
-mariadb_options:
-  innodb_buffer_pool_size: 1073741824
-  innodb_log_file_size: 67108864
-  innodb_lock_wait_timeout: 900
-mariadb_users:
-  - name: "{{ slurm_database_user }}"
-    password: "{{ slurm_database_user_password }}"
-    priv: '{{ slurm_database }}.*:ALL'
-mariadb_databases:
-  - name: '{{ slurm_database }}'
-
 mariadb_password_slurm: "{{ vault_staging_mariadb_password_slurm }}"
 mariadb_password_root: "{{ vault_staging_mariadb_password_root }}"
-
-#Slurmdbd
-
-slurmdbd_config:
-  AuthType: auth/munge
-  AuthInfo: /var/run/munge/munge.socket.2
-  DbdHost: localhost
-  StorageHost: localhost
-  StorageLoc: "{{ slurm_database }}"
-  StoragePass: "{{ slurm_database_user_password }}"
-  StorageType: accounting_storage/mysql
-  StorageUser: "{{ slurm_database_user }}"
-  LogFile: /var/log/slurm-llnl/slurmdbd.log
-  PidFile: /run/slurmdbd.pid
-  SlurmUser: slurm


### PR DESCRIPTION
The slurmdbd configs for phm1 and phm2 were slightly wrong, resulting in no slurmdbd log files. It turns out that all of the VMs using slurmdbd can use the same config block so this is moved to all.yml along with MariaDB config which is the same everywhere.