### PR TITLE
run dorado jobs one at a time

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3623,7 +3623,7 @@ tools:
       - pulsar-qld-gpu
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/.*:
     cores: 8
-    mem: 130  # updated from 69 to 130 to lower the concurrency, not because his needs a lot of RAM
+    mem: 540  # updated from 69 to 130 to lower the concurrency, not because his needs a lot of RAM, the next day updated to 540 so only one will run at once
     gpus: 1
     params:
       singularity_enabled: true


### PR DESCRIPTION
Increase the RAM for dorado so that slurm is unable to schedule more than one at a time