### PR TITLE
use production alphafold DBs on pulsar-qld-gpus

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -192,7 +192,7 @@ destinations:
     rules:
       - id: pulsar_destination_docker_rule
         params:
-            docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
+            docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold:/data:ro
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3258,7 +3258,7 @@ tools:
     params:
       docker_enabled: true
       docker_volumes:
-        $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
+        $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold:/data:ro
       docker_run_extra_arguments: --gpus all --env ALPHAFOLD_AA_LENGTH_MIN=16 --env
         ALPHAFOLD_AA_LENGTH_MAX=3000 --env ALPHAFOLD_DB={alphafold_db}
       tmp_dir: true

--- a/group_vars/pulsar_qld_gpus.yml
+++ b/group_vars/pulsar_qld_gpus.yml
@@ -7,11 +7,7 @@ attached_volumes:
     fstype: ext4
 
 shared_mounts:
-  - src: "{{ hostvars['qld-ref-nfs'].ansible_ssh_host }}:/mnt/vdb/alphafold_db"
-    path: /data/alphafold_databases/2.3
-    fstype: nfs
-    state: mounted
-  - src: "{{ hostvars['qld-ref-nfs'].ansible_ssh_host }}:/mnt/vdc/alphafold"
+  - src: "{{ hostvars['qld-ref-nfs'].ansible_ssh_host }}:/mnt/prod/alphafold"
     path: /data2/alphafold
     fstype: nfs
     state: mounted


### PR DESCRIPTION
@neoformit has consolidated the AF2 DBs to a single new volume. These changes replace the existing Alphafold Database mounts with a single 'production' alphafold database mount.
