### PR TITLE
use latest conda on dev

### DIFF
--- a/group_vars/dev.yml
+++ b/group_vars/dev.yml
@@ -39,3 +39,16 @@ host_machine_users:
         - galaxy_admin
       key: files/keys/tom.pub
       email: "{{ tom_email }}"
+
+# miniconda: stop pinning conda!
+
+# this is to override what is in all.yml with the role default
+miniconda_installer: >-
+  Miniconda3-{{ 'py' ~ (miniconda_python | replace('.', '')) ~ '_' ~ miniconda_version if miniconda_installer_version != 'latest' else 'latest' }}-{{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+
+miniconda_version: latest
+
+miniconda_channels:  # defaults is no longer used in galaxy conda building
+  - conda-forge
+  - bioconda
+miniconda_base_env_packages: []

--- a/host_vars/dev-pulsar.gvl.org.au.yml
+++ b/host_vars/dev-pulsar.gvl.org.au.yml
@@ -15,7 +15,7 @@ pulsar_queue_url: "dev-queue.gvl.org.au"
 pulsar_rabbit_username: "galaxy_au"
 pulsar_rabbit_vhost: "/pulsar/galaxy_au"
 
-pulsar_conda_exec: "mamba"  # Use mamba as replacement for conda
+pulsar_conda_exec: "conda"  # conda uses mamba as resolver in later versions
 
 extra_keys:
   - id: ubuntu_maintenance_key

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -71,6 +71,9 @@ galaxy_job_working_directory: "{{ galaxy_tmp_dir }}/job_working_directory"
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_24.2
 
+# upon upgrade to latest conda
+galaxy_conda_exec: conda
+
 galaxy_file_path: "{{ galaxy_root }}/data-3"
 nginx_upload_store_base_dir: "{{ galaxy_file_path }}/upload_store"
 nginx_upload_store_dir: "{{ nginx_upload_store_base_dir }}/uploads"


### PR DESCRIPTION
The aim is to move away from pinning the conda version and maintaining a mamba package. The latest conda will use mamba as a resolver. Fingers crossed that this just works.

For issue #1931 