### PR TITLE
do not use replication slot on galaxy db

### DIFF
--- a/galaxy-db_playbook.yml
+++ b/galaxy-db_playbook.yml
@@ -38,20 +38,3 @@
       # Note: After running this playbook for the first time the postgresql services
       # may have stopped with errors due to the moving of the data directory.
       # A reboot should fix this.
-  post_tasks:
-  - name: Ensure replication slot exists
-    community.postgresql.postgresql_query:
-      db: galaxy
-      query: >
-        DO $$
-        BEGIN
-          IF NOT EXISTS (
-            SELECT 1 FROM pg_replication_slots WHERE slot_name = '{{ galaxy_db_replication_slot_name }}'
-          ) THEN
-            PERFORM pg_create_physical_replication_slot('{{ galaxy_db_replication_slot_name }}');
-          END IF;
-        END$$;
-      login_user: postgres
-      login_host: ""
-    become: true
-    become_user: postgres

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -327,6 +327,3 @@ mariadb_users:
     priv: '{{ slurm_database }}.*:ALL'
 mariadb_databases:
   - name: '{{ slurm_database }}'
-
-
-galaxy_db_replication_slot_name: galaxy_db_replication_slot

--- a/replicant-galaxy-db_playbook.yml
+++ b/replicant-galaxy-db_playbook.yml
@@ -65,7 +65,6 @@
       dest: "{{ postgresql_pgdata }}/postgresql.auto.conf"
       content: |
         primary_conninfo = 'host={{ db_replication_origin_db_ip }} port=5432 user=replicator password={{ vault_galaxy_db_replicator_password }} application_name=galaxy_db_replica'
-        primary_slot_name = '{{ galaxy_db_replication_slot_name }}'
       owner: postgres
       group: postgres
       mode: '0600'
@@ -109,8 +108,7 @@
         echo "Pulling base backup directly from Sydney..."
         PGPASSWORD='{{ vault_galaxy_db_replicator_password }}' \
         pg_basebackup -h {{ db_replication_origin_db_ip }} -p 5432 -U replicator -D "$DATA_DIR" \
-          -X stream -S {{ galaxy_db_replication_slot_name }} -v -R \
-          --max-rate {{ db_replication_basebackup_max_rate }}
+          -X stream -v -R --max-rate {{ db_replication_basebackup_max_rate }}
 
         echo "Fixing permissions on $DATA_DIR"
         chown -R postgres:postgres "$DATA_DIR"


### PR DESCRIPTION
Using a replication slot runs the risk of db disk at ETCA filling up with WALs if the replication db stalls. Without the replication slot there is a risk of the replica falling behind, but this seems like good trade-off.