### PR TITLE
bwa_mem2 jobs need lots of memory always

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1423,12 +1423,13 @@ tools:
       accept:
       - pulsar
     rules:
-    - id: bwa_mem2_small_input_rule
-      if: input_size < 1
-      cores: 8
-      mem: 30.7
+    # TODO: address effect of reference genome size from data table (particularly aPseCor3hap2)
+    #- id: bwa_mem2_small_input_rule
+    #  if: input_size < 1
+    #  cores: 8
+    #  mem: 30.7
     - id: bwa_mem2_medium_input_rule
-      if: 1 <= input_size < 2
+      if: input_size < 2
       cores: 8
       mem: 100
     - id: bwa_mem2_fail_rule


### PR DESCRIPTION
There is a TODO here to account for reference genome size in history allocation. Both EU and Main do this for reference genome from history but not built in reference.