### PR TITLE
set unkillablesteptimeout in slurm conf

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -255,6 +255,7 @@ group_slurm_config:
   SchedulerType: sched/backfill
   SelectType: select/cons_res
   SelectTypeParameters: CR_CPU_Memory,CR_LLN
+  UnkillableStepTimeout: 180
 
   AccountingStorageHost: "{% if ansible_hostname == slurm_controller_host %}localhost{% else %}{{ slurm_controller_host }}{% endif %}"
   ControlMachine: "{{ slurm_controller_host }}"


### PR DESCRIPTION
For issue https://github.com/usegalaxy-au/infrastructure/issues/1849

Slurm nodes go into drain state due to jobs not ending with signals. The UnkillableStepTimeout defaults to 60 seconds. Hopefully raising it to 180 will stop the slurm nodes going into drain state as frequently.