### PR TITLE
Pin fs.dropboxfs on our side

### DIFF
--- a/dev-handler_playbook.yml
+++ b/dev-handler_playbook.yml
@@ -43,8 +43,6 @@
       become: true
       become_user: galaxy
     # - usegalaxy_eu.galaxy_systemd
-    - nginx-upload-module # depends on nginx conf file, why does this go before nginx?
-    - galaxyproject.nginx
     - galaxyproject.tusd
     - galaxyproject.slurm
     # - galaxyproject.s3fs

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -129,7 +129,7 @@ galaxy_extra_privsep_dirs:
   - "{{ galaxy_config_dir }}/tool_panel_filters"
   - "{{ galaxy_config_dir }}/themes"
 
-tpv_version: "2.3.2"
+tpv_version: "2.4.0"
 
 tpv_packages: |
   {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
@@ -138,6 +138,7 @@ additional_packages:
   - redis
   - flower
   - watchdog==2.2.1
+  - fs.dropboxfs==1.0.1  # (latest version requires python 3.11)
 
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 


### PR DESCRIPTION
the latest fs.dropboxfs is version 1.0.4 and needs python3.11.
galaxy pins it to be at version >1.  version 1.0.1 is ok.

Also update tpv version to 2.4.0