### PR TITLE
pawsey file mounts unavailable

### DIFF
--- a/group_vars/galaxy_etca.yml
+++ b/group_vars/galaxy_etca.yml
@@ -26,7 +26,7 @@ galaxy_db_tiaas_password: "{{ vault_galaxy_db_tiaas_password }}"
 
 # qld_file_mounts_available: set to true if /mnt/files, /mnt/files2 should be in the object store
 qld_file_mounts_available: True # assume true unless set to false
-pawsey_file_mounts_available: True # assume true unless set to false
+pawsey_file_mounts_available: False # assume true unless set to false
 
 qld_file_mounts_path: /mnt/user-data-qld
 pawsey_file_mounts_path: /mnt/user-data-pawsey


### PR DESCRIPTION
Pawsey has sent emails that there is a problem with nimbus: "for now consider all Nimbus instances to be inaccessible". The volumes are still mounted on galaxy VMs but I can't list files and cannot access pawsey-user-nfs.