### PR TITLE
Update tools.yml

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -4010,6 +4010,3 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/aarnet_filesender/aarnet_filesender/.*:
     params:
       singularity_enabled: true
-
-  dorado_error_correct:
-    inherits: toolshed.g2.bx.psu.edu/repos/galaxy-australia/dorado/dorado/.*


### PR DESCRIPTION
remove dorado_error_correct entry (this is a local copy of the tool) from tpv for now. This tool has been pushed to the toolshed and will install this tool from the galaxy toolshed. The new entry will be added after the installation.