### PR TITLE
Add dorado_models loc file

### DIFF
--- a/files/galaxy/config/tool_data_table_conf.xml
+++ b/files/galaxy/config/tool_data_table_conf.xml
@@ -1,4 +1,9 @@
 <tables>
+    <!-- Dorado test  -->
+    <table name="dorado_models" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, container_hash, name, path</columns>
+        <file path="/mnt/tools/tool-data/dorado_models.loc" />
+    </table>
     <!-- FGENESH  -->
     <table name="fgenesh_db" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>


### PR DESCRIPTION
This is currently at `/mnt/galaxy/local_tools/dorado/tool-data/dorado_models.loc.sample`, so someone with sudo would also need to cp it to `/mnt/tools/tool-data/dorado_models.loc`