### PR TITLE
make singularity volumes overridable context variables

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -11,12 +11,19 @@ tools:
       test_cores: 1  # TODO: test_mem?
       max_concurrent_job_count_for_tool_total: null
       max_concurrent_job_count_for_tool_user: null
+
       # pulsar score
       pulsar_score: null  # scores set in tool_pulsar_scores.yml. Not every tool will have a score
       pulsar_score_pulsar_threshold: 10  # above this score, prefer to send jobs to pulsar
       pulsar_score_slurm_threshold: 0.3  # below this score, prefer to send jobs to slurm
       pulsar_score_slurm_max_cores: 12  # if cores >= this number, do not set preference for slurm
       pulsar_score_slurm_max_mem: 48  # if mem >= this number, do not set preference for slurm
+ 
+      # singularity and docker volumes
+      slurm_singularity_volumes: "{{ slurm_singularity_volumes }}"
+      slurm_docker_volumes: "{{ slurm_docker_volumes }}"
+      pulsar_singularity_volumes: "{{ pulsar_singularity_volumes }}"
+      pulsar_docker_volumes: "{{ pulsar_docker_volumes }}"
     scheduling:
       reject:
         - offline

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -20,12 +20,12 @@ destinations:
       - id: slurm_destination_singularity_rule
         if: entity.params.get('singularity_enabled')
         params:
-            singularity_volumes: "{{ slurm_singularity_volumes }}"
+            singularity_volumes: '{ slurm_singularity_volumes }'
             singularity_default_container_id: "{{ singularity_default_container_id }}"
       - id: slurm_destination_docker_rule
         if: entity.params.get('docker_enabled')
         params:
-            docker_volumes: "{{ slurm_docker_volumes }}"
+            docker_volumes: '{ slurm_docker_volumes }'
             docker_memory: '{mem}G'  # TODO: here and in _pulsar_destination, int or round to stop this from ever being 3.79999999999996
             docker_sudo: false
   _pulsar_destination:
@@ -44,7 +44,7 @@ destinations:
       - id: pulsar_destination_singularity_rule
         if: entity.params.get('singularity_enabled')
         params:
-            singularity_volumes: "{{ pulsar_singularity_volumes }}"
+            singularity_volumes: '{ pulsar_singularity_volumes }'
             container_resolvers: 
                 - type: explicit_singularity
                 - type: mulled_singularity
@@ -57,7 +57,7 @@ destinations:
       - id: pulsar_destination_docker_rule
         if: entity.params.get('docker_enabled')
         params:
-            docker_volumes: "{{ pulsar_docker_volumes }}"
+            docker_volumes: '{ pulsar_docker_volumes }'
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
@@ -309,5 +309,8 @@ users:
       params:
         object_store_id: minio_test
     selenium_st_aws_gateway@genome.edu.au:
+      context:
+        slurm_singularity_volumes: "{{ slurm_singularity_volumes }},/mnt/aws_gateway:ro"
+        slurm_docker_volumes: "{{ slurm_docker_volumes }},/mnt/aws_gateway:ro"
       params:
         object_store_id: aws_gateway_test

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -44,7 +44,7 @@ galaxy_dynamic_job_rules:
   - total_perspective_vortex/tools.yml
   - total_perspective_vortex/destinations.yml.j2
   - total_perspective_vortex/tool_pulsar_scores.yml
-  - total_perspective_vortex/users.yml
+  - total_perspective_vortex/users.yml.j2
   - total_perspective_vortex/default_tool.yml.j2
   - readme.txt
 


### PR DESCRIPTION
Rearrange slurm_singularity_volumes etc to be context variables on the default tool instead of hard coding them on destinations. This makes it possible for an aws gateway user to have '/mnt/aws_gateway:ro' appended to volume strings for their jobs.

@jlqfab @nuwang from a dry run this appears to just work.