### PR TITLE
Set pqhm1 to offline and pqhm0 to pulsar-quick

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -207,6 +207,7 @@ destinations:
         - pulsar-qld-high-mem0
       require:
         - pulsar
+        - pulsar-quick
   pulsar-qld-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem1_runner
@@ -223,8 +224,7 @@ destinations:
         - gtdbtk_database
       require:
         - pulsar
-        - pulsar-quick # while waiting for one last job to finish, quick jobs may run here (5/3/25 CB)
-        # - offline
+        - offline
   pulsar-qld-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem2_runner


### PR DESCRIPTION
For QLD hypervisor maintenance
pqhm1 -> offline. Current jobs will be finished by tomorrow and I can let them know.
pqhm0 -> require 'pulsar-quick' so this can be then next one to take offline.