### PR TITLE
common packages deal with ubuntu 24.04 differences

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -162,6 +162,15 @@ common_packages:
     - software-properties-common
     - pigz
 
+problematic_packages_ubuntu_24_04:
+    - libgl1-mesa-glx
+
+additional_packages_ubuntu_24_04:
+    # NOTE: libgl1 and libglx-mesa0 provides equivalent behaviour as obsolete package (23.10 and later) libgl1-mesa-glx
+    # TODO: if libgl1-mesa-glx package is not actually needed any more, these could be removed
+    - libgl1
+    - libglx-mesa0
+
 #Set pip to be pip3 by default - see roles/geerlingguy.pip/defaults/main.yml
 pip_package: python3-pip
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,9 +20,14 @@
       update_cache: yes
   when: not skip_upgrade_dist|d(false)
 
+- name: Adjust packages for Ubuntu 24.04 and later
+  set_fact:
+      ubuntu_packages: "{{ (common_packages | difference(problematic_packages_ubuntu_24_04)) | union(additional_packages_ubuntu_24_04) }}"
+  when: ansible_distribution == "Ubuntu" and (ansible_distribution_version is version('24.04', '>='))
+
 - name: Install some common packages
   apt:
-      name: "{{ common_packages }}"
+      name: "{{ ubuntu_packages | default(common_packages) }}"
       state: latest
 
 - name: Install group specific packages


### PR DESCRIPTION
the Ubuntu package `libgl1-mesa-glx` is obsolete since 23.10. Replace this on Ubuntu 24.04 with `libgl1` and `libglx-mesa0` packages which provide equivalent behaviour.