### PR TITLE
Labs engine update cache handler

### DIFF
--- a/roles/galaxy_labs_engine/handlers/main.yml
+++ b/roles/galaxy_labs_engine/handlers/main.yml
@@ -1,0 +1,8 @@
+- name: update labs cache
+  ansible.builtin.command: >
+    docker compose --profile prod run --rm labs-engine
+    python manage.py update_cache
+  args:
+    chdir: "{{ labs_config_root }}"
+  tags:
+    - always

--- a/roles/galaxy_labs_engine/tasks/main.yml
+++ b/roles/galaxy_labs_engine/tasks/main.yml
@@ -17,6 +17,7 @@
     force_source: yes  # Ensures it re-checks the remote registry
     state: present
   tags: update
+  notify: update labs cache
 
 - name: clone git repository for galaxy-labs-engine
   ansible.builtin.git:
@@ -27,7 +28,7 @@
     force: yes
     update: yes
   tags: always
-  register: git
+  notify: update labs cache
 
 - name: create directories
   file:
@@ -147,15 +148,6 @@
   tags:
     - init
     - django
-
-- name: Django clear cache
-  shell: >
-    docker compose --profile prod run --rm labs-engine
-    python manage.py shell -c
-    "from django.core.cache import cache; cache.clear()"
-  args:
-    chdir: "{{ labs_config_root }}"
-  tags: clear_cache
 
 - name: enable labs_engine socket
   ansible.builtin.systemd:


### PR DESCRIPTION
I added a handler that calls the new `manage.py update_cache` command if the code has changed.
This clears the cache and re-renders and caching all entries that have been viewed in the last 30 days.
It prevents old lab pages from being served from the cache, especially following UI modifications.