### PR TITLE
tpv prep for QLD outages

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -274,7 +274,7 @@ destinations:
         - bakta_database
       require:
         - pulsar
-        #- pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
+        - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -72,6 +72,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
     rules:
     - id: augustus_small_input_rule
       if: input_size < 0.01
@@ -1146,6 +1147,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/.*:
     cores: 6
     mem: 23.0
@@ -1220,6 +1222,8 @@ tools:
     # note: this fails tests with singularity (version 2.4.0)
     mem: 8
   toolshed.g2.bx.psu.edu/repos/genouest/braker3/braker3/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 2
     cores: 16
     mem: 62
     params:
@@ -1334,6 +1338,7 @@ tools:
       scheduling:
         accept:
           - pulsar
+          - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/iuc/baredsc_.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
pulsar-QLD needs an outage for various restarts, so it may only run quick jobs for now. This could be efficient if we could find enough job types to add the 'pulsar-quick' tag to.

Limit braker3 to 2 jobs per person