### PR TITLE
pawsey-user-nfs outage mark mounts offline

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -26,7 +26,7 @@ galaxy_db_tiaas_password: "{{ vault_galaxy_db_tiaas_password }}"
 
 # qld_file_mounts_available: set to true if /mnt/files, /mnt/files2 should be in the object store
 qld_file_mounts_available: True # assume true unless set to false
-pawsey_file_mounts_available: True # assume true unless set to false
+pawsey_file_mounts_available: False # assume true unless set to false
 
 qld_file_mounts_path: /mnt/user-data-qld
 pawsey_file_mounts_path: /mnt/user-data-pawsey


### PR DESCRIPTION
pawsey-user-nfs is down and hard reboot is not working. taking pawsey mounts offline.
