### PR TITLE
put pulsar-qld-gpu3 offline for nvidia updates

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -372,6 +372,7 @@ destinations:
       accept:
         - pulsar-qld-gpu3
         - pulsar-qld-gpu-alphafold
+        - offline
   pulsar-qld-gpu4:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu4_runner


### PR DESCRIPTION
pulsar-qld-gpu3 needs to be taken offline so that Nvidia updates can be applied.