### PR TITLE
pin pycurl for pulsar

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -36,7 +36,7 @@ pulsar_ssl_pem: /etc/ssl/certs/host.pem
 pulsar_optional_dependencies:
   - pyOpenSSL
   - psutil
-  - pycurl
+  - pycurl<=7.45.2
   - drmaa
   - kombu>=5.2.0
   - sentry-sdk


### PR DESCRIPTION
pulsar-qld-gpu1 had the same problem with cert location as pulsar-high-mem1. I've downgraded pycurl to 7.45.2 and now it's OK. For now this will need to be pinned.

There is a bug report but I didn't find it last week - only saw it just now by specifically searching for pycurl 7.45.3 errors https://github.com/pycurl/pycurl/issues/834