### PR TITLE
singularity_enabled: false for lotus2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -935,11 +935,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/earlhaminst/lotus2/lotus2/.*:
     mem: 16  # TODO - follow up with shared-db PR for this
     params:
-      singularity_enabled: true
-    rules:
-    - id: lotus2_small_input_rule  # override rule from shared db which would set mem to 8 here
-      if: input_size < 0.1
-      mem: 16
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/ebi-gxa.*:  # singularity for all tools owned by ebi-gxa
     params:
       singularity_enabled: true


### PR DESCRIPTION
There may be more we have to do to get the dbs into the right spot in the conda environment, provided that they are small. Tools should not be like this.