### PR TITLE
Allow all pulsar jobs to run on pulsar-QLD

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -237,7 +237,7 @@ destinations:
         - pulsar-QLD
       require:
         - pulsar
-        - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
+        # - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner


### PR DESCRIPTION
remove requirement for pulsar-quick tag from pulsar-QLD