### PR TITLE
Add size limit rule for smudgeplot

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -920,6 +920,10 @@ tools:
     scheduling:
       accept:
       - pulsar
+    rules:
+    - id: smudgeplot_fail_rule
+      if: input_size > 50
+      fail: Too much data. Total input data must be less than 50GB.
   toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_classification/cardinal_classification/.*:
     scheduling:
       accept:


### PR DESCRIPTION
limiting smudgeplot jobs to 50G. The allocation/limits can be reviewed over time but at the moment very large job will use a lot of resources for data transfer, run for ages then be oom-killed.