### PR TITLE
reduce min mem for pqhm0 and pqhm1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -77,6 +77,7 @@ destinations:
         - gtdbtk_database
         - bakta_database
         - funannotate
+        - eggnog
   slurm-training:
     inherits: _slurm_destination
     runner: slurm
@@ -92,6 +93,7 @@ destinations:
         - gtdbtk_database
         - bakta_database
         - funannotate
+        - eggnog
       require:
         - training
   interactive_pulsar:
@@ -128,6 +130,7 @@ destinations:
     scheduling:
       accept:
         - bakta_database
+        - eggnog
       require:
         - pulsar
   pulsar-mel3:
@@ -144,6 +147,7 @@ destinations:
         - pulsar-mel3
         - bakta_database
         - funannotate
+        - eggnog
         - training # Temporary reroute while training pulsar is offline
         # - pulsar-blast  # alternate location for pulsar blast jobs when pulsar-qld-blast is unavailable
       require:
@@ -199,7 +203,7 @@ destinations:
     runner: pulsar-qld-high-mem0_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 39
+    min_accepted_mem: 30
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07
@@ -215,7 +219,7 @@ destinations:
     runner: pulsar-qld-high-mem1_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 62.51
+    min_accepted_mem: 30
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07
@@ -256,6 +260,7 @@ destinations:
         - pulsar-blast # allow training jobs with require: pulsar-blast to run here
         - bakta_database
         - funannotate
+        - eggnog
       require:
         - pulsar
         - training

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1170,6 +1170,8 @@ tools:
       accept:
       - pulsar
       - pulsar-quick
+      require:
+      - eggnog
   toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/.*:
     cores: 6
     mem: 23.0


### PR DESCRIPTION
Allow the 8 cpu 32GB jobs to go to high memory pulsars as well, this should be fine except for eggnog