### PR TITLE
bigger cvmfs caches for small workers

### DIFF
--- a/group_vars/pulsar_QLD/pulsar-QLD_workers.yml
+++ b/group_vars/pulsar_QLD/pulsar-QLD_workers.yml
@@ -15,7 +15,7 @@ shared_mounts:
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 20000
+cvmfs_quota_limit: 102400
 
 #Attached volume
 attached_volumes:

--- a/group_vars/pulsar_mel3/pulsar-mel3_workers.yml
+++ b/group_vars/pulsar_mel3/pulsar-mel3_workers.yml
@@ -14,7 +14,7 @@ shared_mounts:
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 20000
+cvmfs_quota_limit: 102400
 
 #Attached volume
 attached_volumes:

--- a/group_vars/pulsar_nci_training/pulsar-nci-training_workers.yml
+++ b/group_vars/pulsar_nci_training/pulsar-nci-training_workers.yml
@@ -20,7 +20,7 @@ shared_mounts:
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 60000
+cvmfs_quota_limit: 102400
 
 #Attached volume
 attached_volumes:


### PR DESCRIPTION
Small/medium workers that have 200GB mounted disks can use 100GB for cvmfs cache