### PR TITLE
move tmp files within mnt tmp

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -158,7 +158,7 @@ group_galaxy_config:
   galaxy:
     check_migrate_tools: false
     log_level: TRACE
-    new_file_path: "{{ galaxy_tmp_dir }}"
+    new_file_path: "{{ galaxy_tmp_dir }}/scratch"
     job_working_directory: "{{ galaxy_tmp_dir }}/job_working_directory"
     allow_user_impersonation: true
     allow_user_deletion: true


### PR DESCRIPTION
store the 1000s of temporary files on the floor of /mnt/tmp in /mnt/tmp/scratch so that they are easier to clean up.

We don't need to create /mnt/tmp/scratch in advance - galaxy will create this.