### PR TITLE
pulsar-qld-gpu4 and gpu5 online

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -359,7 +359,6 @@ destinations:
       accept:
         - pulsar-qld-gpu1
         - pulsar-qld-gpu-alphafold
-        - pulsar-qld-gpu-other # temporary while pulsar-qld-gpu[4-5] offline
   pulsar-qld-gpu2:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu2_runner
@@ -367,7 +366,6 @@ destinations:
       accept:
         - pulsar-qld-gpu2
         - pulsar-qld-gpu-alphafold
-        - pulsar-qld-gpu-other # temporary while pulsar-qld-gpu[4-5] offline
   pulsar-qld-gpu3:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu3_runner
@@ -383,7 +381,6 @@ destinations:
       accept:
         - pulsar-qld-gpu4
         - pulsar-qld-gpu-other
-        - offline
   pulsar-qld-gpu5:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu5_runner
@@ -391,5 +388,4 @@ destinations:
       accept:
         - pulsar-qld-gpu5
         - pulsar-qld-gpu-other
-        - offline
 


### PR DESCRIPTION
Hypervisor maintenance completed. GPU 4 and 5 can go back online. GPU 3 (replaced) needs to be tested first.