### PR TITLE
reduce retention_disk variable in galaxy db backup from 7 to 5

### DIFF
--- a/roles/slg.db-backup/defaults/main.yml
+++ b/roles/slg.db-backup/defaults/main.yml
@@ -25,7 +25,7 @@ weekly_backup_day: 6  #Weekly backups will run on this day of the week
 retention_day: 6       #Keep daily backups for this many days (6 days)
 retention_week: 21     #Keep weekly backups for this many days (21 days = 3 weeks)
 retention_month: 92    #Keep monthly backups for this many days (92 days ~ 3 months)
-retention_disk: 7      # keep backups on local disk for this many days
+retention_disk: 5      # keep backups on local disk for this many days
 
 connection_string: "postgres://{{ db_user }}:{{ db_password }}@{{ db_server }}:{{ db_port }}/{{ psql_db }}"
 


### PR DESCRIPTION
Every morning usage of `/mnt` on galaxy-backup spikes above 90%, let’s keep fewer of these on disk. JL is this the right way?