### PR TITLE
Try overriding the singularity container ID for repeatmasker

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -310,6 +310,7 @@ tools:
     cores: 8
     mem: 120
     params:
+      singularity_container_id_override: docker://quay.io/biocontainers/repeatmasker:4.1.5--pl5321hdfd78af_0
       singularity_enabled: true
     scheduling:
       accept:


### PR DESCRIPTION
Pulsar jobs have been using `4.1.5--pl5321hdfd78af_1`, this PR is to override it with `4.1.5--pl5321hdfd78af_0`. According to Nate's comment [here](https://github.com/galaxyproject/usegalaxy-playbook/blob/7d649a3d41a2a987bb8edadf34039e79d803b3ad/env/common/templates/galaxy/config/tpv/tools.yaml.j2#L269), this is the good version of the container. 

