### PR TITLE
correct mount path of updated alphafold DBs on pulsar-qld-gpus

### DIFF
--- a/group_vars/pulsar_qld_gpus.yml
+++ b/group_vars/pulsar_qld_gpus.yml
@@ -12,7 +12,7 @@ shared_mounts:
     fstype: nfs
     state: mounted
   - src: "{{ hostvars['qld-ref-nfs'].ansible_ssh_host }}:/mnt/vdc/alphafold"
-    path: /data2/alphafold/2.3
+    path: /data2/alphafold
     fstype: nfs
     state: mounted
 


### PR DESCRIPTION
Fixing issue raised by @neoformit whereby current mount results in the wrong path to Alphafold database `/data2/alphafold/2.3/2.3/<dbs>` when it should be `/data2/alphafold/2.3/<dbs>`.

