### PR TITLE
Force update local WALLE DB

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -869,6 +869,7 @@ walle_tool: interactive_tool
 walle_virtualenv: "{{ galaxy_venv_dir }}"
 walle_bashrc: "{{ galaxy_root }}/walle/.bashrc"
 walle_malware_database_location: "{{ galaxy_root }}/walle"
+walle_malware_database_force_update: true
 walle_filesize_min: 0
 walle_verbose: false
 walle_kill: false


### PR DESCRIPTION
This ensures that if there are local changes to WALLE's checksums.yml file (which there shouldn't be on prod), it will still be downloaded/updated from the global "intergalactic most wanted" repo. If we want to add checksums to prod WALLE, the correct approach is to add them to the IGMW list.