### PR TITLE
singularity enabled for snpeff

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2468,6 +2468,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/.*:
     cores: 3
     mem: 11.5
+  toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_get_chr_names/.*:
+    params:
+      singularity_enabled: false  # both installed versions pass tests without singularity enabled, fail 1/2 with singularity enabled
   toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_annotate/.*:
     cores: 3
     mem: 11.5

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2462,6 +2462,9 @@ tools:
     mem: 12
     params:
       singularity_enabled: true
+  toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff.*:
+    params:
+      singularity_enabled: true  
   toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/.*:
     cores: 3
     mem: 11.5


### PR DESCRIPTION
ok for all versions of most snpeff tools. One of the snpeff tools passes its tests with conda, fails jobs and tests with singularity.