### PR TITLE
Update dev_vortex_config.yml

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
@@ -7,6 +7,9 @@ tools:
     scheduling:
       require:
         - interactive_pulsar
+  __IMPORT_HISTORY__:
+    params:
+      tmp_dir: true
   toolshed.g2.bx.psu.edu/repos/fubar/mashmap/mashmap/.*:
     mem: 16
   toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/.*:


### PR DESCRIPTION
so IMPORT_HISTORY tool will not fill worker disk