### PR TITLE
Fix _pulsar_qld_gpu destination alphafold docker volumes

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -342,7 +342,7 @@ destinations:
     rules:
       - id: pulsar_destination_docker_rule
         params:
-            docker_volumes: $job_directory:ro,$job_directory/home:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold_databases:/data:ro
+            docker_volumes: $job_directory:ro,$job_directory/home:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold:/data:ro
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false


### PR DESCRIPTION
Fix the destination docker volume for new prod AF DBs

`/data/alphafold_databases` -> `/data/alphafold`