### PR TITLE
get_organelle_from_reads to pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1365,9 +1365,12 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/getorganelle/get_organelle_from_reads/.*:
-    mem: 24
+    mem: 70
     params:
       singularity_enabled: true
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
This is not multithreaded but needs lots of memory. It is running out of memory frequently with 24G. With mem set to 70 it can run on high memory pulsar.