### PR TITLE
Log values when checking concurrent job per tool in TPV

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -41,9 +41,13 @@ tools:
         total_limit_exceeded = False
         user_limit_exceeded = False
         if max_concurrent_job_count_for_tool_total:
-          total_limit_exceeded = helpers.concurrent_job_count_for_tool(app, tool) >= max_concurrent_job_count_for_tool_total
+          concurrent_job_count_for_tool_total = helpers.concurrent_job_count_for_tool(app, tool)
+          log.info(f"++ ---tpv limit debug -- total limit: {concurrent_job_count_for_tool_total} concurrent jobs of {max_concurrent_job_count_for_tool_total} limit for tool {tool.id}")
+          total_limit_exceeded = concurrent_job_count_for_tool_total >= max_concurrent_job_count_for_tool_total
         if max_concurrent_job_count_for_tool_user and not total_limit_exceeded:
-          user_limit_exceeded = helpers.concurrent_job_count_for_tool(app, tool, user) >= max_concurrent_job_count_for_tool_user
+          concurrent_job_count_for_tool_user = helpers.concurrent_job_count_for_tool(app, tool, user)
+          log.info(f"++ ---tpv limit debug: -- user limit: {concurrent_job_count_for_tool_user} concurrent jobs of {max_concurrent_job_count_for_tool_user} limit for tool {tool.id} per user")
+          user_limit_exceeded = concurrent_job_count_for_tool_user >= max_concurrent_job_count_for_tool_user
         total_limit_exceeded or user_limit_exceeded
       execute: |
         from galaxy.jobs.mapper import JobNotReadyException


### PR DESCRIPTION
Trying to understand why so many jobs queue for trinity, however this may be an inheritance issue and I'm going to try that first.