### PR TITLE
more ram for stacks_tsv2bam

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2617,7 +2617,7 @@ tools:
     mem: 61.4
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_tsv2bam/stacks2_tsv2bam/.*:
     cores: 8
-    mem: 31
+    mem: 42
   toolshed.g2.bx.psu.edu/repos/iuc/stacks2_ustacks/stacks2_ustacks/.*:
     cores: 16
     mem: 100


### PR DESCRIPTION
This tool seems to be using too much memory but until it can be fixed, it should be accommodated