### PR TITLE
update slurm conf and limits

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -146,6 +146,8 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 2
     cores: 8
     mem: 30.7
     params:
@@ -155,6 +157,8 @@ tools:
       - pulsar
       - pulsar-quick
   toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 2
     cores: 8
     mem: 30.7
     params:
@@ -699,7 +703,7 @@ tools:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/.*:
     context:
-      max_concurrent_job_count_for_tool_user: 4
+      max_concurrent_job_count_for_tool_user: 2
     cores: 8
     mem: 30.7
     params:
@@ -3547,6 +3551,8 @@ tools:
       if: input_size >= 0.5
       fail: Too much data, please don't use MAFFT for this.
   toolshed.g2.bx.psu.edu/repos/rnateam/sortmerna/bg_sortmerna/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 2
     cores: 8
     mem: 30.7
   toolshed.g2.bx.psu.edu/repos/rnateam/targetfinder/targetfinder/.*:

--- a/group_vars/galaxy_etca_slurm.yml
+++ b/group_vars/galaxy_etca_slurm.yml
@@ -88,7 +88,8 @@ slurm_nodes:
 
 slurm_partitions:
   - name: main
-    nodes: "galaxy-w1,galaxy-w2,galaxy-w3,galaxy-w4,galaxy-w5,galaxy-w6,galaxy-w8,galaxy-w9,galaxy-w10"
+    # nodes: "galaxy-w1,galaxy-w2,galaxy-w3,galaxy-w4,galaxy-w5,galaxy-w6,galaxy-w8,galaxy-w9,galaxy-w10"
+    nodes: "galaxy-w1,galaxy-w2,galaxy-w3,galaxy-w4,galaxy-w5,galaxy-w8,galaxy-w9,galaxy-w10" # 30/4/25 temporary removal of w6 from non-training
     Default: YES
     State: UP
   - name: training
@@ -96,7 +97,8 @@ slurm_partitions:
     Default: NO
     State: UP
   - name: interactive_tools
-    nodes: "galaxy-w4,galaxy-w5,galaxy-w6"
+    # nodes: "galaxy-w4,galaxy-w5,galaxy-w6"
+    nodes: "galaxy-w4,galaxy-w5" # 30/4/25 temporary removal of w6 from non-training
     Default: NO
     State: UP
     MaxTime: "10:00:00"

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -520,7 +520,7 @@ job_conf_limits:
     value: 80
   - type: destination_user_concurrent_jobs
     id: slurm
-    value: 6
+    value: 5
 
   - type: destination_total_concurrent_jobs
     id: slurm-training


### PR DESCRIPTION
galaxy-w6 becomes training only

reduce concurrent slurm destination limit per user from 6 to 5

set limit per user to 2 for freebayes, sortmerna and some deeptools tools. This is too low and will need to be increased again, or maybe some of these tools are OK on pulsar.