### PR TITLE
remove repetition of themes_by_host in host_vars/galaxy

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -208,11 +208,6 @@ host_galaxy_config: # renamed from __galaxy_config
     # https://docs.galaxyproject.org/en/master/admin/production.html
     enable_celery_tasks: true
 
-    themes_config_file_by_host:
-      genome.usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_genome.yml"
-      proteomics.usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_proteomics.yml"
-      usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_main.yml"
-
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 


### PR DESCRIPTION
Same block on line 190 of this file. Ansible ran with this hosts file without issue, but vscode is protesting.