### PR TITLE
switch on tmp_dir: true for sra tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2595,11 +2595,15 @@ tools:
       max_concurrent_job_count_for_tool_user: 1
     cores: 3
     mem: 11.5
+    params:
+      tmp_dir: true
   toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fastq_dump/.*:
     context:
       max_concurrent_job_count_for_tool_user: 1
     cores: 3
     mem: 11.5
+    params:
+      tmp_dir: true
   toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sam_dump/.*:
     cores: 3
     mem: 11.5


### PR DESCRIPTION
Since a recent update these tools do not write their temporary files to jwds automatically which is good, but today writing to jwds is good for scratch testing