### PR TITLE
Allow 80 jobs in queued/running state for slurm (up from 55)

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -442,7 +442,7 @@ job_conf_limits:
 
   - type: destination_total_concurrent_jobs
     id: slurm
-    value: 55
+    value: 80
   - type: destination_user_concurrent_jobs
     id: slurm
     value: 5


### PR DESCRIPTION
When it's busy, the jobs that are queued and not running tend to be higher-cpu jobs. If enough of them are in the queue the limit (55) is reached and this can block smaller jobs that would be able to run immediately from joining the queue.