### PR TITLE
comment out clean-tmpdisk role, needs more work

### DIFF
--- a/galaxy-workers_playbook.yml
+++ b/galaxy-workers_playbook.yml
@@ -31,7 +31,7 @@
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
       - acl-on-startup
-      - clean-tmpdisk
+      # - clean-tmpdisk
   post_tasks:
       - name: restart munge
         systemd:

--- a/pulsar-high-mem1_playbook.yml
+++ b/pulsar-high-mem1_playbook.yml
@@ -34,7 +34,7 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
-    - clean-tmpdisk
+    # - clean-tmpdisk
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -34,7 +34,7 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
-    - clean-tmpdisk
+    # - clean-tmpdisk
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:

--- a/pulsar-mel2_worker_playbook.yml
+++ b/pulsar-mel2_worker_playbook.yml
@@ -25,7 +25,7 @@
       - geerlingguy.docker
       - acl-on-startup
       - dj-wasabi.telegraf
-      - clean-tmpdisk
+      # - clean-tmpdisk
   post_tasks:
       - name: Restart munge service
         service:

--- a/pulsar-mel3_worker_playbook.yml
+++ b/pulsar-mel3_worker_playbook.yml
@@ -25,7 +25,7 @@
       - geerlingguy.docker
       - acl-on-startup
       - dj-wasabi.telegraf
-      - clean-tmpdisk
+      # - clean-tmpdisk
   post_tasks:
       - name: Restart munge service
         service:

--- a/pulsar-nci-training_workers_playbook.yml
+++ b/pulsar-nci-training_workers_playbook.yml
@@ -36,7 +36,7 @@
       - geerlingguy.docker
       - acl-on-startup
       - dj-wasabi.telegraf
-      - clean-tmpdisk
+      # - clean-tmpdisk
   post_tasks:
       - name: Restart munge service
         service:

--- a/pulsar-paw_worker_playbook.yml
+++ b/pulsar-paw_worker_playbook.yml
@@ -21,7 +21,7 @@
       - geerlingguy.docker
       - acl-on-startup
       - dj-wasabi.telegraf
-      - clean-tmpdisk
+      # - clean-tmpdisk
   post_tasks:
       - name: Restart munge service
         service:

--- a/pulsar-qld-high-mem_playbook.yml
+++ b/pulsar-qld-high-mem_playbook.yml
@@ -37,7 +37,7 @@
     - pulsar-post-tasks
     - slurm-post-tasks
     - slg.galaxy_stats
-    - clean-tmpdisk
+    # - clean-tmpdisk
   post_tasks:
     - name: Create worker tmpdir on /mnt
       file:


### PR DESCRIPTION
there is an ansible template containing literal "{{}}" [here](https://github.com/usegalaxy-au/infrastructure/blob/master/roles/clean-tmpdisk/templates/clean_tmpdisk.py.j2#L72), which to ansible means it should contain a variable to substitute. Needs fixing.