### PR TITLE
lower the min_accepted_mem to 50 on pqhm0

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -199,7 +199,7 @@ destinations:
     runner: pulsar-qld-high-mem0_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 62.51
+    min_accepted_mem: 50
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07


### PR DESCRIPTION
Allow pulsar-qld-high-mem0 to take some of the bigger small-medium jobs