### PR TITLE
toolmsg webhook plugin on dev + prod

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -45,7 +45,8 @@
       become: true
       become_user: galaxy
     - usegalaxy_eu.galaxy_subdomains
-    - webhooks
+    - role: webhooks
+      tags: webhooks
     - nginx-upload-module
     - galaxyproject.nginx
     - galaxyproject.tusd

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -446,6 +446,6 @@ toolmsg_messages:
 # - tool_id: to match subject.startsWith(tool_id)
 #   message: A custom message to be displayed for this tool
 #   class: bootstrap class [primary, info, success, warning, danger]
-  - tool_id: toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
-    message: A custom message for Dia-NN!
+  - tool_id: toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/
+    message: A custom message for ABySS!
     class: danger

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -435,7 +435,17 @@ galaxy_scratch_storage_days: 60
 
 webhook_plugins:
   - subdomain_switcher
+  - toolmsg
   # These ones aren't in the playbook as they are included in the galaxy repo:
   - demo
   - gtn
   - news
+
+# toolmsg webhook plugin:
+toolmsg_messages:
+# - tool_id: to match subject.startsWith(tool_id)
+#   message: A custom message to be displayed for this tool
+#   class: bootstrap class [primary, info, success, warning, danger]
+  - tool_id: toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
+    message: A custom message for Dia-NN!
+    class: danger

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -444,8 +444,18 @@ webhook_plugins:
 # toolmsg webhook plugin:
 toolmsg_messages:
 # - tool_id: to match subject.startsWith(tool_id)
-#   message: A custom message to be displayed for this tool
+#            Best to use remove version numbers and trailing slash
+#            e.g. toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
+#   message: A custom HTML message to be displayed for this tool
 #   class: bootstrap class [primary, info, success, warning, danger]
-  - tool_id: toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe/
-    message: A custom message for ABySS!
-    class: danger
+
+  - tool_id: toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe
+    message: >
+      [TEST] Access rights to this tool have changed, please
+      <a href="https://site.usegalaxy.org.au/request/access/diann"
+         target="_blank"
+      >
+        apply for access
+      </a>
+      to continue using this tool.
+    class: warning

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -785,10 +785,29 @@ galaxy_subsites:
 
 webhook_plugins:
   - subdomain_switcher
+  - toolmsg
   # These ones aren't in the playbook as they are included in the galaxy repo:
   - demo
   - gtn
   - news
+
+toolmsg_messages:
+# - tool_id: to match subject.startsWith(tool_id)
+#            Best to use remove version numbers and trailing slash
+#            e.g. toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
+#   message: A custom HTML message to be displayed for this tool
+#   class: bootstrap class [primary, info, success, warning, danger]
+
+  - tool_id: toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
+    message: >
+      Access rights to this tool have changed, please
+      <a href="https://site.usegalaxy.org.au/request/access/diann"
+         target="_blank"
+      >
+        apply for access
+      </a>
+      to continue using this tool.
+    class: warning
 
 # ssh config, only for ubuntu
 ssh_config_id_file: "/home/{{ ssh_config_user }}/.ssh/internal_hop_key"

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -312,7 +312,26 @@ galaxy_subsites:
 
 webhook_plugins:
   - subdomain_switcher
+  - toolmsg
   # These ones aren't in the playbook as they are included in the galaxy repo:
   - demo
   - gtn
   - news
+
+toolmsg_messages:
+# - tool_id: to match subject.startsWith(tool_id)
+#            Best to use remove version numbers and trailing slash
+#            e.g. toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
+#   message: A custom HTML message to be displayed for this tool
+#   class: bootstrap class [primary, info, success, warning, danger]
+
+  - tool_id: toolshed.g2.bx.psu.edu/repos/galaxyp/diann/diann
+    message: >
+      Access rights to this tool have changed, please
+      <a href="https://site.usegalaxy.org.au/request/access/diann"
+         target="_blank"
+      >
+        apply for access
+      </a>
+      to continue using this tool.
+    class: warning

--- a/roles/webhooks/tasks/main.yml
+++ b/roles/webhooks/tasks/main.yml
@@ -15,4 +15,3 @@
     state: absent
   with_items: "{{ existing_webhook_plugin_dirs.stdout_lines }}"
   when: "item not in webhook_plugins"
-  notify: restart galaxy

--- a/templates/galaxy/webhooks/toolmsg/config.yml.j2
+++ b/templates/galaxy/webhooks/toolmsg/config.yml.j2
@@ -1,0 +1,7 @@
+id: toolmsg
+type:
+  - masthead
+activate: true
+
+# icon: fa-graduation-cap
+# tooltip: See Galaxy Training Materials

--- a/templates/galaxy/webhooks/toolmsg/script.js.j2
+++ b/templates/galaxy/webhooks/toolmsg/script.js.j2
@@ -6,7 +6,7 @@ const toolMessages = [
     {
         {% for message in toolmsg_messages %}
         tool_id: "{{ message.tool_id }}",
-        message: "{{ message.message }}",
+        message: `{{ message.message }}`,
         class: "{{ message.class }}",
         {% endfor %}
     },
@@ -47,7 +47,7 @@ function showToolMessages() {
         if (isCurrentToolForm(toolMessage.tool_id)) {
             const newElement = document.createElement('p');
             newElement.className = 'alert alert-' + toolMessage.class + ' my-3';
-            newElement.innerText = toolMessage.message;
+            newElement.innerHTML = toolMessage.message;
             const referenceElement = document.getElementById('tool-card-body');
             if (referenceElement) {
                 referenceElement.parentNode.insertBefore(newElement, referenceElement);

--- a/templates/galaxy/webhooks/toolmsg/script.js.j2
+++ b/templates/galaxy/webhooks/toolmsg/script.js.j2
@@ -1,5 +1,8 @@
 // Custom messages for tool forms
 
+const enableDebug = false;
+const debugLog = (msg) => enableDebug && console.debug("[ToolMsg]: " + msg);
+
 const WAIT_TOOL_MAX_TRIES = 3;
 const WAIT_TOOL_INTERVAL = 500;
 const toolMessages = [
@@ -17,11 +20,11 @@ function waitToolFormLoad() {
     let matched = false;
     const element = document.querySelector('div[tool_id]');
     if (element) {
-        console.log('Tool form has been loaded');
+        debugLog('Tool form has been loaded');
         matched = showToolMessages();
         tries = WAIT_TOOL_MAX_TRIES;
     } else {
-        console.log("No tool form detected (tries: " + tries + ")");
+        debugLog("No tool form detected (tries: " + tries + ")");
     }
     tries < WAIT_TOOL_MAX_TRIES
         && !matched
@@ -33,11 +36,11 @@ function isCurrentToolForm(toolId) {
     for (let element of elements) {
         const thisToolId = element.getAttribute('tool_id');
         if (thisToolId && thisToolId.startsWith(toolId)) {
-            console.log(toolId + " matches " + thisToolId);
+            debugLog(toolId + " matches " + thisToolId);
             return true;
         }
     }
-    console.log(toolId + " not found in page.");
+    debugLog(toolId + " not found in page.");
     return false;
 }
 
@@ -52,7 +55,7 @@ function showToolMessages() {
             if (referenceElement) {
                 referenceElement.parentNode.insertBefore(newElement, referenceElement);
             } else {
-                console.log('Reference element with id="tool-card-body" not found.');
+                debugLog('Reference element with id="tool-card-body" not found.');
             }
             match = true;
         }
@@ -66,7 +69,7 @@ let lastUrlPath = null;
 // Add observer for Vue pathname changes
 const observer = new MutationObserver( () => {
     if (lastUrlPath !== window.location.href) {
-        console.log("Triggered mutation observer");
+        debugLog("Triggered mutation observer");
         tries = 0;
         lastUrlPath = window.location.href;
         setTimeout(waitToolFormLoad, 500);

--- a/templates/galaxy/webhooks/toolmsg/script.js.j2
+++ b/templates/galaxy/webhooks/toolmsg/script.js.j2
@@ -1,0 +1,77 @@
+// Custom messages for tool forms
+
+const WAIT_TOOL_MAX_TRIES = 3;
+const WAIT_TOOL_INTERVAL = 500;
+const toolMessages = [
+    {
+        {% for message in toolmsg_messages %}
+        tool_id: "{{ message.tool_id }}",
+        message: "{{ message.message }}",
+        class: "{{ message.class }}",
+        {% endfor %}
+    },
+];
+
+function waitToolFormLoad() {
+    tries++;
+    let matched = false;
+    const element = document.querySelector('div[tool_id]');
+    if (element) {
+        console.log('Tool form has been loaded');
+        matched = showToolMessages();
+        tries = WAIT_TOOL_MAX_TRIES;
+    } else {
+        console.log("No tool form detected (tries: " + tries + ")");
+    }
+    tries < WAIT_TOOL_MAX_TRIES
+        && !matched
+        && setTimeout(waitToolFormLoad, WAIT_TOOL_INTERVAL);
+}
+
+function isCurrentToolForm(toolId) {
+    const elements = document.querySelectorAll('[tool_id]');
+    for (let element of elements) {
+        const thisToolId = element.getAttribute('tool_id');
+        if (thisToolId && thisToolId.startsWith(toolId)) {
+            console.log(toolId + " matches " + thisToolId);
+            return true;
+        }
+    }
+    console.log(toolId + " not found in page.");
+    return false;
+}
+
+function showToolMessages() {
+    let match = false;
+    toolMessages.forEach( (toolMessage) => {
+        if (isCurrentToolForm(toolMessage.tool_id)) {
+            const newElement = document.createElement('p');
+            newElement.className = 'alert alert-' + toolMessage.class + ' my-3';
+            newElement.innerText = toolMessage.message;
+            const referenceElement = document.getElementById('tool-card-body');
+            if (referenceElement) {
+                referenceElement.parentNode.insertBefore(newElement, referenceElement);
+            } else {
+                console.log('Reference element with id="tool-card-body" not found.');
+            }
+            match = true;
+        }
+    })
+    return match;
+}
+
+let tries = 0;
+let lastUrlPath = null;
+
+// Add observer for Vue pathname changes
+const observer = new MutationObserver( () => {
+    if (lastUrlPath !== window.location.href) {
+        console.log("Triggered mutation observer");
+        tries = 0;
+        lastUrlPath = window.location.href;
+        setTimeout(waitToolFormLoad, 500);
+    }
+});
+
+// Observe the document body for changes (or another relevant element)
+observer.observe(document.body, { childList: true, subtree: true });


### PR DESCRIPTION
I wrote a webhook plugin that allows us to define tool-specific messages. 

Just [deployed on dev](https://dev.gvl.org.au/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fiuc%2Fabyss%2Fabyss-pe%2F2.3.4) last night.

This config in `dev.gvl.org.au.yml`:

```yml
# N.B. make tool_id as short as possible to match all versions
# A trailing slash can result in a mismatch, depending on how the user navigates to the tool form!
toolmsg_messages:
  - tool_id: toolshed.g2.bx.psu.edu/repos/iuc/abyss/abyss-pe
    message: A custom message for ABySS!
    class: danger
```

Results in:

![image](https://github.com/user-attachments/assets/5a814167-256c-4181-81d5-02bac6c4f5cd)

The `toolmsg_messages` schema:

```yml
  - tool_id: message will display if current_tool_id.startsWith(tool_id)
    message: A custom message to be displayed for this tool (text only, no HTML currently)
    class: bootstrap class - must be one of [primary, info, success, warning, danger]
```