### PR TITLE
Less nfs caching of user data mounts

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -31,6 +31,8 @@ pawsey_file_mounts_available: True # assume true unless set to false
 qld_file_mounts_path: /mnt/user-data-qld
 pawsey_file_mounts_path: /mnt/user-data-pawsey
 
+galaxy_user_data_nfs_opts: 'noatime,defaults'
+
 galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_handlers and workers
   # galaxy-misc-nfs
   - path: /mnt/tools
@@ -52,17 +54,17 @@ galaxy_server_and_worker_shared_mounts: # Everything mounted on galaxy, galaxy_h
   - path: /mnt/user-data-volA # 150T volume
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volA"
     fstype: nfs
-    opts: 'noatime,actimeo=1,defaults'
+    opts: "{{ galaxy_user_data_nfs_opts }}"
     state: mounted
   - path: /mnt/user-data-volB # 50T volume
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volB"
     fstype: nfs
-    opts: 'noatime,actimeo=1,defaults'
+    opts: "{{ galaxy_user_data_nfs_opts }}"
     state: mounted
   - path: /mnt/user-data-volC # 42T volume
     src: "{{ hostvars['galaxy-user-nfs']['internal_ip'] }}:/mnt/volC"
     fstype: nfs
-    opts: 'noatime,actimeo=1,defaults'
+    opts: "{{ galaxy_user_data_nfs_opts }}"
     state: mounted
   # pawsey data volumes
   - path: "{{ pawsey_file_mounts_path }}/user-data"

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -34,6 +34,7 @@ galaxy_commit_id: release_23.1_au
 
 # TODO: check list concatenation with versions of ansible > 2.12
 shared_mounts: "{{ galaxy_server_and_worker_shared_mounts + galaxy_web_server_mounts }}" # sourced from galaxy_etca.yml
+galaxy_user_data_nfs_opts: 'noatime,actimeo=1,defaults' # galaxy VM needs to be able to see files as soon as they arrive in user data folders
 
 # ansible-galaxy
 galaxy_dynamic_job_rules_src_dir: files/galaxy/dynamic_job_rules/production


### PR DESCRIPTION
Only the galaxy VM needs actimeo set for the user data volumes. It doesn't make sense that any of the other VMs would need this.

These volumes are mounted on 12 clients. Is there any difference between all 12 of them having actimeo set, or only one of them? If not, this change is not helpful and this PR can be closed.