### PR TITLE
singularity for all ivar and lastz

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -720,6 +720,9 @@ tools:
     mem: 3.8
     params:
       singularity_enabled: true
+  toolshed.g2.bx.psu.edu/repos/devteam/lastz/.*:
+    params:
+      singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/devteam/lastz/lastz_wrapper_2/.*:
     cores: 16
     mem: 62
@@ -1798,6 +1801,9 @@ tools:
     mem: 10  
     params:
       singularity_enabled: true
+  toolshed.g2.bx.psu.edu/repos/iuc/ivar_.*:
+    params:
+      singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/.*:
     cores: 8
     mem: 30.7
@@ -1808,8 +1814,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/.*:
     cores: 8
     mem: 30.7
-    params:
-      singularity_enabled: true
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
these tools have been failing with conda envs on pulsar-mel3. All are good to go with singularity_enabled for all versions