### PR TITLE
singularity + pulsar for funannotate

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -76,6 +76,7 @@ destinations:
         - slurm
         - gtdbtk_database
         - bakta_database
+        - funannotate
   slurm-training:
     inherits: _slurm_destination
     runner: slurm
@@ -90,6 +91,7 @@ destinations:
         - slurm
         - gtdbtk_database
         - bakta_database
+        - funannotate
       require:
         - training
   interactive_pulsar:
@@ -233,6 +235,7 @@ destinations:
         - pulsar-nci-training
         - pulsar-blast # allow training jobs with require: pulsar-blast to run here
         - bakta_database
+        - funannotate
       require:
         - pulsar
         - training
@@ -264,6 +267,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-QLD
+        - funannotate
       require:
         - pulsar
         # - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1392,6 +1392,8 @@ tools:
     scheduling:
       accept:
         - pulsar
+      require:
+        - funannotate  # both funannotate dbs in /mnt/custom-indices on destination VM
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate_compare/funannotate_compare/.*:
     cores: 8
     mem: 40

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1386,6 +1386,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/.*:
     cores: 5
     mem: 19.1
+  toolshed.g2.bx.psu.edu/repos/iuc/funannotate.*:
+    params:
+      singularity_enabled: true  
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate_compare/funannotate_compare/.*:
     cores: 8
     mem: 40

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1388,7 +1388,10 @@ tools:
     mem: 19.1
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate.*:
     params:
-      singularity_enabled: true  
+      singularity_enabled: true
+    scheduling:
+      accept:
+        - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate_compare/funannotate_compare/.*:
     cores: 8
     mem: 40


### PR DESCRIPTION
At the moment only pulsar-QLD and pulsar-nci-training have to full set of funannotate reference data, so funannotate will only be allowed to run on slurm and these pulsars.