### PR TITLE
reduce concurrency of dorado jobs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3617,7 +3617,7 @@ tools:
       - pulsar-qld-gpu
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/.*:
     cores: 8
-    mem: 69
+    mem: 130  # updated from 69 to 130 to lower the concurrency, not because his needs a lot of RAM
     gpus: 1
     params:
       singularity_enabled: true


### PR DESCRIPTION
Set dorado mem the same as alphafold mem so that not too many jobs will run at once