### PR TITLE
really big cvmfs caches for high mem and blast

### DIFF
--- a/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
+++ b/host_vars/pulsar-high-mem1/pulsar-high-mem1.yml
@@ -24,7 +24,7 @@ use_internal_ips: false
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 250000
+cvmfs_quota_limit: 819200
 
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au

--- a/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
+++ b/host_vars/pulsar-high-mem2/pulsar-high-mem2.yml
@@ -24,7 +24,7 @@ use_internal_ips: false
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 750000
+cvmfs_quota_limit: 819200
 
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au

--- a/host_vars/pulsar-qld-blast.yml
+++ b/host_vars/pulsar-qld-blast.yml
@@ -19,7 +19,7 @@ pulsar_rabbit_vhost: "/pulsar/galaxy_qld_blast"
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 1230000
+cvmfs_quota_limit: 1638400
 
 # TODO: carefull remove telegraf_agent_output from everywhere and put it in all.yml
 # Need to make sure that telegraf_influx_db_name is set properly everywhere

--- a/host_vars/qld-pulsar-himem-0.yml
+++ b/host_vars/qld-pulsar-himem-0.yml
@@ -32,7 +32,7 @@ use_internal_ips: false
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 250000
+cvmfs_quota_limit: 819200
 
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au

--- a/host_vars/qld-pulsar-himem-1.yml
+++ b/host_vars/qld-pulsar-himem-1.yml
@@ -32,7 +32,7 @@ use_internal_ips: false
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 250000
+cvmfs_quota_limit: 819200
 
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au

--- a/host_vars/qld-pulsar-himem-2.yml
+++ b/host_vars/qld-pulsar-himem-2.yml
@@ -32,7 +32,7 @@ use_internal_ips: false
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 250000
+cvmfs_quota_limit: 819200
 
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au


### PR DESCRIPTION
even with 250GB of cache space available, pqhm1 is cleaning out its cache several times a day. Making space for this seems more pressing than space for files. If file space becomes an issue this can be revisited.