### PR TITLE
Use fork for eu-rabbitmq role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -74,8 +74,9 @@ roles:
   # version: 0.0.13
 - src: usegalaxy_eu.apptainer
   version: 0.0.1
-- src: usegalaxy_eu.rabbitmqserver
-  version: 1.4.4
+- name: usegalaxy_eu.rabbitmqserver
+  src: https://github.com/cat-bro/ansible-rabbitmq
+  version: main
 - name: geerlingguy.redis
   version: 1.8.0
 


### PR DESCRIPTION
We can't make configuration changes in rabbitmq unless the config key is hard coded in the config file template, hence adding 'max_message_size' is not possible with their role. I'd like to fix this in the usegalaxy-eu role. In the meantime I have a fork with 'max_message_size' in the template.. we could use this for now.