### PR TITLE
skip attached volumes role on pmel2, pmel3

### DIFF
--- a/pulsar-mel2_playbook.yml
+++ b/pulsar-mel2_playbook.yml
@@ -15,9 +15,11 @@
         cache_valid_time: 3600
         update_cache: yes
       when: ansible_os_family == "Debian"
-    - name: Attach volume to instance
-      include_role:
-        name: attached-volumes
+    # attached_volumes role is broken for legacy cases where there is no partition set.
+    # If we need to run this role again we should be adding partition to each attached_volumes entry for this VM
+    # - name: Attach volume to instance If we need to run this role again we should add parition to the attached_volumes entries for this VM
+    #   include_role:
+    #     name: attached-volumes
     - name: Create pulsar deps path
       file:
         path: "{{ pulsar_dependencies_dir }}"

--- a/pulsar-mel3_playbook.yml
+++ b/pulsar-mel3_playbook.yml
@@ -15,9 +15,11 @@
         cache_valid_time: 3600
         update_cache: yes
       when: ansible_os_family == "Debian"
-    - name: Attach volume to instance
-      include_role:
-        name: attached-volumes
+    # attached_volumes role is broken for legacy cases where there is no parition set.
+    # If we need to run this role again we should be adding partition to each attached_volumes entry for this VM
+    # - name: Attach volume to instance If we need to run this role again we should add parition to the attached_volumes entries for this VM
+    #   include_role:
+    #     name: attached-volumes
     - name: Create pulsar deps path
       file:
         path: "{{ pulsar_dependencies_dir }}"


### PR DESCRIPTION
The attached_volumes role is broken for legacy cases where no partition is set