### PR TITLE
increase concurrent alphafold jobs per user

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -958,7 +958,7 @@ tools:
       alphafold_aa_length_max: 3000
       alphafold_max_input_sequences: 10
       alphafold_db: /data/v2.3
-      max_concurrent_job_count_for_tool_user: 2
+      max_concurrent_job_count_for_tool_user: 4
     gpus: 1
     cores: 16
     mem: 130


### PR DESCRIPTION
There is capacity to increase this - if the queue gets busy it can go down to 2 or 3 again