### PR TITLE
Stop linting workflow from breaking by pinning every galaxy package

### DIFF
--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install total-perspective-vortex==$TPV_VERSION pyyaml galaxy-app
+        pip install total-perspective-vortex==$TPV_VERSION pyyaml galaxy-app==23.1.4 galaxy-auth==23.1.4 galaxy-config==23.1.4 galaxy-data==23.1.4 galaxy-files==23.1.4 galaxy-job-execution==23.1.4 galaxy-job-metrics==23.1.4 galaxy-navigation==23.1.4 galaxy-objectstore==23.1.4 galaxy-tool-util==23.1.4 galaxy-tours==23.1.4 galaxy-util==23.1.4 galaxy-web-framework==23.1.4 galaxy-web-stack==23.1.4
       env:
         TPV_VERSION: '2.3.2'
     - name: Check TPV files and job conf

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1,4 +1,4 @@
-tools:
+tools: # comment to change file to check linting
   testtoolshed.g2.bx.psu.edu/repos/fubar/htseq_bams_to_count_matrix/htseqsams2mxlocal/.*:
     cores: 3
     mem: 11.5


### PR DESCRIPTION
This is unpleasant but it seems to work