### PR TITLE
give all qiime tools `tmp_dir: true`

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2956,6 +2956,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/q2d2/qiime2.*:
     params:
       docker_enabled: true
+      tmp_dir: true
   toolshed.g2.bx.psu.edu/repos/recetox/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
@mthang has noticed that some qiime errors might be due to a temporary folders being given the same name