### PR TITLE
bwa_mem2 data manager to run on pulsar-qld-high-mem1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3512,8 +3512,13 @@ tools:
     cores: 5
     mem: 19.1
   .*data_manager_bwa_mem2_index_builder.*:
-    cores: 16
-    mem: 100
+    cores: 20
+    mem: 250
+    scheduling:
+      accept:
+        - pulsar
+      require:
+        - pulsar-qld-high-mem1
   .*data_manager_cat.*:
     cores: 5
     mem: 19.1


### PR DESCRIPTION
There is probably a reason data managers are never scheduled to pulsar, but this job needs more memory than it can have anywhere else, so worth a try