### PR TITLE
Do not override log_level in host_vars/galaxy

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -204,7 +204,6 @@ host_galaxy_config: # renamed from __galaxy_config
       usegalaxy.org.au: "{{ galaxy_config_dir }}/themes/themes_main.yml"
 
     sentry_dsn: "{{ vault_sentry_url_galaxy_production }}"
-    log_level: INFO
 
     celery_conf:
       result_backend: "redis://:{{ vault_redis_requirepass }}@{{ hostvars['galaxy-queue']['internal_ip'] }}:6379/0"


### PR DESCRIPTION
Since a bug has been fixed, there are no longer lots of error messages in the gunicorn logs, everything is smaller and we can have log_level: TRACE again, as set in group_vars/galaxyservers