### PR TITLE
dev: Add scratch to dev object store

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -72,7 +72,7 @@
         - /mnt/galaxy/data
         - /mnt/galaxy/data-2
         - /mnt/galaxy/data-3
-        - /mnt/galaxy/data-scratch-test
+        - /mnt/galaxy/data-scratch
     - name: Make local_tool directory group-writable by machine users
       file:
         path: /mnt/galaxy/local_tools

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -430,6 +430,8 @@ galaxy_subsites:
         display: none;
       }
 
+galaxy_scratch_storage_days: 60
+
 webhook_plugins:
   - subdomain_switcher
   # These ones aren't in the playbook as they are included in the galaxy repo:

--- a/templates/galaxy/config/dev_object_store_conf.yml.j2
+++ b/templates/galaxy/config/dev_object_store_conf.yml.j2
@@ -1,21 +1,27 @@
 type: distributed
 search_for_missing: false
 backends:
-- id: dev_objects_scratch_test
-  weight: 0
+- id: corral4-scratch
   type: disk
-  store_by: id
-  files_dir: /mnt/galaxy/data-scratch-test
-  extra_dirs:
-  - type: temp
-    path: /mnt/galaxy/tmp_scratch_test/scratch
-  - type: job_work
-    path: /mnt/galaxy/tmp_scratch_test/job_working_directory
+  weight: 0
+  store_by: uuid
+  allow_selection: true
+  private: false
+  quota:
+    source: scratch
+  name: "30-day scratch storage"
+  description: Data in 30-day Storage is scheduled for removal after 30 days, but is afforded a much larger quota than Permanent Storage.
+  files_dir: /corral4/main/objects
+  badges:
+    - type: not_backed_up
+    - type: short_term
+      message: "Data stored here is scheduled for removal after 30 days of inactivity"
 - id: dev_objects_3
   weight: 1
   type: disk
   store_by: uuid
   files_dir: /mnt/galaxy/data-3
+  allow_selection: true
   extra_dirs:
   - type: temp
     path: /mnt/galaxy/tmp/scratch

--- a/templates/galaxy/config/dev_object_store_conf.yml.j2
+++ b/templates/galaxy/config/dev_object_store_conf.yml.j2
@@ -1,7 +1,7 @@
 type: distributed
 search_for_missing: false
 backends:
-- id: corral4-scratch
+- id: dev_scratch
   type: disk
   weight: 0
   store_by: uuid
@@ -9,13 +9,13 @@ backends:
   private: false
   quota:
     source: scratch
-  name: "30-day scratch storage"
-  description: Data in 30-day Storage is scheduled for removal after 30 days, but is afforded a much larger quota than Permanent Storage.
-  files_dir: /corral4/main/objects
+  name: "{{ galaxy-scratch_storage_days }}-day scratch storage"
+  description: "Data in {{ galaxy-scratch_storage_days }}-day Storage is scheduled for removal after {{ galaxy-scratch_storage_days }} days, but is afforded a much larger quota than Permanent Storage."
+  files_dir: /mnt/galaxy/data-scratch
   badges:
     - type: not_backed_up
     - type: short_term
-      message: "Data stored here is scheduled for removal after 30 days of inactivity"
+      message: "Data stored here is scheduled for removal after {{ galaxy-scratch_storage_days }} days of inactivity"
 - id: dev_objects_3
   weight: 1
   type: disk


### PR DESCRIPTION
This is not production ready and I've kept some of Galaxy Main's text as a placeholder

This adds 'dev_scratch' to the object store and and removes 'dev_objects_scratch_test' (which is not needed and had nothing to do with the current work, despite the similar name).