### PR TITLE
writable-tmpfs for braker?

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1094,6 +1094,7 @@ tools:
     params:
       singularity_container_id_override: docker://teambraker/braker3:v1.0.6
       singularity_enabled: true
+      singularity_run_extra_arguments: --writable-tmpfs
     scheduling:
       require:
       - pulsar


### PR DESCRIPTION
I have braker3 failing when I re-run a job that previously succeeded. Not sure if this will fix it. Error is

```
ERROR in file /opt/BRAKER/scripts/braker.pl at line 5893
Failed to create new species with new_species.pl, check write permissions in /usr/share/augustus/config//species directory! Command was /usr/bin/perl /usr/share/augustus/scripts/new_species.pl --species=cladocopium_goreaui --AUGUSTUS_CONFIG_PATH=/usr/share/augustus/config/ 1> /dev/null 2>/mnt/pulsar/files/staging/9192576/working/braker/errors/new_species.stderr
```

### failed job

`a6e389a98c2d167882357d636876289a (21677419)`

### successful job

`a6e389a98c2d16788e014074d44a804a (19931009)`