### PR TITLE
remove build_mulled_singularity from container resolvers

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -264,9 +264,6 @@ group_galaxy_config:
         cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
       - type: mulled_singularity
         cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
-      - type: build_mulled_singularity
-        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
-        auto_install: false
 
     # Taken from usegalaxy.org
     tool_name_boost: 0.1


### PR DESCRIPTION
GA does not need this container resolver option is never used - from handler logs it is the order of trying resolvers is clear and it never gets as far as build_mulled_singularity.