### PR TITLE
update max mem for some worker VMs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -66,7 +66,7 @@ destinations:
     inherits: _slurm_destination
     runner: slurm
     max_accepted_cores: 32
-    max_accepted_mem: 122.86
+    max_accepted_mem: 125
     context:
       destination_total_cores: 192
       destination_total_mem: 737
@@ -81,7 +81,7 @@ destinations:
     inherits: _slurm_destination
     runner: slurm
     max_accepted_cores: 32
-    max_accepted_mem: 122.86
+    max_accepted_mem: 125
     context:
       destination_total_cores: 192
       destination_total_mem: 737
@@ -96,7 +96,7 @@ destinations:
         - training
   interactive_pulsar:
     max_accepted_cores: 32
-    max_accepted_mem: 122.86
+    max_accepted_mem: 125
     context:
       destination_total_cores: 192
       destination_total_mem: 737
@@ -120,7 +120,7 @@ destinations:
     inherits: _pulsar_destination
     runner: pulsar_mel2_runner
     max_accepted_cores: 8
-    max_accepted_mem: 31.45
+    max_accepted_mem: 31.25
     context:
       destination_total_cores: 56
       destination_total_mem: 220.15
@@ -134,7 +134,7 @@ destinations:
     inherits: _pulsar_destination
     runner: pulsar-mel3_runner
     max_accepted_cores: 32
-    max_accepted_mem: 63 # reduced from 122.86 to assist with scheduling
+    max_accepted_mem: 62.5 # can allocate up to 125 but this has been reduced so that those jobs are scheduled to abundant high memory resources
     context:
       destination_total_cores: 144
       destination_total_mem: 553
@@ -260,7 +260,7 @@ destinations:
     inherits: _pulsar_destination
     runner: pulsar-QLD_runner
     max_accepted_cores: 16
-    max_accepted_mem: 62.72
+    max_accepted_mem: 62.5
     context:
       destination_total_cores: 112
       destination_total_mem: 439

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3511,14 +3511,11 @@ tools:
   .*data_manager.*:
     cores: 5
     mem: 19.1
+    params:
+      singularity_enabled: true
   .*data_manager_bwa_mem2_index_builder.*:
-    cores: 20
-    mem: 250
-    scheduling:
-      accept:
-        - pulsar
-      require:
-        - pulsar-qld-high-mem1
+    cores: 6
+    mem: 125
   .*data_manager_cat.*:
     cores: 5
     mem: 19.1


### PR DESCRIPTION
Update mem values in destinations.yml.j2 so that the max allowed is the amount allowed in the slurm scheduler for the normal-sized VMs (32000/64000/128000 MB limits, corresponding to 31.25/62.5/125GB). Some were set higher than the slurm limit, some lower.

Revert scheduling of bwa_mem2 data manager since it cannot run on pulsar and enable singularity for all data managers.