### PR TITLE
Set galaxy head node log level to INFO

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -180,6 +180,7 @@ host_galaxy_config: # renamed from __galaxy_config
     activation_email: <activation-noreply@usegalaxy.org.au>
 
     sentry_dsn: "{{ vault_sentry_url_galaxy_production }}"
+    log_level: INFO
 
     celery_conf:
       result_backend: "redis://:{{ vault_redis_requirepass }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:6379/0"


### PR DESCRIPTION
Galaxy head node's root partition is filling up due to excessive Galaxy logging (currently at `log_level: TRACE`). Set log level to `INFO` to reduce size of log files.
