### PR TITLE
increase max size for rabbitmq messages

### DIFF
--- a/host_vars/galaxy-queue.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-queue.usegalaxy.org.au.yml
@@ -20,6 +20,7 @@ rabbitmq_config:
   management:
     disable_stats: 'false'
   consumer_timeout: 21600000 # 6 hours in milliseconds
+  max_message_size: 536870912 # 512MB, max size allowed
 
 rabbitmq_users:
   - user: admin


### PR DESCRIPTION
The max allowed size for rabbit messages defaults to 128MB but used to be much higher and has been reduced over time. The max they allow now is 512MB. This change will allow some pulsar jobs to finish.