### PR TITLE
put citations_export_message_html in galaxy.yml

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -233,6 +233,8 @@ group_galaxy_config:
     build_sites_config_file: "{{ galaxy_config_dir }}/build_sites.yml"
     enable_old_display_applications: true
 
+    citations_export_message_html: 'When writing up your analysis, remember to include all references that should be cited in order to completely describe your work. Also, please remember to <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy Australia</a>.'
+
     dependency_resolvers:
       - type: tool_shed_packages
       - type: galaxy_packages


### PR DESCRIPTION
Minh has added an option for us to customise the 'cite galaxy' message which allows us to alter the text and/or the URL it links to. The galaxyhub URL it links to by default seems like the right URL, since it comprehensively describes how to cite many components of Galaxy. This pull request changes our text to say 'cite Galaxy Australia' instead of 'cite Galaxy' and leaves the link as is.