### PR TITLE
Fix subdomain name typo

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -29,6 +29,7 @@ certbot_domains:
   - "genome.{{ hostname }}"
   - "proteomics.{{ hostname }}"
   - "singlecell.{{ hostname }}"
+  - "microbe.{{ hostname }}"
 certbot_dns_provider: cloudflare
 certbot_dns_credentials:
   api_token: "{{ vault_dns_cloudflare_gvl_api_token }}"

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -431,7 +431,7 @@ galaxy_subsites:
       #masthead .navbar-text {
         display: none;
       }
-  - name: microgalaxy
+  - name: microbe
     brand: Microbe Lab
     iframe: "https://labs.usegalaxy.org.au/?content_root=https://github.com/galaxyproject/galaxy_codex/blob/main/communities/microgalaxy/lab/usegalaxy.org.au.yml"
     wallpaper: false


### PR DESCRIPTION
Sorry, I called it `microgalaxy` instead of `microbe`