### PR TITLE
disable daily stats collection for now

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -239,7 +239,7 @@ influx_url: "stats.usegalaxy.org.au"
 influx_db_stats: "GA_server"
 stats_db_password: "{{ galaxy_db_reader_password }}"
 influx_salt: "{{ prod_queue_size_salt }}"
-add_daily_stats: true
+add_daily_stats: false
 add_monthly_stats: true
 add_utilisation_info: true
 add_queue_info: true


### PR DESCRIPTION
daily stats collection is running all of the influx friendly queries in gxadmin for time window since the beginning of time. Recently there has been a daily spike of ~15GB of database disk use at about the time that the daily stats script is run