### PR TITLE
install github hub package for jenkins server

### DIFF
--- a/group_vars/jenkins.yml
+++ b/group_vars/jenkins.yml
@@ -1,0 +1,3 @@
+group_packages:
+  - hub
+

--- a/jenkins-2024_playbook.yml
+++ b/jenkins-2024_playbook.yml
@@ -3,6 +3,7 @@
   become: true
   vars_files:
     - group_vars/all.yml
+    - group_vars/jenkins.yml
     - group_vars/VAULT
     - secret_group_vars/ubuntu_maintenance_key
     - host_vars/jenkins-2024.yml


### PR DESCRIPTION
The github Hub package is now included in the standard Ubuntu Apt repos, installing via `common` role with `group_packages`.