### PR TITLE
mount new custom indices volume on misc

### DIFF
--- a/host_vars/galaxy-misc-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-misc-nfs.usegalaxy.org.au.yml
@@ -15,6 +15,10 @@ attached_volumes:
     path: "{{ nfs_custom_indices_dir }}"
     fstype: ext4
     partition: 1
+  - device: /dev/vde
+    path: "/mnt/indices2" # new volume for custom-indices data, will replace /mnt/custom-indices
+    fstype: ext4
+    partition: 1
 
 nfs_dirs:
   - "{{ nfs_app_dir }}"


### PR DESCRIPTION
New 4TB volume is replacing the 3TB volume but has the placeholder name `indices2` in the meantime.
We sync old to new and switch them on an early morning when there are no jobs running using the data. No hurry.
Then the old volume is recycled and there is volume matter that can be used to expand /mnt/tools