### PR TITLE
Update hifiasm memory rules, add rule for very large input

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -211,8 +211,14 @@ tools:
     rules:
     - id: hifiasm_small_input_rule
       if: input_size < 0.2
-      cores: 2
-      mem: 7.6
+      cores: 4
+      mem: 15.3
+    - id: hifiasm_xlarge_input_rule
+      if: input_size > 200
+      mem: 1922
+      scheduling:
+        require:
+        - pulsar-high-mem1
   toolshed.g2.bx.psu.edu/repos/bgruening/interproscan/interproscan/.*:
     context:
       max_concurrent_job_count_for_tool_user: 3


### PR DESCRIPTION
Add a rule for > 200GB input, to run with higher memory (2TB) on pulsar-high-mem1 since that VM has more memory per CPU than the others