### PR TITLE
restrict pmel2 to test users

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -127,10 +127,10 @@ destinations:
     tags: {{ job_conf_limits.environments['pulsar-mel2'].tags }}
     scheduling:
       accept:
-        - pulsar-mel2
         - bakta_database
       require:
         - pulsar
+        - pulsar-mel2  # 29/11/12: temporary change for storage testing, this tag should normally be in 'accept' instead of 'require'
   pulsar-mel3:
     inherits: _pulsar_destination
     runner: pulsar-mel3_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3226,6 +3226,13 @@ tools:
   toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/.*:
     cores: 5
     mem: 19.1
+    rules:
+    - id: cutadapt_singularity_rule
+      if: |
+        minimum_singularity_version = '4.0+galaxy0'  # earlier versions have not been tested and might work
+        helpers.tool_version_gte(tool, minimum_singularity_version)
+      params:
+        singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/lparsons/htseq_count/htseq_count/.*:
     cores: 8
     mem: 30.7

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
@@ -325,7 +325,7 @@ users:
             tool_id_matched
           scheduling:
             require:
-              - pulsar
+              - pulsar-mel2
     selenium_st_regular@genome.edu.au:
       inherits: __selenium_test_user
     selenium_st_minio@genome.edu.au:


### PR DESCRIPTION
Get storage test user pulsar jobs to go exclusively to pulsar-mel2. It's quiet enough that pulsar-mel2 can be used only for these jobs.