### PR TITLE
Update anndata import rule

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1142,7 +1142,7 @@ tools:
       accept:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/.*:
-    mem: 2 + input_size * 7
+    mem: 2 + (input_size * 7)
     scheduling:
       accept:
         - pulsar  


### PR DESCRIPTION
add parentheses to expression though these should be redundant. anndata_import job has run with far too little memory (277m), the lowest value possible ought to be 2gb