### PR TITLE
change pulsar-qld-gpu limits for testing

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -528,37 +528,22 @@ job_conf_limits:
   - type: destination_total_concurrent_jobs
     id: pulsar-azure-gpu
     value: 8
-  - type: destination_user_concurrent_jobs
-    id: pulsar-azure-gpu
-    value: 2
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-gpu1
     value: 6
-  - type: destination_user_concurrent_jobs
-    id: pulsar-qld-gpu1
-    value: 3
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-gpu2
     value: 6
-  - type: destination_user_concurrent_jobs
-    id: pulsar-qld-gpu2
-    value: 3
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-gpu3
     value: 6
-  - type: destination_user_concurrent_jobs
-    id: pulsar-qld-gpu3
-    value: 3
 
   - type: destination_total_concurrent_jobs
     id: pulsar-qld-gpu4
     value: 6
-  - type: destination_user_concurrent_jobs
-    id: pulsar-qld-gpu4
-    value: 3
 
 # Singularity and docker volumes
 slurm_singularity_volumes_list:

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -432,16 +432,16 @@ job_conf_limits:
       - registered_user_concurrent_jobs_10
     pulsar-qld-gpu1:
       tags:
-      - registered_user_concurrent_jobs_10
+      - registered_user_concurrent_jobs_25
     pulsar-qld-gpu2:
       tags:
-      - registered_user_concurrent_jobs_10
+      - registered_user_concurrent_jobs_25
     pulsar-qld-gpu3:
       tags:
-      - registered_user_concurrent_jobs_10
+      - registered_user_concurrent_jobs_25
     pulsar-qld-gpu4:
       tags:
-      - registered_user_concurrent_jobs_10
+      - registered_user_concurrent_jobs_25
   limits:
   - type: anonymous_user_concurrent_jobs
     value: 1


### PR DESCRIPTION
Initial testing on pulsar-qld-gpu 1-4: change `registered_user_concurrent_jobs_10` to `registered_user_concurrent_jobs_25` leaving `destination_user_concurrent_jobs` untouched for later stress testing.
