### PR TITLE
remove large cpu/mem allocation for phyml

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2441,8 +2441,6 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/phyml/phyml/.*:
-    cores: 60
-    mem: 961
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
This has persisted in the configuration because Simon made a local alteration to the phyml wrapper to allow it to run with multiple threads. This was during pawsey times and we no longer have that wrapper, so phyml is single threaded.