### PR TITLE
add headers to /_x_accel_redirect/ block in nginx template

### DIFF
--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -76,6 +76,8 @@ server {
     location /_x_accel_redirect/ {
         internal;
         alias /;
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-Content-Type-Options nosniff;
     }
 
     location /training-material/ {


### PR DESCRIPTION
EU and main both have this. I'm wondering if a recent problem with content-length not being defined things sent to pulsar might have to do with the absence of this in our own config.