### PR TITLE
All tools can have _JAVA_OPTIONS

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -7,6 +7,9 @@ tools:
     mem: cores * 3.8
     env: 
       HDF5_USE_FILE_LOCKING: "FALSE"
+      SINGULARITYENV_HDF5_USE_FILE_LOCKING: "FALSE"
+      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
+      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     context:
       partition: main
       test_cores: 1  # TODO: test_mem?

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -650,9 +650,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
     cores: 8
     mem: 30.7
-    env:
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     scheduling:
       accept:
       - pulsar
@@ -828,9 +825,6 @@ tools:
     mem: 11.5
     params:
       tmp_dir: true
-    env:
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     scheduling: # these jobs can run on pulsar but it may not be worth transferring them because the job walltime is much quicker than the transport time
       accept:
       - pulsar
@@ -1206,8 +1200,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/.*:
     cores: 7
     mem: 26.8
-    env:
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
   toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet.*:
     params:
       singularity_enabled: true 
@@ -1347,9 +1339,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/bbtools_.*:
     cores: 3
     mem: 11.5
-    env:
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/.*:
@@ -2424,9 +2413,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/pilon/pilon/.*:
     cores: 16
     mem: 62
-    env:
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     params:
       singularity_enabled: true
     scheduling:
@@ -3421,9 +3407,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/.*:
     cores: 3
     mem: 11.5
-    env:
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
a bunch of pilon jobs failed because the tool had the `_JAVA_OPTIONS` environment variable but not the `SINGULARITYENV__JAVA_OPTIONS` environment variable.

All tools can have java options set - they won't be used if it's not a java tool anyway. The lack of propagation of regular environment variables for container jobs is annoying but easy enough to get around if the variable can be put on the default tool like this.