### PR TITLE
Test dorado on prod

### DIFF
--- a/files/galaxy/config/local_tool_conf.xml
+++ b/files/galaxy/config/local_tool_conf.xml
@@ -3,6 +3,8 @@
     <section id="local_tools" name="Local Tools">
         <!-- <tool file="galaxy-local-tools/tools/canu/canu.xml" labels="test"/> -->
         <tool file="/mnt/galaxy/local_tools/alphafold-test/alphafold.xml" labels="test"/>
+        <tool file="/mnt/galaxy/local_tools/dorado/dorado.xml" labels="test"/>
+        <tool file="/mnt/galaxy/local_tools/dorado/dorado_pod5_convert.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/gtdbtk/gtdbtk_classify_wf.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/fgenesh/fgenesh.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/fgenesh/fgenesh_annotate.xml" labels="test"/>

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3343,3 +3343,15 @@ tools:
         require:
         - pulsar
         - pulsar-azure-1-gpu
+  dorado:
+    cores: 8
+    mem: 69
+    gpus: 1
+    params:
+      singularity_enabled: true
+      singularity_run_extra_arguments: --nv
+    scheduling:
+      accept:
+      - pulsar
+      require:
+      - pulsar-qld-gpu


### PR DESCRIPTION
The dorado wrapper is ready to go onto production with a test label.

I'm trying to send jobs to the new GPU runners.

I've put the wrapper at /mnt/galaxy/local_tools/dorado.