### PR TITLE
use ports instead of sockets for nginx bind

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -126,9 +126,16 @@ host_galaxy_config_gravity:
   app_server: gunicorn
   virtualenv: "{{ galaxy_venv_dir }}"
   gunicorn:
-    - bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"
+    - bind: "0.0.0.0:8888"
       # performance options
-      workers: 2
+      workers: 1
+      # Other options that will be passed to gunicorn
+      extra_args: '--forwarded-allow-ips="*"'
+      preload: true
+      environment: "{{ galaxy_process_env }}"
+    - bind: "0.0.0.0:8889"
+      # performance options
+      workers: 1
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       preload: true

--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -43,7 +43,7 @@ host_galaxy_config_gravity:
   app_server: gunicorn
   virtualenv: "{{ galaxy_venv_dir }}"
   gunicorn:
-    - bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.handlers.sock"
+    - bind: "0.0.0.0:8888"
       # performance options
       workers: 2
       # Other options that will be passed to gunicorn

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -105,7 +105,7 @@ host_galaxy_config_gravity:
     enable: false
     enable_beat: false
   gunicorn:
-    - bind: unix:{{ galaxy_mutable_config_dir }}/gunicorn1.sock
+    - bind: "0.0.0.0:8888"
       workers: 2
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
@@ -113,7 +113,7 @@ host_galaxy_config_gravity:
       restart_timeout: 1800
       preload: true
       environment: "{{ galaxy_process_env }}"
-    - bind: unix:{{ galaxy_mutable_config_dir }}/gunicorn2.sock
+    - bind: "0.0.0.0:8889"
       workers: 2
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -97,7 +97,7 @@ host_galaxy_config: # renamed from __galaxy_config
     app_server: gunicorn
     virtualenv: "{{ galaxy_venv_dir }}"
     gunicorn:
-      - bind: "unix:{{ galaxy_mutable_config_dir }}/gunicorn.sock"
+      - bind: "0.0.0.0:8888"
         # performance options
         workers: 2
         # Other options that will be passed to gunicorn

--- a/templates/nginx/galaxy-handlers.j2
+++ b/templates/nginx/galaxy-handlers.j2
@@ -1,7 +1,6 @@
 upstream galaxy {
-{% set num_gunicorn_processes = galaxy_config.gravity.gunicorn | length %}
 {% for gunicorn_process in galaxy_config.gravity.gunicorn %}
-    server {{ gunicorn_process.bind | replace('unix:', 'unix://') }} weight={{ (100-debug.memray.weight / galaxy_config.gravity.gunicorn|length) | int }};
+    server {{ gunicorn_process.bind }} weight={{ (100-debug.memray.weight / galaxy_config.gravity.gunicorn|length) | int }};
 {% endfor %}
 {% if debug.memray.weight > 0 %}
     server localhost:8082 weight={{ debug.memray.weight | int }};

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -1,7 +1,7 @@
 upstream galaxy {
 {% set num_gunicorn_processes = galaxy_config.gravity.gunicorn | length %}
 {% for gunicorn_process in galaxy_config.gravity.gunicorn %}
-    server {{ gunicorn_process.bind | replace('unix:', 'unix://') }} weight={{ (100-debug.memray.weight / galaxy_config.gravity.gunicorn|length) | int }};
+    server {{ gunicorn_process.bind }} weight={{ (100-debug.memray.weight / galaxy_config.gravity.gunicorn|length) | int }};
 {% endfor %}
 {% if debug.memray.weight > 0 %}
     server localhost:8082 weight={{ debug.memray.weight | int }};


### PR DESCRIPTION
Rolling restarts stopped working with release 24.2 and the galaxy and galaxy_update_configs playbooks have been broken as a result. Switching to using ports instead of sockets fixes this.

This also adds an extra gunicorn on dev