### PR TITLE
reduce phm1's RealMemory for slurm to match available memory after rebuild

### DIFF
--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -53,7 +53,7 @@ slurm_nodes:
     - name: pulsar-high-mem1
       NodeAddr: "{{ hostvars['pulsar-high-mem1']['ansible_ssh_host'] }}"
       CPUs: 126
-      RealMemory: 3937300
+      RealMemory: 3927300
       State: UNKNOWN
 
 slurm_partitions:


### PR DESCRIPTION
After rebuild of pulsar-high-mem1 it has less free memory than what is specified by slurm's `RealMemory` which prevents slurm from utilising the node. Reducing `RealMemory` to match what's now available.