### PR TITLE
remove pulsar score entry for funannotate_sort

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tool_pulsar_scores.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tool_pulsar_scores.yml
@@ -437,9 +437,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate_predict/funannotate_predict/*:
     context:
       pulsar_score: 10.418343
-  toolshed.g2.bx.psu.edu/repos/iuc/funannotate_sort/funannotate_sort/*:
-    context:
-      pulsar_score: 0.090799
+  #toolshed.g2.bx.psu.edu/repos/iuc/funannotate_sort/funannotate_sort/*:
+  #  context:
+  #    pulsar_score: 0.090799
   toolshed.g2.bx.psu.edu/repos/iuc/gecko/gecko/*:
     context:
       pulsar_score: 1.777701


### PR DESCRIPTION
something in new default tool rules is causing an illegal comparison between an int and a string, only for funannotate_sort