### PR TITLE
Update lab urls with new exported lab pages

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -356,7 +356,7 @@ galaxy_subsite_dir: /mnt/galaxy/subsites
 galaxy_subsites:
   - name: genome
     brand: Genome lab
-    iframe: "https://dev-site.gvl.org.au/landing/genome"
+    iframe: "https://dev-site.gvl.org.au/lab/export?content_root=https://dev-site.gvl.org.au/static/home/labs/genome/main.yml"
     # If wallpaper is true, then files/subsites/{name}.png will be copied to
     # /static/dist/{name}.png, and can be used exactly like that in the CSS.
     wallpaper: false
@@ -382,7 +382,7 @@ galaxy_subsites:
       }
   - name: proteomics
     brand: Proteomics lab
-    iframe: "https://site.usegalaxy.org.au/landing/proteomics"
+    iframe: "https://dev-site.gvl.org.au/lab/export?content_root=https://dev-site.gvl.org.au/static/home/labs/proteomics/main.yml"
     wallpaper: false
     tool_sections: []
     custom_css: |

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -611,7 +611,7 @@ galaxy_subsite_dir: /mnt/galaxy/subsites
 galaxy_subsites:
   - name: genome
     brand: Genome Lab
-    iframe: "https://site.usegalaxy.org.au/landing/genome"
+    iframe: "https://site.usegalaxy.org.au/lab/export?content_root=https://site.usegalaxy.org.au/static/home/labs/genome/main.yml"
     wallpaper: false # If wallpaper is true, then files/subsites/{name}.png will be copied to /static/dist/{name}.png, and can be used exactly like that in the CSS.
     tool_sections: []
     custom_css: |
@@ -630,7 +630,7 @@ galaxy_subsites:
   - name: proteomics
     hidden: true
     brand: Proteomics lab
-    iframe: "https://site.usegalaxy.org.au/landing/proteomics"
+    iframe: "https://site.usegalaxy.org.au/lab/export?content_root=https://site.usegalaxy.org.au/static/home/labs/proteomics/main.yml"
     wallpaper: false # If wallpaper is true, then files/subsites/{name}.png will be copied to /static/dist/{name}.png, and can be used exactly like that in the CSS.
     tool_sections: []
     custom_css: |

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -239,7 +239,7 @@ galaxy_subsite_dir: /mnt/galaxy/subsites
 galaxy_subsites:
   - name: genome
     brand: Genome Lab
-    iframe: "https://site.usegalaxy.org.au/landing/genome"
+    iframe: "https://site.usegalaxy.org.au/lab/export?content_root=https://site.usegalaxy.org.au/static/home/labs/genome/main.yml"
     wallpaper: false # If wallpaper is true, then files/subsites/{name}.png will be copied to /static/dist/{name}.png, and can be used exactly like that in the CSS.
     tool_sections: []
     custom_css: |
@@ -258,7 +258,7 @@ galaxy_subsites:
   - name: proteomics
     hidden: true
     brand: Proteomics lab
-    iframe: "https://site.usegalaxy.org.au/landing/proteomics"
+    iframe: "https://site.usegalaxy.org.au/lab/export?content_root=https://site.usegalaxy.org.au/static/home/labs/proteomics/main.yml"
     wallpaper: false # If wallpaper is true, then files/subsites/{name}.png will be copied to /static/dist/{name}.png, and can be used exactly like that in the CSS.
     tool_sections: []
     custom_css: |


### PR DESCRIPTION
Replace old lab landing page iframe URLs with new exported lab URLs:

https://site.usegalaxy.org.au/lab/export?content_root=https://site.usegalaxy.org.au/static/home/labs/genome/main.yml
https://site.usegalaxy.org.au/lab/export?content_root=https://site.usegalaxy.org.au/static/home/labs/proteomics/main.yml

The old pages at `/landing/<labname>` are no longer maintained and will be taken down soon.