### PR TITLE
Add training-exempt tags for helixer and fgenesh_annotate

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3556,6 +3556,7 @@ tools:
     scheduling:
       accept:
         - pulsar
+        - training-exempt  # skips user training role rules within users.yml
       require:
         - pulsar-high-mem2
   fgenesh_merge:
@@ -3645,6 +3646,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - training-exempt
       require:
       - pulsar-qld-gpu-other
       - pulsar-qld-gpu

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1799,6 +1799,8 @@ tools:
     mem: 11.5
   toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/.*:
     mem: 8
+    params:
+      singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/jellyfish/jellyfish/.*:
     mem: 24
     scheduling:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3660,6 +3660,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - training-exempt
       require:
       - pulsar-qld-gpu-other
       - pulsar-qld-gpu


### PR DESCRIPTION
this tag means a helixir job is treated the same as if it were not being run by a training user.