### PR TITLE
alphafold helixir to qld

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -293,7 +293,8 @@ destinations:
     max_accepted_gpus: 1
     scheduling:
       require:
-        - pulsar  # maybe require a group tag as well here idk
+        - pulsar
+        - pulsar-qld-gpu # for testing purposes require this tag
     rules:
       - id: pulsar_destination_docker_rule
         params:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -837,9 +837,8 @@ tools:
       tmp_dir: true
     rules:
     - if: |
-        user and 'Alphafold' in [role.name for role in user.all_roles() if not role.deleted] and not (
-          'UoM_Vet_Alphafold' in [role.name for role in user.all_roles() if not role.deleted]
-        )
+        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user and 'Alphafold' in user_roles and not 'UoM_Vet_Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles
       context:
         partition: azuregpu0
       scheduling:
@@ -849,7 +848,8 @@ tools:
         accept:
         - training-exempt
     - if: |
-        user and 'UoM_Vet_Alphafold' in [role.name for role in user.all_roles() if not role.deleted]
+        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user and 'UoM_Vet_Alphafold' in user_roles
       context:
         partition: azuregpu1
       scheduling:
@@ -857,10 +857,17 @@ tools:
         - pulsar
         - pulsar-azure-1-gpu
     - if: |
+        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user.name in [f'qldgpu{x+1}' for x in range(6)] or 'pulsar_gpu_test' in user_roles
+      scheduling:
+        accept:
+        - pulsar
+        - pulsar-qld-gpu
+    - if: |
         not user or not any([
           role for role in user.all_roles() if (
-            role.name in ['Alphafold', 'UoM_Vet_Alphafold'] and not role.deleted
-        )])
+            role.name in ['Alphafold', 'UoM_Vet_Alphafold', 'pulsar_gpu_test'] and not role.deleted
+        )]) and user.name not in [f'qldgpu{x+1}' for x in range(6)]
       fail: |
         This tool is currently being beta-tested on GPUs and your account has not been given access. Contact help@genome.edu.au if you think this is in error.
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/2.1.*:
@@ -3238,14 +3245,25 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/*:
-    context:
-      partition: azuregpu0
     cores: 8
     mem: 69
     params:
       docker_enabled: true
       docker_run_extra_arguments: --gpus all
-    scheduling:
-      require:
-      - pulsar
-      - pulsar-azure-1-gpu
+    rules:
+    - if: | # pulsar test users only
+        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user and (user.name in [f'qldgpu{x+1}' for x in range(6)] or 'pulsar_gpu_test' in user_roles)
+      scheduling:
+        accept:
+        - pulsar
+        - pulsar-qld-gpu
+    - if: | # everything but a pulsar test user
+        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user and user.name not in [f'qldgpu{x+1}' for x in range(6)] and 'pulsar_gpu_test' not in user_roles
+      context:
+        partition: azuregpu0
+      scheduling:
+        require:
+        - pulsar
+        - pulsar-azure-1-gpu

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
@@ -149,6 +149,7 @@ users:
           scheduling:
             accept:
               - pulsar
+              - pulsar-qld-gpu
               - offline
             require:
               - pulsar-qld-gpu1
@@ -159,6 +160,7 @@ users:
           scheduling:
             accept:
               - pulsar
+              - pulsar-qld-gpu
               - offline
             require:
               - pulsar-qld-gpu2
@@ -169,6 +171,7 @@ users:
           scheduling:
             accept:
               - pulsar
+              - pulsar-qld-gpu
               - offline
             require:
               - pulsar-qld-gpu3
@@ -179,6 +182,7 @@ users:
           scheduling:
             accept:
               - pulsar
+              - pulsar-qld-gpu
               - offline
             require:
               - pulsar-qld-gpu4
@@ -189,6 +193,7 @@ users:
           scheduling:
             accept:
               - pulsar
+              - pulsar-qld-gpu
               - offline
             require:
               - pulsar-qld-gpu5
@@ -199,6 +204,7 @@ users:
           scheduling:
             accept:
               - pulsar
+              - pulsar-qld-gpu
               - offline
             require:
               - pulsar-qld-gpu6

--- a/scripts/create_test_users.py
+++ b/scripts/create_test_users.py
@@ -1,0 +1,78 @@
+import argparse
+import secrets
+import string
+from bioblend.galaxy import GalaxyInstance
+
+
+def generate_password():
+    # Generate a random 12-character hexadecimal password
+    return "".join(secrets.choice(string.hexdigits) for i in range(12))
+
+
+def get_or_create_user(galaxy, username, email, password=None):
+    # Filter users based on email
+    users = galaxy.users.get_users(f_email=email)
+
+    if users:
+        user = users[0]
+        print(f"User '{username}' already exists.")
+        return user["email"], galaxy.users.get_user_apikey(user["id"])
+    else:
+        if not password:
+            password = generate_password()
+
+        try:
+            user = galaxy.users.create_local_user(username, email, password=password)
+            print(f"User '{username}' created successfully with password: {password}")
+            user_id = user["id"]
+            user_api_key = galaxy.users.create_user_apikey(user_id)
+            return user["email"], user_api_key
+        except Exception as e:
+            print(f"Failed to create user '{username}': {e}")
+            return None, None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create users in Galaxy")
+    parser.add_argument(
+        "-a", "--admin_api_key", required=True, help="Admin's Galaxy API key"
+    )
+    parser.add_argument(
+        "-g",
+        "--galaxy_url",
+        default="https://usegalaxy.org.au",
+        help="Galaxy URL (default: https://usegalaxy.org.au)",
+    )
+    parser.add_argument(
+        "-n",
+        "--names",
+        required=True,
+        nargs="+",
+        help="List of names to create users for",
+    )
+    parser.add_argument(
+        "-p",
+        "--password",
+        help="Password for the users (default: random 12-character hexadecimal)",
+    )
+
+    args = parser.parse_args()
+
+    galaxy = GalaxyInstance(url=args.galaxy_url, key=args.admin_api_key)
+
+    api_keys = {}
+    for name in args.names:
+        username = name
+        email = f"{name}@genome.edu.au"
+
+        email, api_key = get_or_create_user(galaxy, username, email, args.password)
+        if email and api_key:
+            api_keys[username] = api_key
+
+    print("\nAPI Keys for created users:")
+    for username, api_key in api_keys.items():
+        print(f"Username: {username}\tAPI Key: {api_key}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
adjust tpv rules for alphafold and helixir to allow members of a group 'pulsar_gpu_test' or the pulsar test users to send alphafold/helixir jobs to qld instead of azure. Add a script for creating the pulsar users