### PR TITLE
Set concurrent user limit for trinity

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3084,6 +3084,8 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 2
     cores: 60
     mem: 961
     params:


### PR DESCRIPTION
This is currently set for `/trinity.*` and not `/trinity/trinity/.*`. The simplest thing to hope for is that inheritance hasn't worked as expected. If this doesn't fix it, it's a much bigger problem.