### PR TITLE
use galaxy main kraken2 rule on production

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -147,6 +147,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-mel3
+        - cvmfs_cache_100plus
         - bakta_database
         - funannotate
         - eggnog
@@ -167,6 +168,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-high-mem1
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
       require:
         - pulsar
   pulsar-high-mem2:
@@ -180,6 +183,9 @@ destinations:
     # min_accepted_mem: 62.51 # 2/10/23 accept all job sizes
     tags: {{ job_conf_limits.environments['pulsar-high-mem2'].tags }}
     scheduling:
+      accept:
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
       require:
         - pulsar
         - pulsar-high-mem2
@@ -195,6 +201,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-mel-blast
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
       require:
         - pulsar
         - pulsar-blast
@@ -212,6 +220,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-qld-high-mem0
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
         - bakta_database
         - funannotate
         - eggnog
@@ -230,6 +240,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-qld-high-mem1
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
         - gtdbtk_database
       require:
         - pulsar
@@ -246,6 +258,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-qld-high-mem2
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
       require:
         - pulsar
   pulsar-nci-training:
@@ -260,6 +274,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-nci-training
+        - cvmfs_cache_100plus
         - pulsar-blast # allow training jobs with require: pulsar-blast to run here
         - bakta_database
         - funannotate
@@ -279,6 +294,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-qld-blast
+        - cvmfs_cache_100plus
+        - cvmfs_cache_800plus
       require:
         - pulsar
         - pulsar-blast
@@ -294,6 +311,7 @@ destinations:
     scheduling:
       accept:
         - pulsar-QLD
+        - cvmfs_cache_100plus
         - funannotate
         - bakta_database
       require:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1362,6 +1362,8 @@ tools:
     params:
       singularity_enabled: true
     scheduling:
+      prefer:
+        - cvmfs_cache_100plus
       require:
         - bakta_database
     rules:
@@ -1952,14 +1954,38 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/.*:
     context:
       max_concurrent_job_count_for_tool_user: 3
+    # Galaxy Main's kraken2 memory rule
     cores: 16
-    mem: 200
+    mem: |
+      import os
+      mem = 64
+      table_name = "kraken2_databases"
+      lookup_column = "value"
+      value_column = "path"
+      value_template = "{value}/hash.k2d"
+      options = job.get_param_values(app)
+      lookup_value = options["kraken2_database"]
+      table_value = app.tool_data_tables.get(table_name).get_entry(lookup_column, lookup_value, value_column)
+      if table_value is not None:
+          table_value = value_template.format(value=table_value)
+          try:
+              mem = int(os.path.getsize(table_value)/1024**3 * 1.2)
+              log.debug("Data table '%s' lookup '%s=%s: %s=%s': %s GB",
+                        table_name, lookup_column, lookup_value, value_column, table_value, mem)
+          except OSError:
+              log.exception("Failed to get size of: %s", table_value)
+      else:
+          log.warning("Data table '%s' lookup '%s=%s: %s=None' returned None!, defaulting to %s",
+                      table_name, lookup_column, lookup_value, value_column, mem)
+      min(mem + 48, 980)
     params:
       singularity_enabled: true
     scheduling:
       accept:
       - pulsar
       - pulsar-training-large
+      prefer:
+      - cvmfs_cache_100plus
       reject:
       - pulsar-QLD
     rules:


### PR DESCRIPTION
Galaxy Main’s kraken2 rule works well on dev. I was initially worried about frequent file size lookups but apparently this is not a super expensive operation, though it will be done over and over.

This also adds cmvfs_cache_100plus and cvmfs_cache_800plus tags to various destinations so that bakta and kraken2 can prefer destinations with non-tiny caches.