### PR TITLE
disable singularity for sam data manager

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3565,6 +3565,9 @@ tools:
   .*data_manager_interproscan.*:
     cores: 5
     mem: 19.1
+  .*data_manager_sam_fasta_index_builder.*:
+    params:
+      singularity_enabled: false
   .*hisat2_index_builder_data_manager.*:
     cores: 5
     mem: 19.1


### PR DESCRIPTION
looking into the possibility that data managers have been nerfed by singularity volume rules. Trying to override these at the tool level has not worked.