### PR TITLE
Collect labs logs

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -50,8 +50,10 @@
       tags: webhooks
     - role: usegalaxy_eu.galaxy_subdomains
       tags: galaxy_subdomains
-    - nginx-upload-module
-    - galaxyproject.nginx
+    - name: nginx-upload-module
+      tags: nginx
+    - name: galaxyproject.nginx
+      tags: nginx
     - galaxyproject.tusd
     - geerlingguy.nfs
     - galaxyproject.slurm
@@ -111,6 +113,7 @@
       with_items:
         - "{{ nginx_log_olddir_root }}"
         - "{{ nginx_long_term_log_dir }}"
+      tags: nginx
     - name: Add lines to main block in nginx logrotate conf
       lineinfile:
         path: /etc/logrotate.d/nginx
@@ -119,6 +122,7 @@
       with_items:
         - "\tdateext"
         - "\tolddir {{ nginx_log_olddir_root }}"
+      tags: nginx
     - name: Add lines to postrotate task in nginx logrotate conf
       lineinfile:
         path: /etc/logrotate.d/nginx
@@ -126,3 +130,4 @@
         insertafter: "\tpostrotate"
       with_items:
         - "\t\tcp {{ nginx_log_olddir_root }}/* {{ nginx_long_term_log_dir }}/"
+      tags: nginx

--- a/templates/nginx/galaxy-dev.j2
+++ b/templates/nginx/galaxy-dev.j2
@@ -1,3 +1,28 @@
+map $http_referer $log_lab {
+    default 0;
+    ~*://[^/]+\.(dev\.gvl\.[a-z.]+) 1;
+}
+
+map $request $log_tool_click {
+    default 0;
+    ~*/api/tools/toolshed\.g2\.bx\.psu\.edu 1;
+}
+
+map $request $log_welcome {
+    default 0;
+    ~*/welcome 1;
+}
+
+map "$log_lab:$log_welcome" $log_lab_welcome {
+    default 0;
+    "1:1" 1;
+}
+
+map "$log_lab:$log_tool_click" $log_lab_tool {
+    default 0;
+    "1:1" 1;
+}
+
 server {
     # Listen on port 443
     listen        *:443 ssl default_server;
@@ -8,6 +33,15 @@ server {
     access_log  /var/log/nginx/access.log;
     error_log   /var/log/nginx/error.log;
     sendfile    on;
+
+    # Special log files for Galaxy Labs
+    access_log /var/log/nginx/labs-welcome.access.log galaxy if=$log_lab_welcome;
+    access_log /var/log/nginx/labs-tools.access.log galaxy if=$log_lab_tool;
+    add_header X-Lab $log_lab;
+    add_header X-ToolClick $log_tool_click;
+    add_header X-Welcome $log_welcome;
+    add_header X-LabWelcome $log_lab_welcome;
+    add_header X-LabTool $log_lab_tool;
 
     uwsgi_buffer_size 16k;
     uwsgi_busy_buffers_size 24k;

--- a/templates/nginx/galaxy-dev.j2
+++ b/templates/nginx/galaxy-dev.j2
@@ -35,8 +35,8 @@ server {
     sendfile    on;
 
     # Special log files for Galaxy Labs
-    access_log /var/log/nginx/labs-welcome.access.log galaxy if=$log_lab_welcome;
-    access_log /var/log/nginx/labs-tools.access.log galaxy if=$log_lab_tool;
+    access_log /var/log/nginx/labs-welcome.access.log if=$log_lab_welcome;
+    access_log /var/log/nginx/labs-tools.access.log if=$log_lab_tool;
     add_header X-Lab $log_lab;
     add_header X-ToolClick $log_tool_click;
     add_header X-Welcome $log_welcome;

--- a/templates/nginx/galaxy-dev.j2
+++ b/templates/nginx/galaxy-dev.j2
@@ -1,28 +1,3 @@
-map $http_referer $log_lab {
-    default 0;
-    ~*://[^/]+\.(dev\.gvl\.[a-z.]+) 1;
-}
-
-map $request $log_tool_click {
-    default 0;
-    ~*/api/tools/toolshed\.g2\.bx\.psu\.edu 1;
-}
-
-map $request $log_welcome {
-    default 0;
-    ~*/welcome 1;
-}
-
-map "$log_lab:$log_welcome" $log_lab_welcome {
-    default 0;
-    "1:1" 1;
-}
-
-map "$log_lab:$log_tool_click" $log_lab_tool {
-    default 0;
-    "1:1" 1;
-}
-
 server {
     # Listen on port 443
     listen        *:443 ssl default_server;
@@ -33,15 +8,6 @@ server {
     access_log  /var/log/nginx/access.log;
     error_log   /var/log/nginx/error.log;
     sendfile    on;
-
-    # Special log files for Galaxy Labs
-    access_log /var/log/nginx/labs-welcome.access.log if=$log_lab_welcome;
-    access_log /var/log/nginx/labs-tools.access.log if=$log_lab_tool;
-    add_header X-Lab $log_lab;
-    add_header X-ToolClick $log_tool_click;
-    add_header X-Welcome $log_welcome;
-    add_header X-LabWelcome $log_lab_welcome;
-    add_header X-LabTool $log_lab_tool;
 
     uwsgi_buffer_size 16k;
     uwsgi_busy_buffers_size 24k;

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -1,3 +1,28 @@
+map $http_referer $log_lab {
+    default 0;
+    ~*://[^/]+\.(usegalaxy\.[a-z.]+) 1;
+}
+
+map $request $log_tool_click {
+    default 0;
+    ~*/api/tools/toolshed\.g2\.bx\.psu\.edu 1;
+}
+
+map $request $log_welcome {
+    default 0;
+    ~*/welcome 1;
+}
+
+map "$log_lab:$log_welcome" $log_lab_welcome {
+    default 0;
+    "1:1" 1;
+}
+
+map "$log_lab:$log_tool_click" $log_lab_tool {
+    default 0;
+    "1:1" 1;
+}
+
 upstream galaxy {
 {% set num_gunicorn_processes = galaxy_config.gravity.gunicorn | length %}
 {% for gunicorn_process in galaxy_config.gravity.gunicorn %}
@@ -18,6 +43,15 @@ server {
     access_log  /var/log/nginx/access.log;
     error_log   /var/log/nginx/error.log;
     sendfile    on;
+
+    # Special log files for Galaxy Labs
+    access_log /var/log/nginx/labs-welcome.access.log galaxy if=$log_lab_welcome;
+    access_log /var/log/nginx/labs-tools.access.log galaxy if=$log_lab_tool;
+    add_header X-Lab $log_lab;
+    add_header X-ToolClick $log_tool_click;
+    add_header X-Welcome $log_welcome;
+    add_header X-LabWelcome $log_lab_welcome;
+    add_header X-LabTool $log_lab_tool;
 
     uwsgi_buffer_size 16k;
     uwsgi_busy_buffers_size 24k;

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -45,8 +45,8 @@ server {
     sendfile    on;
 
     # Special log files for Galaxy Labs
-    access_log /var/log/nginx/labs-welcome.access.log galaxy if=$log_lab_welcome;
-    access_log /var/log/nginx/labs-tools.access.log galaxy if=$log_lab_tool;
+    access_log /var/log/nginx/labs-welcome.access.log if=$log_lab_welcome;
+    access_log /var/log/nginx/labs-tools.access.log if=$log_lab_tool;
 
     uwsgi_buffer_size 16k;
     uwsgi_busy_buffers_size 24k;

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -1,23 +1,20 @@
 map $http_referer $log_lab {
+    # It is a subdomain of dev.gvl.org.au or usegalaxy.org.au
     default 0;
-    ~*://[^/]+\.(usegalaxy\.[a-z.]+) 1;
+    ~*://[^/]+\.(usegalaxy|dev\.gvl)\.org\.au 1;
 }
-
 map $request $log_tool_click {
     default 0;
-    ~*/api/tools/toolshed\.g2\.bx\.psu\.edu 1;
+    ~*/api/tools/toolshed.+build 1;
 }
-
 map $request $log_welcome {
     default 0;
     ~*/welcome 1;
 }
-
 map "$log_lab:$log_welcome" $log_lab_welcome {
     default 0;
     "1:1" 1;
 }
-
 map "$log_lab:$log_tool_click" $log_lab_tool {
     default 0;
     "1:1" 1;
@@ -45,8 +42,8 @@ server {
     sendfile    on;
 
     # Special log files for Galaxy Labs
-    access_log /var/log/nginx/labs-welcome.access.log if=$log_lab_welcome;
-    access_log /var/log/nginx/labs-tools.access.log if=$log_lab_tool;
+    access_log /var/log/nginx/labs-welcome.access.log combined if=$log_lab_welcome;
+    access_log /var/log/nginx/labs-tools.access.log combined if=$log_lab_tool;
 
     uwsgi_buffer_size 16k;
     uwsgi_busy_buffers_size 24k;
@@ -61,6 +58,13 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
         
         add_header X-Clacks-Overhead 'GNU James Taylor (@jxtx) Simon Gladman (@slugger70)';
+
+        # For DEBUGGING ONLY, remove when confirmed working:
+        add_header X-Lab $log_lab;
+        add_header X-ToolClick $log_tool_click;
+        add_header X-Welcome $log_welcome;
+        add_header X-LabWelcome $log_lab_welcome;
+        add_header X-LabTool $log_lab_tool;
     }
 
     location ~ ^/api/dataset_collections/([^/]+)/download/?$ {

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -47,12 +47,6 @@ server {
     # Special log files for Galaxy Labs
     access_log /var/log/nginx/labs-welcome.access.log galaxy if=$log_lab_welcome;
     access_log /var/log/nginx/labs-tools.access.log galaxy if=$log_lab_tool;
-    # For debugging only, remove when confirmed working:
-    add_header X-Lab $log_lab;
-    add_header X-ToolClick $log_tool_click;
-    add_header X-Welcome $log_welcome;
-    add_header X-LabWelcome $log_lab_welcome;
-    add_header X-LabTool $log_lab_tool;
 
     uwsgi_buffer_size 16k;
     uwsgi_busy_buffers_size 24k;

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -47,6 +47,7 @@ server {
     # Special log files for Galaxy Labs
     access_log /var/log/nginx/labs-welcome.access.log galaxy if=$log_lab_welcome;
     access_log /var/log/nginx/labs-tools.access.log galaxy if=$log_lab_tool;
+    # For debugging only, remove when confirmed working:
     add_header X-Lab $log_lab;
     add_header X-ToolClick $log_tool_click;
     add_header X-Welcome $log_welcome;


### PR DESCRIPTION
Add some filtered Nginx log files for Galaxy Labs usage reporting. These log statements will allow us to capture visits and tool clicks in each Galaxy Lab.

See `/var/log/nginx/labs-welcome.access.log` on dev.gvl.org.au for an example log file. This file receives one log line per Galaxy Lab welcome page load:

```
cameron@dev:/var/log/nginx$ cat labs-welcome.access.log 
1.128.110.63 - - [08/Apr/2025:03:51:13 +0000] "GET /welcome HTTP/1.1" 302 281 "https://genome.dev.gvl.org.au/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
```

And  `/var/log/nginx/labs-tools.access.log` receives two lines (GET + POST) per tool form load in a Galaxy Lab:

```
cameron@dev:/var/log/nginx$ cat labs-tools.access.log 
1.128.110.63 - - [08/Apr/2025:03:50:45 +0000] "POST /api/tools/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0/build HTTP/1.1" 200 2911 "https://genome.dev.gvl.org.au/root?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Ffastqc%2Ffastqc" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
```