### PR TITLE
Increase limits for alphafold

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -530,10 +530,10 @@ job_conf_limits:
 
   - type: destination_total_concurrent_jobs
     id: pulsar-azure-gpu
-    value: 8
+    value: 12
   - type: destination_user_concurrent_jobs
     id: pulsar-azure-gpu
-    value: 2
+    value: 3
 
 # Singularity and docker volumes
 slurm_singularity_volumes_list:


### PR DESCRIPTION
The current batch of credits runs out at the end of this month (Feb 2024) so the increase in limits is an attempt to spend these.