### PR TITLE
pulsar-quick for pqhm1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -208,7 +208,8 @@ destinations:
         - gtdbtk_database
       require:
         - pulsar
-        - offline
+        - pulsar-quick # while waiting for one last job to finish, quick jobs may run here (5/3/25 CB)
+        # - offline
   pulsar-qld-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem2_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1426,6 +1426,8 @@ tools:
     cores: 20
     mem: 250
     scheduling:
+      accept:
+      - pulsar-quick
       prefer:
       - pulsar
     rules:


### PR DESCRIPTION
Let pulsar-qld-high-mem1 run "quick" jobs while it waits for the last job to finish.  The tools tagged with pulsar-quick that can run there are bwa_mem2 and minimap, better than nothing.