### PR TITLE
revert pulsar-QLD capacity back to full capacity

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -263,8 +263,8 @@ destinations:
     max_accepted_cores: 16
     max_accepted_mem: 62.72
     context:
-      destination_total_cores: 80  # 112 (reduced 6/11/24 while workers are down)
-      destination_total_mem: 314  # 439 (reduced 6/11/24 while workers are down)
+      destination_total_cores: 112
+      destination_total_mem: 439
     tags: {{ job_conf_limits.environments['pulsar-QLD'].tags }}
     scheduling:
       accept:


### PR DESCRIPTION
Hypervisor maintenance for pulsar-QLD-w5 and pulsar-QLD-w6 completed. Workers put back online.