### PR TITLE
no redirect for /mnt/scratch in alphafold jobs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -262,7 +262,7 @@ destinations:
     rules:
       - id: pulsar_destination_docker_rule
         params:
-            docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro,/mnt/scratch:/tmp:rw
+            docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false


### PR DESCRIPTION
Hi @neoformit , we have a flag set for alphafold `tmp_dir: true` which should mean anything that would be written to `/tmp` will be written to `<jwd>/tmp` instead. It might be the case that this 'docker_volumes' entry has priority over that, and everything goes to /tmp which is not big enough in a handful of cases.

[EDIT: the mapping means that everything from /tmp goes to /mnt/scratch which is 60G as also too small]