### PR TITLE
hide the builtin sort tool

### DIFF
--- a/files/galaxy/config/tool_conf.xml
+++ b/files/galaxy/config/tool_conf.xml
@@ -70,7 +70,7 @@
     </section>
     <section id="filter" name="Filter and Sort">
         <tool file="stats/filtering.xml"/>
-        <tool file="filters/sorter.xml"/>
+        <tool file="filters/sorter.xml" hidden="True"/>
         <tool file="filters/grep.xml"/>
         <label id="gff" text="GFF"/>
         <tool file="filters/gff/extract_GFF_Features.xml"/>


### PR DESCRIPTION
There is a toolshed tool that does the same thing and looks identical in the panel. This is being hidden instead of removed so that existing workflows using the built-in tool are unaffected.