### PR TITLE
copy Galaxy Main’s scaling rule for bigwig converters

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3736,8 +3736,12 @@ tools:
   CONVERTER.*:
     params:
       tmp_dir: true
+  CONVERTER_bam_to_bigwig_0:
+    inherits: wig_to_bigWig  
   CONVERTER_bedgraph_to_bigwig:
     inherits: wig_to_bigWig
+  CONVERTER_wig_to_bigwig:
+    inherits: wig_to_bigWig  
   fgenesh_tool:
     abstract: true
     params:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3326,7 +3326,7 @@ tools:
       cores: 8
       mem: 30.7
   toolshed.g2.bx.psu.edu/repos/iuc/ucsc_wigtobigwig/ucsc_wigtobigwig/.*:
-    mem: 20
+    inherits: wig_to_bigWig
   toolshed.g2.bx.psu.edu/repos/iuc/varscan_.*:
     params:
       singularity_enabled: true
@@ -3737,7 +3737,7 @@ tools:
     params:
       tmp_dir: true
   CONVERTER_bedgraph_to_bigwig:
-    mem: 30
+    inherits: wig_to_bigWig
   fgenesh_tool:
     abstract: true
     params:
@@ -3856,7 +3856,7 @@ tools:
       cores: 1
       mem: 3.8
   wig_to_bigWig:
-    mem: 19.1
+    mem: min(max(input_size * 20, 28), 58)
     scheduling:
       accept:
       - training-exempt   # these jobs are exempt from training rules that would reduce allocated memory


### PR DESCRIPTION
There are a lot of OOM jobs for these tools. This PR copies Galaxy Main’s memory allocation rule for bigwig that scales memory with file size. It would increase the mem allocation for most of the jobs that have run out of memory.