### PR TITLE
disable celery on galaxy web server

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -90,6 +90,9 @@ host_galaxy_config_gravity:
   galaxy_user: "{{ galaxy_user.name }}"
   app_server: gunicorn
   virtualenv: "{{ galaxy_venv_dir }}"
+  celery:
+    enable: false
+    enable_beat: false
   gunicorn:
     - bind: unix:{{ galaxy_mutable_config_dir }}/gunicorn1.sock
       workers: 2


### PR DESCRIPTION
with this setting, all celery tasks will run from the galaxy handlers VM. Currently they are divided between galaxy and galaxy-handlers.