### PR TITLE
set ready_window_size to 120

### DIFF
--- a/templates/galaxy/config/galaxy_job_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_job_conf.yml.j2
@@ -2,7 +2,7 @@ handling:
   assign:
     - db-skip-locked
   max_grab: 8
-  ready_window_size: 20
+  ready_window_size: 120  # Increased from 20 to 120 on 17/10/24 due to jobs not scheduling when there are many jobs in new state with TPV limits, see issue https://github.com/usegalaxy-au/infrastructure/issues/2254
 runners:
   local:
     load: galaxy.jobs.runners.local:LocalJobRunner


### PR DESCRIPTION
ready_window_size has been set to 120 for two hours and I can't see any problems arising from it in terms of handler/db CPU or memory use.

This mitigates https://github.com/usegalaxy-au/infrastructure/issues/2254 for now but there needs to be a better solution for this issue.