### PR TITLE
Require pulsar-quick tag on pulsar-mel2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -111,6 +111,7 @@ destinations:
         - pulsar-mel2
       require:
         - pulsar
+        - pulsar-quick  # tag given to tools where jobs are likely to complete in less than a day
   pulsar-paw:
     inherits: _pulsar_destination
     runner: pulsar-paw_runner


### PR DESCRIPTION
Allow only quick jobs on pulsar-mel2 so that it can be taken offline at some point