### PR TITLE
put singularity default container id in context

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -29,6 +29,8 @@ tools:
       slurm_docker_volumes: "{{ slurm_docker_volumes }}"
       pulsar_singularity_volumes: "{{ pulsar_singularity_volumes }}"
       pulsar_docker_volumes: "{{ pulsar_docker_volumes }}"
+      singularity_default_container_id: "{{ singularity_default_container_id }}"
+
     scheduling:
       reject:
         - offline

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -48,7 +48,7 @@ destinations:
             container_resolvers: 
                 - type: explicit_singularity
                 - type: mulled_singularity
-            singularity_default_container_id: "{{ singularity_default_container_id }}"
+            singularity_default_container_id: '{ singularity_default_container_id }'
             dependency_resolution: none
         env:
           SINGULARITY_CACHEDIR: /mnt/pulsar/deps/singularity


### PR DESCRIPTION
move templated `singularity_default_container_id` to context so that it can be overridden.

We did something similar with singularity and docker volumes a while ago.
