### PR TITLE
Set `metadata_strategy: extended` on slurm destinations in tpv

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -21,6 +21,7 @@ destinations:
     abstract: true
     params:
         nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
+        metadata_strategy: extended
     rules:
       - id: slurm_destination_singularity_rule
         if: entity.params.get('singularity_enabled')

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -12,6 +12,7 @@ destinations:
     abstract: true
     params:
         nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
+        metadata_strategy: extended
     rules:
       - id: slurm_destination_singularity_rule
         if: entity.params.get('singularity_enabled')

--- a/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/staging_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/staging/total_perspective_vortex/staging_destinations.yml.j2
@@ -11,6 +11,7 @@ destinations:
     abstract: true
     params:
         nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
+        metadata_strategy: extended
     rules:
       - id: slurm_destination_singularity_rule
         if: entity.params.get('singularity_enabled')


### PR DESCRIPTION
For GA this fixes a bug with samtools_split and a couple of other tools https://github.com/galaxyproject/galaxy/issues/17208 though it's still a Galaxy bug that postprocessing fails for those tools with the default metadata_strategy.

This parameter can't be set for pulsar destinations unless the destinations have a galaxy code directory - something for later.
