### PR TITLE
prepare pmel3 for shutdown

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -130,7 +130,6 @@ destinations:
         - bakta_database
       require:
         - pulsar
-        - pulsar-mel2  # 29/11/12: temporary change for storage testing, this tag should normally be in 'accept' instead of 'require'
   pulsar-mel3:
     inherits: _pulsar_destination
     runner: pulsar-mel3_runner
@@ -149,6 +148,7 @@ destinations:
         # - pulsar-blast  # alternate location for pulsar blast jobs when pulsar-qld-blast is unavailable
       require:
         - pulsar
+        - pulsar-quick
   pulsar-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-high-mem1_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2770,7 +2770,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      # - pulsar-quick # commented out since snippy requires data from all_fasta data table
+      - pulsar-quick
     rules:
     - id: snippy_small_input_rule
       if: input_size < 0.015


### PR DESCRIPTION
Allow pulsar-mel2 to run user jobs again, and add 'require: pulsar-quick' to pulsar-mel3 so that it can only run jobs from tools with that tag.