### PR TITLE
add tpv entry for morpheus

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1029,6 +1029,12 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant_mqpar/maxquant_mqpar/.*:
     cores: 16
     mem: 61.4
+  toolshed.g2.bx.psu.edu/repos/galaxyp/morpheus/morpheus/.*:
+    params:
+      singularity_enabled: true  
+    scheduling:
+      accept:
+        - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:
     cores: 1
     mem: 3.8


### PR DESCRIPTION
morpheus can run on pulsar. It is getting its cores/mem from the shared db as 1c/64gb. Because of the memory requirement it will almost always be better off on pulsar. Jobs like this with low CPU count and high memory are not handled well by the ranking function that sends the job to the destination with the lowest %CPUs allocated.