### PR TITLE
exclude pulsar-qld-gpu-dev from pulsar-qld-gpu playbook

### DIFF
--- a/pulsar-qld-gpu_playbook.yml
+++ b/pulsar-qld-gpu_playbook.yml
@@ -1,4 +1,4 @@
-- hosts: pulsar_qld_gpus
+- hosts: pulsar_qld_gpus:!pulsar-qld-gpu-dev
   become: true
   vars_files:
     - group_vars/all.yml


### PR DESCRIPTION
exclude pulsar-qld-gpu-dev from pulsar-qld-gpu_playbook as it is a member of pulsar_qld_gpus but has its own playbook to give devs sudo