### PR TITLE
read perthNFS2 and perthNFS4 from qld

### DIFF
--- a/templates/galaxy/config/galaxy_object_store_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.yml.j2
@@ -107,18 +107,6 @@ backends:
   store_by: id
   files_dir: /mnt/user-data-volA/user-data-7
 
-{% if pawsey_file_mounts_available|d(True) %}
-- id: perthNFS4
-  weight: 0
-  type: disk
-  store_by: id
-  files_dir: {{ pawsey_file_mounts_path }}/user-data-4/perthNFS4
-- id: perthNFS2
-  weight: 0
-  type: disk
-  store_by: id
-  files_dir: {{ pawsey_file_mounts_path }}/user-data-2/perthNFS2
-{% endif %}
 {% if qld_file_mounts_available|d(True) %}
 - id: qldNFS1
   weight: 0
@@ -135,11 +123,21 @@ backends:
   type: disk
   store_by: id
   files_dir: {{ qld_file_mounts_path }}/files/perthNFS1
+- id: perthNFS2
+  weight: 0
+  type: disk
+  store_by: id
+  files_dir: {{ qld_file_mounts_path }}/files/perthNFS2
 - id: perthNFS3
   weight: 0
   type: disk
   store_by: id
   files_dir: {{ qld_file_mounts_path }}/files/perthNFS3
+- id: perthNFS4
+  weight: 0
+  type: disk
+  store_by: id
+  files_dir: {{ qld_file_mounts_path }}/files/perthNFS4
 - id: aarnetNFS5
   weight: 0
   type: disk
@@ -151,6 +149,15 @@ backends:
   store_by: id
   files_dir: {{ qld_file_mounts_path }}/files/aarnetNFS6
 {% endif %}
+
+- id: pawsey_nfs_test
+  weight: 0
+  type: disk
+  store_by: uuid
+  files_dir: {{ pawsey_file_mounts_path }}/user-data/pawsey_nfs_test
+  extra_dirs:
+    - type: job_work
+      path: /mnt/scratch/job_working_directory
 
 {% if test_object_store_paths_enabled|d(False) %}
 - id: minio_test
@@ -236,14 +243,6 @@ backends:
     path: /mnt/user-data-volD/pawsey_s3_test_cache
     size: 50
     cache_updated_data: true
-  extra_dirs:
-    - type: job_work
-      path: /mnt/scratch/job_working_directory
-- id: pawsey_nfs_test
-  weight: 0
-  type: disk
-  store_by: uuid
-  files_dir: {{ pawsey_file_mounts_path }}/user-data/pawsey_nfs_test
   extra_dirs:
     - type: job_work
       path: /mnt/scratch/job_working_directory


### PR DESCRIPTION
Remaining perth NFS dirs are available on the QLD volume

Enable a test object store backend (pawsey_nfs_test) so that data can be purged from galaxy. I'll remove this afterwards.