### PR TITLE
Remove alphafold_db_test rule

### DIFF
--- a/files/galaxy/config/local_tool_conf.xml
+++ b/files/galaxy/config/local_tool_conf.xml
@@ -12,7 +12,6 @@
         <tool file="/mnt/galaxy/local_tools/fgenesh/fgenesh_get_proteins.xml" label="test"/>
         <tool file="/mnt/galaxy/local_tools/cellranger/cellranger.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/alphafold/alphafold.xml" labels="test"/>
-        <tool file="/mnt/galaxy/local_tools/alphafold/alphafold_test_2.xml" labels="test"/>
     </section>
     <section id="interactivetools" name="Interactive Tools">
 	<tool file="/mnt/galaxy/local_tools/interactive_tool/lfq/interactivetool_lfqanalyst.xml" />

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -346,10 +346,6 @@ destinations:
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false
-      - id: pulsar_destination_docker_af_db_test_rule
-        params:
-            docker_volumes: $job_directory:ro,$job_directory/home:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data2/alphafold:/data:ro
-        if: entity.context.get('alphafold_db_test')
   pulsar-qld-gpu1:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu1_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3206,9 +3206,6 @@ tools:
       require:
       - pulsar
       - pulsar-qld-gpu
-  alphafold_test_2:
-    context:
-      alphafold_db_test: true
 
   cellranger:
     cores: 6


### PR DESCRIPTION
This is redundant now. Will also remove `alphafold_test_2` tool which was for testing the AF DBs mounted at `/data2/`.