### PR TITLE
disable HDF5 file locking

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -5,7 +5,8 @@ tools:
   default:
     cores: 1
     mem: cores * 3.8
-    env: {}
+    env: 
+      HDF5_USE_FILE_LOCKING: "FALSE"
     context:
       partition: main
       test_cores: 1  # TODO: test_mem?

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -147,6 +147,7 @@ galaxy_process_env:  # environment variables for gunicorn and handlers processes
   DRMAA_LIBRARY_PATH: "/usr/lib/slurm-drmaa/lib/libdrmaa.so.1"
   SINGULARITY_CACHEDIR: "{{ galaxy_user_singularity_cachedir }}"
   SINGULARITY_TMPDIR: "{{ galaxy_user_singularity_tmpdir }}"
+  HDF5_USE_FILE_LOCKING: "FALSE"
 
 #########################################
 # group_galaxy_config contains variables for galaxy_config that can be overridden by variables in host_galaxy_config (defined in host_vars)


### PR DESCRIPTION
There has been an error in gunicorn logs coming from the tool predictions API:
```
Dec 03 00:01:47 galaxy galaxyctl[2118437]:   File "h5py/h5f.pyx", line 102, in h5py.h5f.open
Dec 03 00:01:47 galaxy galaxyctl[2118437]: OSError: Unable to synchronously open file (file locking flag values don't match)
```

From a google search I found recommendations to use `HDF5_USE_FILE_LOCKING: "FALSE"`. Checked out EU and Main infrastructure playbooks and found that they are already using this, and they have adopted it recently. (https://github.com/galaxyproject/usegalaxy-playbook/commit/3724a136012c3846a869a74df26b99f64d002e9e#diff-68bca5ccf2e9695dcca9925b36cce7bb8e7bd223d9c6531649be01986c661020R31)

I'm not sure if this means instances are individually compensating for something that has gone wrong in Galaxy