### PR TITLE
create data21 on user-data-volC

### DIFF
--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -21,6 +21,7 @@ nfs_data20_dir: "{{ volB_path }}/data20"
 # volume C (~42 TB)
 nfs_data10_dir: "{{ volC_path }}/data10"
 nfs_data13_dir: "{{ volC_path }}/data13"
+nfs_data21_dir: "{{ volC_path }}/data21"
 
 attached_volumes:
   - device: /dev/vdb
@@ -51,6 +52,7 @@ nfs_dirs:
   - "{{ nfs_data18_dir }}"
   - "{{ nfs_data19_dir }}"
   - "{{ nfs_data20_dir }}"
+  - "{{ nfs_data21_dir }}"
 
 nfs_exports:
   - "{{ volA_path }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -61,7 +61,7 @@ galaxy_job_working_directory: /mnt/scratch/job_working_directory
 
 galaxy_infrastructure_url: https://usegalaxy.org.au
 
-upload_store_volume_dir: /mnt/user-data-volB
+upload_store_volume_dir: /mnt/user-data-volC
 nginx_upload_store_base_dir: "{{ upload_store_volume_dir }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/job_files"

--- a/templates/galaxy/config/galaxy_object_store_conf.xml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.xml.j2
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 <object_store type="distributed" id="primary" order="0">
     <backends>
-        <backend id="data20" type="disk" weight="1" store_by="uuid">
+        <backend id="data21" type="disk" weight="1" store_by="uuid">
+            <files_dir path="/mnt/user-data-volC/data21" />
+            <extra_dir type="job_work" path="/mnt/scratch/job_working_directory"/>
+        </backend>
+        <backend id="data20" type="disk" weight="0" store_by="uuid">
             <files_dir path="/mnt/user-data-volB/data20" />
             <extra_dir type="job_work" path="/mnt/scratch/job_working_directory"/>
         </backend>


### PR DESCRIPTION
The current user-data volume, `user-data-volB`, is running low on space. Create `data21` on `user-data-volC`.

NOTE: This is not to be merged, and galaxy playbook run to update object store, until `volB` is close to full, as `volC` has limited space available.

