### PR TITLE
ignore all geerlingguy roles - installed via requirements.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,7 @@ roles/galaxyproject.tusd
 roles/galaxyproject.tiaas2
 roles/galaxyproject.slurm
 # roles/galaxyproject.repos/ # Commented out as Simon made a modification so ppa is added to ubuntu 20.04
-roles/geerlingguy.pip/
-roles/geerlingguy.nfs/
-roles/geerlingguy.redis/
+roles/geerlingguy.*/
 roles/galaxyproject.postgresql_objects/
 roles/uchida.miniconda/
 roles/galaxyproject.miniconda
@@ -43,7 +41,6 @@ roles/dj-wasabi.telegraf
 roles/galaxyproject.gxadmin
 roles/usegalaxy_eu.tiaas2
 roles/usegalaxy_eu.gie_proxy
-roles/geerlingguy.docker
 roles/cloudalchemy.grafana
 roles/galaxyproject.miniconda
 roles/usegalaxy_eu.influxdb


### PR DESCRIPTION
Rather than ignoring the installed geerlingguy roles on a one by one case, ignore all of them by default.