### PR TITLE
Add prefer score to tpv ranking

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -64,6 +64,22 @@ tools:
                   }
               db_queue_info[destination_id][state] = {'sum_cores': sum_cores, 'sum_mem': sum_mem, 'job_count': count_id}
 
+          def score_preferred(dest, ent):
+              """
+              Computes a compatibility score between tag sets based only on a 'prefer' tag in one matching a positive tag in the other.
+              :param ent:
+              :return:
+              """
+              def a_prefers_b(a_tags, b_tags):
+                  return any(
+                    tag for tag in a_tags.filter(tag_type = TagType.PREFER)
+                    if list(b_tags.filter(tag_type = [TagType.ACCEPT, TagType.PREFER, TagType.REQUIRE], tag_value = tag.value))
+                  )
+              dest_tags = dest.tpv_dest_tags
+              ent_tags = ent.tpv_tags
+              score = 1 if a_prefers_b(dest_tags, ent_tags) or a_prefers_b(ent_tags, dest_tags) else 0
+              return score
+
           def destination_usage_proportion(destination):
             if not destination.context.get('destination_total_mem') or not destination.context.get('destination_total_cores'):
               raise Exception(f"++ ---tpv rank debug: At least one of destination_total_mem, destination_total_cores is unavailable")
@@ -90,7 +106,7 @@ tools:
 
           # New ranking method: consider memory use at destination as well as CPU use
           # Sort destinations by the number of jobs with these values of entity cores/mem that would be able to run there
-          candidate_destinations.sort(key=lambda d: (-1 * destination_availability_score(d), random.randint(0,9)))
+          candidate_destinations.sort(key=lambda d: (-1 * score_preferred(d, entity), -1 * destination_availability_score(d), random.randint(0,9)))
 
           final_destinations = candidate_destinations
           log.info(f"++ ---tpv rank debug: destinations ranked: {[d.id for d in final_destinations]}")

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -24,7 +24,7 @@ tools:
     cores: 8
     mem: 30.7
     scheduling:
-      prefer:
+      accept:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/bebatut/cdhit/cd_hit_est/.*:
     cores: 4
@@ -959,7 +959,7 @@ tools:
     params:
       singularity_enabled: true
     scheduling:
-      prefer:
+      accept:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/smudgeplot/smudgeplot/.*:
     cores: 8
@@ -1116,9 +1116,6 @@ tools:
       if: input_size < 0.005
       cores: 1
       mem: 3.8
-      scheduling:
-        prefer:
-        - slurm
     - id: abricate_medium_input_rule
       if: 0.005 <= input_size < 0.02
       cores: 4
@@ -1527,7 +1524,7 @@ tools:
     params:
       singularity_enabled: true
     scheduling:
-      prefer:
+      accept:
         - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/hybpiper/hybpiper/.*:
     params:
@@ -1568,8 +1565,6 @@ tools:
     cores: 8
     mem: 30.7
     scheduling:
-      prefer:
-      - pulsar-paw
       accept:
       - pulsar
       - pulsar-quick
@@ -1577,8 +1572,6 @@ tools:
     cores: 8
     mem: 30.7
     scheduling:
-      prefer:
-      - pulsar-paw
       accept:
       - pulsar
       - pulsar-quick
@@ -1586,8 +1579,6 @@ tools:
     cores: 8
     mem: 30.7
     scheduling:
-      prefer:
-      - pulsar-paw
       accept:
       - pulsar
       - pulsar-quick
@@ -1679,8 +1670,6 @@ tools:
     cores: 4
     mem: 15.3
     scheduling:
-      prefer:
-      - pulsar-paw
       accept:
       - pulsar
       - pulsar-quick
@@ -1691,8 +1680,6 @@ tools:
     cores: 4
     mem: 15.3
     scheduling:
-      prefer:
-      - pulsar-paw
       accept:
       - pulsar
       - pulsar-quick
@@ -3057,7 +3044,7 @@ tools:
     cores: 8
     mem: 30.7
     scheduling:
-      prefer:
+      accept:
       - pulsar
     rules:
     - id: rbc_mafft_fail_rule


### PR DESCRIPTION
Add a function to TPV ranking that ranks destination A ahead of destination B only when the tool and destination A have a common 'prefer' category tag.

Also remove all prefer: pulsar tags from tools.yml with a view to adding them automatically later on.