### PR TITLE
unjam dorado queue

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -397,7 +397,8 @@ destinations:
     scheduling:
       accept:
         - pulsar-qld-gpu3
-        - pulsar-qld-gpu-alphafold
+        # - pulsar-qld-gpu-alphafold
+        - pulsar-qld-gpu-other  # switched to other temporarily to solve helixir/dorado jam 23/5/25
   pulsar-qld-gpu4:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu4_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3890,6 +3890,7 @@ tools:
       - pulsar
       - training-exempt
       require:
+      - pulsar-qld-gpu4
       - pulsar-qld-gpu-other
       - pulsar-qld-gpu
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/.*:
@@ -3904,6 +3905,7 @@ tools:
       - pulsar
       - training-exempt
       require:
+      - pulsar-qld-gpu3  # TODO: change this to gpu5 when is it is no longer jammed with helixir job
       - pulsar-qld-gpu-other
       - pulsar-qld-gpu
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado_pod5_convert/dorado_pod5_convert/.*:


### PR DESCRIPTION
Borrow an alphafold pulsar for dorado. gpu4 and gpu5 both have long running helixir jobs. I’ll merge this quick before users turn up with alphafold jobs.