### PR TITLE
scratch test2 object store ID

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml
@@ -34,7 +34,7 @@ users:
       context:
         partition: scratch_test
       params:
-        object_store_id: scratch_test
+        object_store_id: scratch_test2
       scheduling:
         require:
           - slurm

--- a/templates/galaxy/config/galaxy_object_store_conf.xml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.xml.j2
@@ -62,6 +62,10 @@
 
         <!-- test scratch server -->
         <backend id="scratch_test" type="disk" weight="0" store_by="id">
+            <files_dir path="/mnt/user-data-volA/scratch_test/first_test" />
+            <extra_dir type="job_work" path="/mnt/scratch/job_working_directory"/>
+        </backend> 
+        <backend id="scratch_test2" type="disk" weight="0" store_by="uuid">
             <files_dir path="/mnt/user-data-volA/scratch_test" />
             <extra_dir type="job_work" path="/mnt/scratch/job_working_directory"/>
         </backend> 


### PR DESCRIPTION
Add another zero-weight object store backend with `store_by="uuid"`. I'll keep the first one for comparison but I've moved it to a different path