### PR TITLE
move user data 7 to qld

### DIFF
--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -4,7 +4,6 @@ volC_path: /mnt/volC
 volD_path: /mnt/volD
 
 # volume A (~171 TB)
-nfs_user_data_7_dir: "{{ volA_path }}/user-data-7"
 nfs_data22_dir: "{{ volA_path }}/data22"
 nfs_data25_dir: "{{ volA_path }}/data25"
 nfs_data26_dir: "{{ volA_path }}/data26"
@@ -52,7 +51,6 @@ attached_volumes:
     fstype: ext4
 
 nfs_dirs:
-  - "{{ nfs_user_data_7_dir }}"
   - "{{ nfs_data08_dir }}"
   - "{{ nfs_data09_dir }}"
   - "{{ nfs_data10_dir }}"

--- a/templates/galaxy/config/galaxy_object_store_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.yml.j2
@@ -106,11 +106,6 @@ backends:
   type: disk
   store_by: uuid
   files_dir: /mnt/user-data-volB/data08
-- id: aarnetNFS7
-  weight: 0
-  type: disk
-  store_by: id
-  files_dir: /mnt/user-data-volA/user-data-7
 
 {% if qld_file_mounts_available|d(True) %}
 - id: qldNFS1
@@ -153,6 +148,11 @@ backends:
   type: disk
   store_by: id
   files_dir: {{ qld_file_mounts_path }}/files/aarnetNFS6
+- id: aarnetNFS7
+  weight: 0
+  type: disk
+  store_by: id
+  files_dir: {{ qld_file_mounts_path }}/files2/aarnetNFS7
 {% endif %}
 
 {% if test_object_store_paths_enabled|d(False) %}


### PR DESCRIPTION
read user-data-7 from the 2nd volume attached to exports, and call it aarnetNFS7 to be consistent with other folder names