### PR TITLE
Use Galaxy Main's mem formula for bwa_mem2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1178,6 +1178,8 @@ tools: # comment to change file to check linting
       cores: 8
       mem: 30.7
   toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 4
     cores: 20
     mem: 250
     scheduling:
@@ -1192,6 +1194,17 @@ tools: # comment to change file to check linting
       if: 0.25 <= input_size < 2
       cores: 8
       mem: 30.7
+    - id: bwa_mem2_history_reference_rule
+      # This rule is copied from usegalaxy.org with bwa_mem2_max_mem increased from 120 to 480
+      # See https://github.com/galaxyproject/usegalaxy-playbook/blob/5be90699d922c85228836a5a974b05cfd08a6c4b/env/common/templates/galaxy/config/tpv/tools_vgp.yaml.j2#L217C1-L224C93
+      if: |
+        helpers.job_args_match(job, app, {"reference_source": {"reference_source_selector": "history"}})
+      # per https://github.com/bwa-mem2/bwa-mem2/issues/41 it's 28 * reference
+      mem: |
+        bwa_mem2_max_mem = 480
+        options = job.get_param_values(app)
+        size = options["reference_source"]["ref_file"].get_size()
+        min(max(float(size/1024**3) * 28, (input_size - float(size/1024**3)) * 2, 7.6), bwa_mem2_max_mem)
   toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
There is a user with large reference genomes from history and all of their bwa_mem jobs are failing. Nate has set up a rule to estimate memory requirements based on the size of the reference genome from history. They are setting the max value as 120G RAM. This would not work for the GA user whose jobs are being killed with 250G. This PR adds Nate's rule with a max value of 480 which still might not be enough.

Lint is still failing due to an inconsistency in galaxy-app requirements so I'm not merging this.