### PR TITLE
Resubmittable tool in dev tpv

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
@@ -1,4 +1,15 @@
 tools:
+  __lomem_with_resubmit:
+    abstract: true
+    mem: 0.0001 + 4 * (int(job.destination_params.get('submission_number', 1) - 1 if job.destination_params else 0)
+    params:
+      submission_number: "{1 + int(job.destination_params.get('submission_number', 1) if job.destination_params else 1}"
+    resubmit:
+      obviously_bcos_too_low_to_start_with:
+        condition: memory_limit_reached and attempt <= 3
+        destination: tpv_dispatcher
+  toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1:
+    inherits: lomem_with_resubmit
   __DATA_FETCH__:
     params:
       tmp_dir: True

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
@@ -1,15 +1,26 @@
 tools:
-  __lomem_with_resubmit:
+  __resubmittable_tool:
     abstract: true
-    mem: 0.0001 + 4 * (int(job.destination_params.get('submission_number', 1) - 1 if job.destination_params else 0)
-    params:
-      submission_number: "{1 + int(job.destination_params.get('submission_number', 1) if job.destination_params else 1}"
+    context:
+      base_mem: 3.8
+      mem_increment: 10
+    mem: |
+      # add mem_increment if job has been seen before, hence job.destination_params is populated
+      base_mem + mem_increment if job.destination_params else base_mem
     resubmit:
-      obviously_bcos_too_low_to_start_with:
-        condition: memory_limit_reached and attempt <= 3
+      resubmit_job_once_due_to_oom_error:
+        condition: memory_limit_reached and attempt <= 3  # this will only work once but keep attempt limit just in case it starts working 
         destination: tpv_dispatcher
-  toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1:
-    inherits: lomem_with_resubmit
+  toolshed.g2.bx.psu.edu/repos/iuc/bandage/bandage_image/.*:
+    inherits: __resubmittable_tool
+    context:
+      base_mem: 2  # this would be 16 in production but set it low for testing
+      mem_increment: 20
+  toolshed.g2.bx.psu.edu/repos/iuc/bandage/bandage_info/.*:
+    inherits: __resubmittable_tool
+    context:
+      base_mem: 2
+      mem_increment: 20
   __DATA_FETCH__:
     params:
       tmp_dir: True


### PR DESCRIPTION
Add an abstract tool `__resubmittable_tool` to dev's vortex config. I've been trying out the resubmit option and I can only get it to resubmit once - from reading issues/PRs on TPV's github I think others have come across this.

Even so, the ability to automatically resubmit a job once would be beneficial in the case of tools with very unpredictable memory requirements.
