### PR TITLE
tmp_dir: true for hisat2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1410,6 +1410,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/.*:
     cores: 36
     mem: 500
+    params:
+      tmp_dir: true
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
hisat2 is filling up a worker tmpdisk. It creates too many intermediate files.