### PR TITLE
Add walle to requirements + dev

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -80,3 +80,5 @@ roles:
 - name: geerlingguy.redis
   version: 1.8.0
 
+- name: usegalaxy_eu.walle  # TODO: ALPHEBATISE THIS FILE IT IS HARD TO READ
+  version: 0.0.2


### PR DESCRIPTION
This is a draft. All that it does so far is add the [walle ansible role](https://github.com/usegalaxy-eu/WallE) to requirements.yml.  This role, developed by Mira of Galaxy Europe, will help defend interactive tools from misuse