### PR TITLE
Dev: Set job_working_directory in TPV for all remote pulsar destinations

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -41,6 +41,7 @@ destinations:
   _pulsar_destination:
     abstract: true
     params:
+      job_working_directory: "{{ galaxy_pulsar_job_working_directory }}"
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
       jobs_directory: /mnt/pulsar/files/staging # TODO: this could be a variable
       transport: curl

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -68,6 +68,12 @@ galaxy_tus_upload_store: "{{ galaxy_tmp_dir }}/tus"
 
 galaxy_job_working_directory: "{{ galaxy_tmp_dir }}/job_working_directory"
 
+# separate galaxy location for pulsar job JWDs close to upload store
+galaxy_pulsar_job_working_directory: "{{ galaxy_tmp_dir }}/pulsar_jwds"
+
+host_galaxy_extra_dirs:
+  - "{{ galaxy_pulsar_job_working_directory }}"
+
 galaxy_repo: https://github.com/galaxyproject/galaxy.git
 galaxy_commit_id: release_24.2
 


### PR DESCRIPTION
Test overriding the job_working_directory job working directory for pulsar jobs only. All jobs have a JWD on galaxy, including pulsar ones. The location of the galaxy JWDs can be tricky when job outputs are being posted back to galaxy by via the upload store.