### PR TITLE
galaxy celery tmp

### DIFF
--- a/galaxy-handlers_playbook.yml
+++ b/galaxy-handlers_playbook.yml
@@ -49,6 +49,12 @@
       with_items:
         - "{{ qld_file_mounts_path }}"
         - "{{ pawsey_file_mounts_path }}"
+    - name: create celery tmp dir
+      file:
+        state: directory
+        path: "{{ galaxy_celery_tmp_dir }}"
+        owner: galaxy
+        group: galaxy
   roles:
         - mounts
         - geerlingguy.pip

--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -30,6 +30,8 @@ galaxy_fetch_dependencies: false
 galaxy_manage_mutable_setup: false
 galaxy_build_client: false
 
+galaxy_celery_tmp_dir: /pvol/celery_tmp
+
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/handlers_job_files"
 nginx_ssl_servers:
   - galaxy-handlers
@@ -53,6 +55,8 @@ host_galaxy_config_gravity:
     enable_beat: true
     concurrency: 2
     loglevel: DEBUG
+    environment:
+      TMPDIR: "{{ galaxy_celery_tmp_dir }}"
   handlers:
     handler:
       environment: "{{ galaxy_process_env }}"
@@ -65,7 +69,6 @@ host_galaxy_config_gravity:
       pools:
         - workflow-schedulers
 
-# TODO: Ask BG about flower!
 # # Flower
 flower_python_version: python3
 flower_app_dir: /mnt/galaxy


### PR DESCRIPTION
Add a temp directory for celery. Found an example of this while trawling through Galaxy Main's gravity configuration. If it works, it would prevent galaxy-handlers' root disk filling up like it did last night. 