### PR TITLE
make max length and db path context variables for alphafold so that max length can be extended for group members

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -839,6 +839,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
     context:
       alphafold_aa_length_max: 3000
+      alphafold_max_input_sequences: 10
       alphafold_db: /data/v2.3
     gpus: 1
     cores: 8
@@ -848,15 +849,19 @@ tools:
       docker_volumes: 
         $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
       docker_run_extra_arguments: |
-        '--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=5 --env
-        ALPHAFOLD_AA_LENGTH_MAX={alphafold_aa_length_max} --env ALPHAFOLD_DB={alphafold_db}'
+        '--gpus all
+        --env ALPHAFOLD_AA_LENGTH_MIN=5
+        --env ALPHAFOLD_AA_LENGTH_MAX={alphafold_aa_length_max}
+        --env ALPHAFOLD_MAX_SEQUENCES={alphafold_max_input_sequences}
+        --env ALPHAFOLD_DB={alphafold_db}'
       tmp_dir: true
     rules:
     - if: |
         user_roles = [role.name for role in user.all_roles() if not role.deleted]
         'Alphafold_plus' in user_roles
       context:
-        alphafold_aa_length_max: 6000
+        alphafold_aa_length_max: 3000
+        alphafold_max_input_sequences: 20
     - if: |
         user_roles = [role.name for role in user.all_roles() if not role.deleted]
         user and 'Alphafold' in user_roles and not 'UoM_Vet_Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -837,6 +837,9 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
+    context:
+      alphafold_aa_length_max: 3000
+      alphafold_db: /data/v2.3
     gpus: 1
     cores: 8
     mem: 69
@@ -844,8 +847,16 @@ tools:
       docker_enabled: true
       docker_volumes: 
         $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
+      docker_run_extra_arguments: |
+        '--gpus all --env ALPHAFOLD_AA_LENGTH_MIN=5 --env
+        ALPHAFOLD_AA_LENGTH_MAX={alphafold_aa_length_max} --env ALPHAFOLD_DB={alphafold_db}'
       tmp_dir: true
     rules:
+    - if: |
+        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        'Alphafold_plus' in user_roles
+      context:
+        alphafold_aa_length_max: 6000
     - if: |
         user_roles = [role.name for role in user.all_roles() if not role.deleted]
         user and 'Alphafold' in user_roles and not 'UoM_Vet_Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles
@@ -883,21 +894,16 @@ tools:
         This tool is currently being beta-tested on GPUs and your account has not been given access. Contact help@genome.edu.au if you think this is in error.
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/2.1.*:
     inherits: toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*
-    params:
-      docker_run_extra_arguments: --gpus all --env ALPHAFOLD_AA_LENGTH_MIN=5 --env
-        ALPHAFOLD_AA_LENGTH_MAX=3000 --env ALPHAFOLD_DB=/data/v2.1
+    context:
+      alphafold_db: /data/v2.1
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/2.3.*:
     inherits: toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*
-    params:
-      docker_run_extra_arguments: --gpus all --env ALPHAFOLD_AA_LENGTH_MIN=5 --env
-        ALPHAFOLD_AA_LENGTH_MAX=3000 --env ALPHAFOLD_DB=/data/v2.3
     rules:
     - if: |
         min_version = '2.3.1+galaxy2'
         helpers.tool_version_gte(tool, min_version)
-      params:
-        docker_run_extra_arguments: --gpus all --env ALPHAFOLD_AA_LENGTH_MIN=5 --env
-          ALPHAFOLD_AA_LENGTH_MAX=3000 --env ALPHAFOLD_DB=/data
+      context:
+        alphafold_db: /data
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
     context:
       test_cores: 10


### PR DESCRIPTION
Hi @neoformit, this should work to allow members of an extra group to run alphafold with bigger inputs. They would have to be members of the base 'Alphafold' group as well as 'Alphafold_plus' (or whatever name) and the new group would need to have an associated role. Pick whatever number is suitable for the aa length max in the new group.