### PR TITLE
set pulsar-qld-high-mem0 offline for hypervisor maintenance

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -191,6 +191,7 @@ destinations:
         - pulsar-qld-high-mem0
       require:
         - pulsar
+        - offline
   pulsar-qld-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem1_runner


### PR DESCRIPTION
Underlying hypervisor has developed a hardware fault. Taking offline for maintenance.