### PR TITLE
test galaxy main kraken2 rule on dev

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
@@ -15,6 +15,36 @@ tools:
       - type: docker
         shell: /bin/bash
         identifier: quay.io/natefoo/docker-rstudio-notebook:23.1-proxy1
+  toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
+    # Galaxy Main's kraken2 memory rule
+    cores: 8  # 16 on Galaxy Main
+    mem: |
+      import os
+      mem = 64
+      table_name = "kraken2_databases"
+      lookup_column = "value"
+      value_column = "path"
+      value_template = "{value}/hash.k2d"
+      options = job.get_param_values(app)
+      lookup_value = options["kraken2_database"]
+      table_value = app.tool_data_tables.get(table_name).get_entry(lookup_column, lookup_value, value_column)
+      if table_value is not None:
+          table_value = value_template.format(value=table_value)
+          try:
+              mem = int(os.path.getsize(table_value)/1024**3 * 1.2)
+              log.debug("Data table '%s' lookup '%s=%s: %s=%s': %s GB",
+                        table_name, lookup_column, lookup_value, value_column, table_value, mem)
+          except OSError:
+              log.exception("Failed to get size of: %s", table_value)
+      else:
+          log.warning("Data table '%s' lookup '%s=%s: %s=None' returned None!, defaulting to %s",
+                      table_name, lookup_column, lookup_value, value_column, mem)
+      min(mem + 48, 980)
+    params:
+      singularity_enabled: true
+    scheduling:
+      accept:
+        - pulsar
   __IMPORT_HISTORY__:
     params:
       tmp_dir: true


### PR DESCRIPTION
Galaxy Main assigns memory to kraken2 jobs based on the size of the reference file using os.path.getsize() on the file path it gets from the job params.