### PR TITLE
set actimeo=0 for /mnt/tools

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -36,7 +36,7 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
   - path: /mnt/tools
     src: "{{ hostvars['galaxy-misc-nfs']['internal_ip'] }}:/mnt/tools"
     fstype: nfs
-    opts: 'noatime,defaults'
+    opts: 'noatime,actimeo=0,defaults'
     state: mounted
   - path: /mnt/custom-indices
     src: "{{ hostvars['galaxy-misc-nfs']['internal_ip'] }}:/mnt/custom-indices"


### PR DESCRIPTION
There is a problem with tool installation where some job/web handlers cannot find the tool even after a delay of 5 minutes. This might be due to cache delay.