### PR TITLE
Remove bwa_mem2 history reference rule

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1199,17 +1199,6 @@ tools:
       if: 0.25 <= input_size < 2
       cores: 8
       mem: 30.7
-    - id: bwa_mem2_history_reference_rule
-      # This rule is copied from usegalaxy.org with bwa_mem2_max_mem increased from 120 to 250
-      # See https://github.com/galaxyproject/usegalaxy-playbook/blob/5be90699d922c85228836a5a974b05cfd08a6c4b/env/common/templates/galaxy/config/tpv/tools_vgp.yaml.j2#L217C1-L224C93
-      if: |
-        helpers.job_args_match(job, app, {"reference_source": {"reference_source_selector": "history"}})
-      # per https://github.com/bwa-mem2/bwa-mem2/issues/41 it's 28 * reference
-      mem: |
-        bwa_mem2_max_mem = 250
-        options = job.get_param_values(app)
-        size = options["reference_source"]["ref_file"].get_size()
-        min(max(float(size/1024**3) * 28, (input_size - float(size/1024**3)) * 2, 7.6), bwa_mem2_max_mem)
   toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
This rule is borrowed from Galaxy Main. Some bwa_mem2 jobs have failed with OOM error when the reference genome is very small compared to the rest of the input data. It is also more likely to run out of memory with compressed fastq input.

It's a shame to remove this because it is nice to calculate memory needs rather than giving every job 250G. I'll make an issue with examples of cases where the calculated memory has been too low.