### PR TITLE
Change mount settings

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -47,22 +47,22 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
     src: "{{ hostvars['galaxy-job-nfs']['internal_ip'] }}:/mnt/tmp"
     fstype: nfs
     state: mounted
-    opts: 'noatime,actimeo=0,defaults'
+    opts: 'noatime,defaults'
   # galaxy-user-nfs
   - path: /mnt/user-data-volA # 150T volume
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volA"
     fstype: nfs
-    opts: 'noatime,actimeo=0,defaults'
+    opts: 'noatime,actimeo=1,defaults'
     state: mounted
   - path: /mnt/user-data-volB # 50T volume
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volB"
     fstype: nfs
-    opts: 'noatime,actimeo=0,defaults'
+    opts: 'noatime,actimeo=1,defaults'
     state: mounted
   - path: /mnt/user-data-volC # 42T volume
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volC"
     fstype: nfs
-    opts: 'noatime,actimeo=0,defaults'
+    opts: 'noatime,actimeo=1,defaults'
     state: mounted
   # pawsey data volumes
   - path: "{{ pawsey_file_mounts_path }}/user-data"


### PR DESCRIPTION
The reason we started setting actimeo at ETCA was that files created and shown as available in the history panel would not become available until 10-20 seconds later. From memory, using actimeo=2 for the user volumes was adequate. I don't know if we have a use case for setting actimeo=0 on /mnt/tmp - switching to default is worth a try to see if it will improve performance.