### PR TITLE
Set `tmp_dir: true` for built-in converter tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3388,6 +3388,9 @@ tools:
         not user or not 'cellranger' in [role.name for role in user.all_roles() if not role.deleted]
       fail: Your account has not been given access to cellranger. Contact help@genome.edu.au
         if you think this is in error.
+  CONVERTER.*:
+    params:
+      tmp_dir: true
   CONVERTER_bedgraph_to_bigwig:
     mem: 30
   ^fgenesh$:


### PR DESCRIPTION
These can create a lot of temporary files if there is sorting involved and for the most part they clean up but not if the job is cancelled by the user