### PR TITLE
add plugins and hostname to jenkins playbook

### DIFF
--- a/host_vars/jenkins-2024.yml
+++ b/host_vars/jenkins-2024.yml
@@ -2,14 +2,20 @@ hostname: "{{ ansible_hostname }}.genome.edu.au"
 
 
 # Jenkins settings
+jenkins_hostname: jenkins-2024.genome.edu.au
 jenkins_http_port: 8080
 jenkins_admin_username: admin
 jenkins_admin_password: "{{ vault_jenkins_2024_admin_password }}"
 jenkins_package_state: latest
 jenkins_plugins:
-  - matrix-auth
-  - git
   - build-timeout
+  - git
+  - github
+  - htmlpublisher
+  - matrix-auth
+  - slack
+  - ssh-agent
+  - sshd
 
 
 # Keys and shares

--- a/host_vars/jenkins-2024.yml
+++ b/host_vars/jenkins-2024.yml
@@ -16,6 +16,7 @@ jenkins_plugins:
   - slack
   - ssh-agent
   - sshd
+jenkins_plugins_install_dependencies: true
 
 
 # Keys and shares


### PR DESCRIPTION
Additional plugins used by Jenkins jobs from 2018 server need to be installed. Also adding jenkins server hostname.
