### PR TITLE
more memory, fewer cores for mirdeep2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3342,11 +3342,11 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2.*:
+    mem: 8
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2_mapper/rbc_mirdeep2_mapper/.*:
-    cores: 9
-    mem: 34.5
+    mem: 28
     scheduling:
       accept:
         - pulsar


### PR DESCRIPTION
set 8GB for mirdeep2 tools and 28GB for mirdeep2_mapper. This doesn't need cores because the wrapper doesn't use the GALAXY_SLOTS variable