### PR TITLE
vary nginx logrotate file to keep logs forever (dev)

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -96,3 +96,27 @@
       become: yes
       become_user: root
 
+    # Nginx logrotate: keep nginx logs forever on /mnt disk
+    - name: Make sure extra nginx log dirs exist
+      file:
+        state: directory
+        path: "{{ item }}"
+      with_items:
+        - nginx_log_olddir_root
+        - nginx_long_term_log_dir
+    - name: Add lines to main block in nginx logrotate conf
+      lineinfile:
+        path: /etc/logrotate.d/nginx
+        line: "{{ item }}"
+        insertafter: ".*{"
+      with_items:
+        - "\tdateext"
+        - "\tolddir {{ nginx_log_olddir_root }}"
+    - name: Add lines to postrotate task in nginx logrotate conf
+      lineinfile:
+        path: /etc/logrotate.d/nginx
+        line: "{{ item }}"
+        insertafter: "\tpostrotate"
+      with_items:
+        - "\t\tcp {{ nginx_log_olddir_root }}/* {{ nginx_long_term_log_dir }}/"
+

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -102,8 +102,8 @@
         state: directory
         path: "{{ item }}"
       with_items:
-        - nginx_log_olddir_root
-        - nginx_long_term_log_dir
+        - "{{ nginx_log_olddir_root }}"
+        - "{{ nginx_long_term_log_dir }}"
     - name: Add lines to main block in nginx logrotate conf
       lineinfile:
         path: /etc/logrotate.d/nginx

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -395,3 +395,7 @@ debug:
   # determines whether to enable memray debugging. Memray process must be manually started on port 8082
   memray:
     weight: 0
+
+# dirs for nginx logs
+nginx_log_olddir_root: /var/log/nginx/olddir
+nginx_long_term_log_dir: /mnt/var/log/nginx


### PR DESCRIPTION
This is a setup for dev to see if it has the desired result.

Two weeks of nginx logs is 1.1GB in size so keeping them forever on the root disk is not an option.

There is a lot of space on /mnt on the galaxy VM so we could probably keep them for several years or just this year to get access data. This is a few lineinfiles on the nginx logrotate conf that adds a date to the files, stores them in an olddir which has to be on the same device (apparently logrotate will protest if it is not) and copies the files to a directory on /mnt where they will not be rotated out but accumulate instead.

If this is approved and works on dev I'll want to put it on production (and remove it from dev where space on /mnt is not abundant).

before:
```
/var/log/nginx/*.log {
	daily
	missingok
	rotate 14
	compress
	delaycompress
	notifempty
	create 0640 www-data adm
	sharedscripts
	prerotate
		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
			run-parts /etc/logrotate.d/httpd-prerotate; \
		fi \
	endscript
	postrotate
		invoke-rc.d nginx rotate >/dev/null 2>&1
	endscript
}
```

after:
```
/var/log/nginx/*.log {
	olddir /var/log/nginx/olddir
	dateext
	daily
	missingok
	rotate 14
	compress
	delaycompress
	notifempty
	create 0640 www-data adm
	sharedscripts
	prerotate
		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
			run-parts /etc/logrotate.d/httpd-prerotate; \
		fi \
	endscript
	postrotate
		cp /var/log/nginx/olddir/* /mnt/var/log/nginx/
		invoke-rc.d nginx rotate >/dev/null 2>&1
	endscript
}
```