### PR TITLE
use type: swift instead of type: boto3 for nectar_test in object store

### DIFF
--- a/templates/galaxy/config/galaxy_object_store_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.yml.j2
@@ -206,9 +206,8 @@ backends:
   connection:
     host: "swift.rc.nectar.org.au"
     port: 443
-    is_secure: false
-    conn_path: ""
-    multipart: true
+    is_secure: true
+    conn_path: "/"
   cache:
     path: /mnt/user-data-volD/nectar_test_cache
     size: 200

--- a/templates/galaxy/config/galaxy_object_store_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.yml.j2
@@ -193,7 +193,7 @@ backends:
     - type: job_work
       path: /mnt/scratch/job_working_directory  
 - id: nectar_test
-  type: boto3
+  type: swift
   weight: 0
   store_by: uuid
   auth:
@@ -201,8 +201,14 @@ backends:
     secret_key: {{ vault_nectar_melbournegvl_cb_ec2_secret_key }}
   bucket:
     name: usegalaxy-au-object-store-backend-test
+    use_reduced_redundancy: false
+    max_chunk_size: 250
   connection:
-    endpoint_url: https://swift.rc.nectar.org.au:443/
+    host: "swift.rc.nectar.org.au"
+    port: 443
+    is_secure: false
+    conn_path: ""
+    multipart: true
   cache:
     path: /mnt/user-data-volD/nectar_test_cache
     size: 200


### PR DESCRIPTION
This is trying to be like Galaxy Main's entry here: https://github.com/galaxyproject/usegalaxy-playbook/blob/33fac17ea40efe05a11e68204f1d5f079b5ed775/env/main/group_vars/all/galaxy_config_vars.yml#L181-L203


