### PR TITLE
fix nginx template upstream section

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -84,8 +84,6 @@ nginx_upload_module_url: https://swift.rc.nectar.org.au/v1/AUTH_377/galaxy_infra
 # miniconda
 miniconda_prefix: "{{ galaxy_conda_prefix }}"
 
-num_gunicorn_processes: 1
-
 # singularity cache of galaxy user (this defaults to /home/galaxy/.singularity). Not to be confused with cache directory for built sif files in galaxy_config.galaxy.container_resolvers_conf
 galaxy_user_singularity_cachedir: /mnt/singularity_data
 galaxy_user_singularity_tmpdir: "{{ galaxy_user_singularity_cachedir }}/tmp"
@@ -396,5 +394,4 @@ lsyncd_max_user_watches: 524288
 debug:
   # determines whether to enable memray debugging. Memray process must be manually started on port 8082
   memray:
-    enabled: false
     weight: 0

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -114,14 +114,13 @@ host_galaxy_config_gravity:
   app_server: gunicorn
   virtualenv: "{{ galaxy_venv_dir }}"
   gunicorn:
-    # listening options
-    bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"
-    # performance options
-    workers: 2
-    # Other options that will be passed to gunicorn
-    extra_args: '--forwarded-allow-ips="*"'
-    preload: true
-    environment: "{{ galaxy_process_env }}"
+    - bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"
+      # performance options
+      workers: 2
+      # Other options that will be passed to gunicorn
+      extra_args: '--forwarded-allow-ips="*"'
+      preload: true
+      environment: "{{ galaxy_process_env }}"
   gx_it_proxy:
     enable: true
     version: '>=0.0.5'  # default from galaxy.yml.sample

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -26,8 +26,6 @@ nginx_ssl_servers:
   - galaxy
   - galaxy-gie-proxy ## we still do this?
 
-num_gunicorn_processes: 2
-
 # gie proxy hostname
 interactive_tools_server_name: "usegalaxy.org.au"
 

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -84,14 +84,13 @@ host_galaxy_config: # renamed from __galaxy_config
     app_server: gunicorn
     virtualenv: "{{ galaxy_venv_dir }}"
     gunicorn:
-      # listening options
-      bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"
-      # performance options
-      workers: 2
-      # Other options that will be passed to gunicorn
-      extra_args: '--forwarded-allow-ips="*"'
-      preload: true
-      environment: "{{ galaxy_process_env }}"
+      - bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"
+        # performance options
+        workers: 2
+        # Other options that will be passed to gunicorn
+        extra_args: '--forwarded-allow-ips="*"'
+        preload: true
+        environment: "{{ galaxy_process_env }}"
     celery:
       concurrency: 2
       loglevel: DEBUG

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -1,8 +1,11 @@
 upstream galaxy {
-{% for i in range(1, num_gunicorn_processes+1) %}
-    server unix://{{ galaxy_mutable_config_dir }}/gunicorn{% if num_gunicorn_processes > 1 %}{{i}}{% endif %}.sock weight={{100-debug.memray.weight/num_gunicorn_processes}};
+{% set num_gunicorn_processes = galaxy_config.gravity.gunicorn | length %}
+{% for gunicorn_process in galaxy_config.gravity.gunicorn %}
+    server {{ gunicorn_process.bind | replace('unix:', 'unix://') }} weight={{ (100-debug.memray.weight / galaxy_config.gravity.gunicorn|length) | int }};
 {% endfor %}
-    server localhost:8082 {% if not debug.memray.enabled %}down{% endif %} weight={{debug.memray.weight}};
+{% if debug.memray.weight > 0 %}
+    server localhost:8082 weight={{ debug.memray.weight | int }};
+{% endif %}
 }
 
 server {


### PR DESCRIPTION
This ensures weight is a non-zero integer and removes the num_gunicorn_processes variable. The format of galaxy_config.gravity.gunicorn needs to be a list across all dev/staging/galaxy for this to work.