### PR TITLE
set pqgpu3 offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -373,6 +373,7 @@ destinations:
       accept:
         - pulsar-qld-gpu3
         - pulsar-qld-gpu-alphafold
+        - offline
   pulsar-qld-gpu4:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu4_runner


### PR DESCRIPTION
Every job on pulsar-qld-gpu3 has failed since about this time last month. Some jobs are failing with the error: "INTERNAL: Failed to launch CUDA kernel". This error has not been seen on any of the other pulsars while they have been in production.