### PR TITLE
create one-offs ubuntu system updates playbook

### DIFF
--- a/one-offs/ubuntu-updates_playbook.yml
+++ b/one-offs/ubuntu-updates_playbook.yml
@@ -1,0 +1,9 @@
+- hosts: all
+  become: true
+  tasks:
+  - name: Update the Ubuntu apt repositories and base OS
+    apt:
+      upgrade: dist
+      update_cache: yes
+      force_apt_get: yes
+


### PR DESCRIPTION
To address OpenSSH vulnerability [CVE-2024-6387](https://ubuntu.com/security/notices/USN-6859-1)