### PR TITLE
use qld pulsars for alphafold

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -284,6 +284,7 @@ destinations:
       require:
         - pulsar
         - pulsar-azure
+        - offline
   pulsar-azure-gpu:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner
@@ -298,6 +299,7 @@ destinations:
       require:
         - pulsar
         - pulsar-azure-gpu
+        - offline
     rules:
       - id: pulsar_destination_docker_rule
         params:
@@ -319,6 +321,7 @@ destinations:
       require:
         - pulsar
         - pulsar-azure-1-gpu
+        - offline
     rules:
       - id: pulsar_destination_docker_rule
         params:
@@ -352,28 +355,33 @@ destinations:
     scheduling:
       accept:
         - pulsar-qld-gpu1
+        - pulsar-qld-gpu-alphafold
   pulsar-qld-gpu2:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu2_runner
     scheduling:
       accept:
         - pulsar-qld-gpu2
+        - pulsar-qld-gpu-alphafold
   pulsar-qld-gpu3:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu3_runner
     scheduling:
       accept:
         - pulsar-qld-gpu3
+        - pulsar-qld-gpu-alphafold
   pulsar-qld-gpu4:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu4_runner
     scheduling:
       accept:
         - pulsar-qld-gpu4
+        - pulsar-qld-gpu-other
   pulsar-qld-gpu5:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu5_runner
     scheduling:
       accept:
         - pulsar-qld-gpu5
+        - pulsar-qld-gpu-other
 

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -892,9 +892,10 @@ tools:
       alphafold_aa_length_max: 3000
       alphafold_max_input_sequences: 10
       alphafold_db: /data/v2.3
+      max_concurrent_job_count_for_tool_user: 2
     gpus: 1
-    cores: 8
-    mem: 69
+    cores: 16
+    mem: 130
     params:
       docker_enabled: true
       docker_volumes: 
@@ -910,24 +911,13 @@ tools:
         alphafold_max_input_sequences: 20
     - if: |
         user_roles = [role.name for role in user.all_roles() if not role.deleted]
-        user and 'Alphafold' in user_roles and not 'UoM_Vet_Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles
-      context:
-        partition: azuregpu0
+        user and 'Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles
       scheduling:
         require:
         - pulsar
-        - pulsar-azure-gpu
+        - pulsar-qld-gpu-alphafold
         accept:
         - training-exempt
-    - if: |
-        user_roles = [role.name for role in user.all_roles() if not role.deleted]
-        user and 'UoM_Vet_Alphafold' in user_roles
-      context:
-        partition: azuregpu1
-      scheduling:
-        require:
-        - pulsar
-        - pulsar-azure-1-gpu
     - if: |
         user_roles = [role.name for role in user.all_roles() if not role.deleted]
         user.username in [f'qldgpu{x+1}' for x in range(6)] or 'pulsar_gpu_test' in user_roles
@@ -935,7 +925,7 @@ tools:
         accept:
         - pulsar
         require:
-        - pulsar-qld-gpu
+        - pulsar-qld-gpu-alphafold
     - if: |
         not user or not any([
           role for role in user.all_roles() if (
@@ -3256,8 +3246,8 @@ tools:
   alphafold_test.*:
     context:
       alphafold_db: /data
-    cores: 8
-    mem: 69
+    cores: 16
+    mem: 130
     params:
       docker_enabled: true
       docker_volumes:
@@ -3413,7 +3403,7 @@ tools:
       accept:
       - pulsar
       require:
-      - pulsar-qld-gpu
+      - pulsar-qld-gpu-other
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/.*:
     cores: 8
     mem: 69
@@ -3425,7 +3415,7 @@ tools:
       accept:
       - pulsar
       require:
-      - pulsar-qld-gpu
+      - pulsar-qld-gpu-other
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado_pod5_convert/dorado_pod5_convert/.*:
     cores: 8
     params:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3258,7 +3258,7 @@ tools:
     scheduling:
       require:
       - pulsar
-      - pulsar-qld-gpu
+      - pulsar-qld-gpu-alphafold
 
   cellranger:
     cores: 6


### PR DESCRIPTION
Reserve pulsar-qld-gpu VMs 1-3 for alphafold with up to 4 jobs running at a time and add a user limit of 2 concurrent alphafold jobs. Set cores/mem for alphafold to 16/130.

dorado and helixir can go to VMs 4 and 5. @TomHarrop I haven't changed the resources for these tools and they can still run 6 per VM, but this could be altered