### PR TITLE
Enable toolmsg debug console logs

### DIFF
--- a/templates/galaxy/webhooks/toolmsg/script.js.j2
+++ b/templates/galaxy/webhooks/toolmsg/script.js.j2
@@ -1,6 +1,6 @@
 // Custom messages for tool forms
 
-const enableDebug = false;
+let enableDebug = true;
 const debugLog = (msg) => enableDebug && console.debug("[ToolMsg]: " + msg);
 
 const WAIT_TOOL_MAX_TRIES = 3;


### PR DESCRIPTION
Code on usegalaxy.org.au client looks fine - diann tool ID should be matching the configured toolmsg. Maybe debug logs will help me understand.