### PR TITLE
new interactive tool urls

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -25,6 +25,7 @@ shared_mounts:
 certbot_domains:
   - "{{ hostname }}"
   - "*.interactivetoolentrypoint.interactivetool.{{ hostname }}"
+  - "*.ep.interactivetool.{{ hostname }}"
   - "genome.{{ hostname }}"
   - "proteomics.{{ hostname }}"
 certbot_dns_provider: cloudflare

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -14,6 +14,7 @@ certbot_domains:
   - "usegalaxy.org.au"
   - "www.usegalaxy.org.au"
   - "*.interactivetoolentrypoint.interactivetool.usegalaxy.org.au"
+  - "*.ep.interactivetool.usegalaxy.org.au"
   - "genome.usegalaxy.org.au"
   - "proteomics.usegalaxy.org.au"
 certbot_dns_provider: cloudflare

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -9,6 +9,7 @@ attached_volumes:
 certbot_domains:
   - "{{ hostname }}"
   - "*.interactivetoolentrypoint.interactivetool.{{ hostname }}"
+  - "*.ep.interactivetool.{{ hostname }}"
   - "genome.{{ hostname }}"
   - "proteomics.{{ hostname }}"
 certbot_dns_provider: cloudflare


### PR DESCRIPTION
Since updating dev to release_23.2 interactive tools are being mapped to < some uuid >.ep.interactivetool.dev.gvl.org.au instead of < some uuid >.interactivetoolentrypoint.interactivetool.dev.gvl.org.au.  After creating a new CNAME record for dev and updated the certificate to include the new pattern, ITs are working on dev. I could be missing something about how ITs are supposed to work post 23.2.