### PR TITLE
dev destination params in advance

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -2,6 +2,10 @@ destinations:
   default:
     runner: slurm # abstract: this runner will be overridden
     abstract: true
+    params:
+      tpv_cores: '{cores}'
+      tpv_gpus: '{gpus}'
+      tpv_mem: '{mem}'
     # having rules on default abstract dest then rules on descendant abstract dest seems to prevent the descendant rules from applying
     # rules:
     #   - id: default_destination_singularity_rule


### PR DESCRIPTION
add tpv_cores, tpv_mem and tpv_gpus to params in dev default destination. This will become part of the default destination in shared db, this change is useful in order to start writing queries using these values