### PR TITLE
fixes to pulsar-qld-gpu playbook and nvidia-ctk role

### DIFF
--- a/pulsar-qld-gpu_playbook.yml
+++ b/pulsar-qld-gpu_playbook.yml
@@ -10,7 +10,7 @@
   pre_tasks:
     - name: ensure Nvidia GPU has been pre-configured with one-offs/initial_nvidia_config_and_disable_cgroups_v2_playbook.yml
       shell:
-        cmd: nvidia-detector
+        cmd: nvidia-smi
       register: nvidia_card
       failed_when: nvidia_card.rc != 0
     - name: Attach volume to instance

--- a/roles/nvidia-ctk/defaults/main.yml
+++ b/roles/nvidia-ctk/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 nvidia_ctk_apt_gpg_key_url: https://nvidia.github.io/libnvidia-container/gpgkey
-nvidia_ctk_apt_gpg_key_dest: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-nvidia_ctk_apt_repository: "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /"
-nvidia_ctk_apt_filename: nvidia-container-toolkit.list
+nvidia_ctk_apt_gpg_key_dest: /usr/share/keyrings/nvidia-container-toolkit-keyring.asc
+nvidia_ctk_apt_repo_url: "https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH)"
+nvidia_ctk_apt_repository: "deb [signed-by={{ nvidia_ctk_apt_gpg_key_dest }}] {{ nvidia_ctk_apt_repo_url }} /"
+nvidia_ctk_apt_filename: nvidia-container-toolkit
 

--- a/roles/nvidia-ctk/tasks/main.yml
+++ b/roles/nvidia-ctk/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Add nvidia-container-toolkit apt key.
   ansible.builtin.get_url:
     url: "{{ nvidia_ctk_apt_gpg_key_url }}"
-    dest: /etc/apt/keyrings/nvidia-ctk-keyring.gpg
+    dest: "{{ nvidia_ctk_apt_gpg_key_dest }}"
     mode: '0644'
     force: false
   register: add_repository_key


### PR DESCRIPTION
`nvidia-detector` only tested if nvidia GPU present, changed to using `nvidia-smi `which will fail of the one-offs hasn't been run.
`nvidia-ctk` role fixed - need to use a .asc extension rather than .gpg for repo key, this means that don't need to add an additional gpg dearmor step.
