### PR TITLE
Switch toolmsg to type 'onload'

### DIFF
--- a/templates/galaxy/webhooks/toolmsg/config.yml.j2
+++ b/templates/galaxy/webhooks/toolmsg/config.yml.j2
@@ -1,7 +1,4 @@
 id: toolmsg
 type:
-  - masthead
+  - onload
 activate: true
-
-# icon: fa-graduation-cap
-# tooltip: See Galaxy Training Materials


### PR DESCRIPTION
This one was easier - it still works on 24.2 but I changed it to `type: onload` to get rid of the blank button in the masthead.