### PR TITLE
galaxy singularity common cache

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -85,7 +85,7 @@ nginx_upload_module_url: https://swift.rc.nectar.org.au/v1/AUTH_377/galaxy_infra
 miniconda_prefix: "{{ galaxy_conda_prefix }}"
 
 # singularity cache of galaxy user (this defaults to /home/galaxy/.singularity). Not to be confused with cache directory for built sif files in galaxy_config.galaxy.container_resolvers_conf
-galaxy_user_singularity_cachedir: /mnt/singularity_data
+galaxy_user_singularity_cachedir: "{{ galaxy_tools_indices_dir }}/singularity_data"
 galaxy_user_singularity_tmpdir: "{{ galaxy_user_singularity_cachedir }}/tmp"
 
 # Galaxy

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -40,10 +40,6 @@ nginx_ssl_servers:
 #gie proxy hostname
 interactive_tools_server_name: "{{ hostname }}"
 
-# singularity cache of galaxy user (overridden from galaxyservers entry)
-galaxy_user_singularity_cachedir: /mnt/galaxy/singularity_data
-galaxy_user_singularity_tmpdir: "{{ galaxy_user_singularity_cachedir }}/tmp"
-
 galaxy_db_user_password: "{{ vault_dev_db_user_password }}"
 
 # ansible-galaxy

--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -21,10 +21,6 @@ galaxy_mount:
 
 shared_mounts: "{{ galaxy_mount + galaxy_server_and_worker_shared_mounts }}"
 
-# singularity cache of galaxy user (this defaults to /home/galaxy/.singularity). Not to be confused with cache directory for built sif files in galaxy_config.galaxy.container_resolvers_conf
-galaxy_user_singularity_cachedir: /pvol/singularity_data
-galaxy_user_singularity_tmpdir: "{{ galaxy_user_singularity_cachedir }}/tmp"
-
 galaxy_config_file: /opt/galaxy/galaxy.yml
 
 # galaxy role applied to dev-handlers machine is only needed for gravity and the galaxy config files. Skip other tasks


### PR DESCRIPTION
To fix the issue when the first run of a tool fails after the container has been auto fetched. SINGULARITY_CACHEDIR needs to be off the root disk and the path needs to exist on the workers so it may as well be common. On production galaxy it will be /mnt/tools/singularity_data.

This change will improve the tool installation process and make it easier to mark existing tools as singularity enabled.

[EDIT] I mistakenly wrote /mnt/galaxy/singularity_data