### PR TITLE
override lotus2 small input rule from shared db

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -936,6 +936,10 @@ tools:
     mem: 16  # TODO - follow up with shared-db PR for this
     params:
       singularity_enabled: true
+    rules:
+    - id: lotus2_small_input_rule  # override rule from shared db which would set mem to 8 here
+      if: input_size < 0.1
+      mem: 16
   toolshed.g2.bx.psu.edu/repos/ebi-gxa.*:  # singularity for all tools owned by ebi-gxa
     params:
       singularity_enabled: true


### PR DESCRIPTION
As a first pass, check that lotus2 is not quietly failing to allocate memory