### PR TITLE
disable singularity for retrieve_scxa

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -904,6 +904,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/.*:
     params:
       singularity_enabled: true
+  toolshed.g2.bx.psu.edu/repos/ebi-gxa/retrieve_scxa/retrieve_scxa/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy.*:
     mem: 4 + input_size * 10
     params:


### PR DESCRIPTION
Fix issue for EBI SCXA Data Retrieval where get the following error: `wget: unable to resolve host address 'ftp.ebi.ac.uk'`. This appears to be caused by running the tool within singularity.
