### PR TITLE
Remove test dorado

### DIFF
--- a/files/galaxy/config/local_tool_conf.xml
+++ b/files/galaxy/config/local_tool_conf.xml
@@ -3,8 +3,6 @@
     <section id="local_tools" name="Local Tools">
         <!-- <tool file="galaxy-local-tools/tools/canu/canu.xml" labels="test"/> -->
         <tool file="/mnt/galaxy/local_tools/alphafold-test/alphafold.xml" labels="test"/>
-        <tool file="/mnt/galaxy/local_tools/dorado/dorado.xml" labels="test"/>
-        <tool file="/mnt/galaxy/local_tools/dorado/dorado_pod5_convert.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/gtdbtk/gtdbtk_classify_wf.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/fgenesh/fgenesh.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/fgenesh/fgenesh_annotate.xml" labels="test"/>

--- a/files/galaxy/config/tool_data_table_conf.xml
+++ b/files/galaxy/config/tool_data_table_conf.xml
@@ -1,9 +1,4 @@
 <tables>
-    <!-- Dorado test  -->
-    <table name="dorado_models" comment_char="#" allow_duplicate_entries="False">
-        <columns>value, container_hash, name, path</columns>
-        <file path="/mnt/tools/tool-data/dorado_models.loc" />
-    </table>
     <!-- FGENESH  -->
     <table name="fgenesh_db" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3344,7 +3344,7 @@ tools:
         require:
         - pulsar
         - pulsar-azure-1-gpu
-  dorado:
+  toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/.*:
     cores: 8
     mem: 69
     gpus: 1

--- a/jenkins/update_labels/tool_labels.yml
+++ b/jenkins/update_labels/tool_labels.yml
@@ -8,6 +8,7 @@ deprecated:
 - toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/*
 test:
 - toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/*
+- toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/*
 training-only:
 - toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvet/*
 - toolshed.g2.bx.psu.edu/repos/devteam/velvet/velvetg/*


### PR DESCRIPTION
Dorado's been tested and I've put it on the toolshed so we can remove it from local_tools.

I'm not sure if the change to `files/galaxy/config/tool_data_table_conf.xml` is necessary. If it's not we don't need commit 95eeb9d2e6b5d13faa8eab8afd4b96f53eb13cb1.

If the loc files need to be removed from `/mnt/tools/tool-data/`   someone with sudo would have to do that too.

Thanks!