### PR TITLE
extra environment variable for pilon

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2426,6 +2426,7 @@ tools:
     mem: 62
     env:
       _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
+      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     params:
       singularity_enabled: true
     scheduling:


### PR DESCRIPTION
Java options might not be being passed through the normal `_JAVA_OPTIONS` environment variable.

I doubt this will fix pilon but this should be tried first