### PR TITLE
Fix proteomics lab tool panel

### DIFF
--- a/files/galaxy/config/tool_panel_filters/proteomics.yml
+++ b/files/galaxy/config/tool_panel_filters/proteomics.yml
@@ -1,7 +1,18 @@
-name: Proteomics toolbox
+name: Proteomics
 id: proteomics
 type: activity
 items:
+- id: general_section
+  text: General Tools
+  type: label
+- sections:
+  - getext
+  - send
+  - collection_operations
+  - plots
+  - textutil
+  - filter
+  - group
 - type: label
   text: Proteomics
 - type: section

--- a/files/galaxy/config/tool_panel_filters/proteomics.yml
+++ b/files/galaxy/config/tool_panel_filters/proteomics.yml
@@ -13,7 +13,8 @@ items:
   - textutil
   - filter
   - group
-- type: label
+- id: proteomics_section
+  type: label
   text: Proteomics
 - type: section
   id: databases

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -78,6 +78,8 @@ host_galaxy_config_files:
     dest: "{{ galaxy_config_dir }}/mail/activation-email.html"
   - src: "{{ galaxy_config_file_src_dir }}/config/activation-email.txt"
     dest: "{{ galaxy_config_dir }}/mail/activation-email.txt"
+  - src: "{{ galaxy_config_file_src_dir }}/config/tool_panel_filters/proteomics.yml"
+    dest: "{{ galaxy_config_dir }}/tool_panel_filters/proteomics.yml"
 
 host_galaxy_config_templates:
   - src: "{{ galaxy_config_template_src_dir }}/config/galaxy_object_store_conf.xml.j2"
@@ -180,6 +182,15 @@ host_galaxy_config: # renamed from __galaxy_config
 
     user_activation_on: true
     activation_email: <activation-noreply@usegalaxy.org.au>
+
+    # Panel views / themes
+    panel_views_dir: "{{ galaxy_config_dir }}/tool_panel_filters"
+    default_panel_view_by_host:
+      proteomics.usegalaxy.org.au: proteomics
+    themes_config_file_by_host:
+      genome.usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_genome.yml"
+      proteomics.usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_proteomics.yml"
+      usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_main.yml"
 
     sentry_dsn: "{{ vault_sentry_url_galaxy_production }}"
     log_level: INFO

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -75,6 +75,8 @@ host_galaxy_config_files:
     dest: "{{ galaxy_config_dir}}/oidc_config.xml"
   - src: "{{ galaxy_config_file_src_dir }}/config/trs_servers_conf.yml"
     dest: "{{ galaxy_config_dir }}/trs_servers_conf.yml"
+  - src: "{{ galaxy_config_file_src_dir }}/config/tool_panel_filters/proteomics.yml"
+    dest: "{{ galaxy_config_dir }}/tool_panel_filters/proteomics.yml"
 
 galaxy_handler_count: 2 ############# europe uses 5, this could be host specific
 
@@ -149,6 +151,11 @@ host_galaxy_config: # renamed from __galaxy_config
     # For subdomains
     tool_section_filters: global_host_filters:per_host_tool_sections
     tool_label_filters: global_host_filters:per_host_tool_labels
+
+    # Panel views / themes
+    panel_views_dir: "{{ galaxy_config_dir }}/tool_panel_filters"
+    default_panel_view_by_host:
+      proteomics.staging.gvl.org.au: proteomics
     themes_config_file_by_host:
       genome.staging.gvl.org.au: "{{ galaxy_config_dir }}/themes/themes_genome.yml"
       proteomics.staging.gvl.org.au: "{{ galaxy_config_dir }}/themes/themes_proteomics.yml"


### PR DESCRIPTION
- Add proteomics tool panel view to staging/prod
- Minor tweaks to tool panel view for proteomics lab

FYI there still seems to be issues with panel_views. The fundamentals work, I can select the "Proteomics" toolbox on https://proteomics.dev.gvl.org.au and the tool panel changes.

Sections from default panel are displayed correctly:

```yml
- sections:
  - getext
  - send
  - ...
```

But none of the custom labels/sections are displayed:

```yml
- id: proteomics_section
  type: label
  text: Proteomics
- type: section
  id: databases
  name: Databases
  items:
    - type: tool
      id: toolshed.g2.bx.psu.edu/repos/galaxyp/custom_pro_db/custom_pro_db
```

I'm unsure if this is something to do with dev, but this PR will let us see if it's working on Staging/Prod.
These features all seems to be working on https://singlecell.usegalaxy.org.
I don't think it's because the tools are missing on dev, because I tried with a tool_id that is installed on dev.