### PR TITLE
reduce mem to 2 for mothur_venn

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2440,6 +2440,8 @@ tools:
       if: 0.02 <= input_size < 2
       cores: 5
       mem: 19.1
+  toolshed.g2.bx.psu.edu/repos/iuc/mothur_venn/mothur_venn/.*:  # does not work on pulsar
+      mem: 2
   toolshed.g2.bx.psu.edu/repos/iuc/multigsea/multigsea/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
Mem is being set to 20 from shared_db and not only is this unnecessary, this tool seems to need far less than the default.

‘gxadmin local query-tool-memory mothur_venn’ shows no job from the past year that used more than 1GB.