### PR TITLE
put fastqc back on pulsar for now

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -553,10 +553,10 @@ tools:
     env:
       SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-    # scheduling:
-    #   accept:
-    #   - pulsar
-    #   - pulsar-quick
+    scheduling:
+      accept:
+      - pulsar
+      - pulsar-quick
     rules:
     - if: |
         minimum_singularity_version = '0.72+galaxy1'


### PR DESCRIPTION
Hopefully this will not put too much pressure on galaxy with pulsar transfers. The slurm queue is overloaded at present.