### PR TITLE
Hide salsa?

### DIFF
--- a/jenkins/update_labels/hidden_tools.yml
+++ b/jenkins/update_labels/hidden_tools.yml
@@ -12,3 +12,4 @@ hidden_tool_ids:
 - toolshed.g2.bx.psu.edu/repos/vlefort/phyml/phyml/*
 - toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/jmoleditor/1.0.0
 - toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/*
+- toolshed.g2.bx.psu.edu/repos/iuc/salsa/salsa/*


### PR DESCRIPTION
I'm concerned about whether this tool is working correctly. It's been outputting AGP that isn't formatted correctly and sometimes even when it runs it spits out errors but exits cleanly, e.g.

```
bedfile loaded
Traceback (most recent call last):
  File "/mnt/tools/tool_dependencies/_conda/envs/mulled-v1-497196df66fa9a9ec7ca5cd006fec337d10a3922853cc6022890faf95ba41dcf/bin/correct.py", line 70, in <module>
    oline += str(contig2new[attrs[0]] +'\t'+attrs[1]+'\t'+attrs[2]+'\t'+attrs[3]+'\n')
KeyError: 'chr1'
```

Apart from jenkins salsa has been run 88 times between 2021-07-22 and 2024-04-05.