### PR TITLE
update galaxy role pre release

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,8 @@ collections:
 
 roles:
 - name: galaxyproject.galaxy
-  version: 0.10.19
+  src: https://github.com/galaxyproject/ansible-galaxy
+  version: 7650a92
 - name: galaxyproject.nginx
   version: 0.7.1
 - name: galaxyproject.postgresql


### PR DESCRIPTION
update galaxyproject.galaxy role between releases because there is a commit that fixes the problem of themes disappearing.