### PR TITLE
Update destination scoring

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -151,13 +151,15 @@ tools:
               if not destination.context.get('destination_total_mem') or not destination.context.get('destination_total_cores'):
                 raise Exception(f"++ ---tpv rank debug: At least one of destination_total_mem, destination_total_cores is unavailable")
               destination_ids = [destination.id] + destination.context.get('shared_resource_destination_ids', [])
-              destination_cores_committed = sum([
-                sum([db_queue_info.get(d_id, {}).get(state, {}).get('sum_cores', 0) for state in ['queued', 'running']])
-                for d in destination_ids]
+              destination_cores_committed = sum(
+                  db_queue_info.get(d_id, {}).get(state, {}).get('sum_cores', 0)
+                  for d_id in destination_ids
+                  for state in ['queued', 'running']
               )
-              destination_mem_committed = sum([
-                sum([db_queue_info.get(destination.id, {}).get(state, {}).get('sum_mem', 0.0) for state in ['queued', 'running']])
-                for d_id in destination_ids]
+              destination_mem_committed = sum(
+                  db_queue_info.get(d_id, {}).get(state, {}).get('sum_mem', 0.0)
+                  for d_id in destination_ids
+                  for state in ['queued', 'running']
               )
               available_cores = destination.context['destination_total_cores'] - destination_cores_committed
               available_mem = float(destination.context['destination_total_mem']) - (float(destination_mem_committed)/1024)

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -147,19 +147,18 @@ tools:
               score = 1 if a_prefers_b(dest_tags, ent_tags) or a_prefers_b(ent_tags, dest_tags) else 0
               return score
 
-          def destination_usage_proportion(destination):
-            if not destination.context.get('destination_total_mem') or not destination.context.get('destination_total_cores'):
-              raise Exception(f"++ ---tpv rank debug: At least one of destination_total_mem, destination_total_cores is unavailable")
-            destination_total_cores = destination.context.get('destination_total_cores')
-            return_value = sum([db_queue_info.get(destination.id, {}).get(state, {}).get('sum_cores', 0) for state in ['queued', 'running']])/destination_total_cores
-            log.info(f"++ ---tpv rank debug: returning usage proportion value for destination {destination.id}: {str(return_value)}")
-            return return_value
-
           def destination_availability_score(destination):
               if not destination.context.get('destination_total_mem') or not destination.context.get('destination_total_cores'):
                 raise Exception(f"++ ---tpv rank debug: At least one of destination_total_mem, destination_total_cores is unavailable")
-              destination_cores_committed = sum([db_queue_info.get(destination.id, {}).get(state, {}).get('sum_cores', 0) for state in ['queued', 'running']])
-              destination_mem_committed = sum([db_queue_info.get(destination.id, {}).get(state, {}).get('sum_mem', 0) for state in ['queued', 'running']])
+              destination_ids = [destination.id] + destination.context.get('shared_resource_destination_ids', [])
+              destination_cores_committed = sum([
+                sum([db_queue_info.get(d_id, {}).get(state, {}).get('sum_cores', 0) for state in ['queued', 'running']])
+                for d in destination_ids]
+              )
+              destination_mem_committed = sum([
+                sum([db_queue_info.get(destination.id, {}).get(state, {}).get('sum_mem', 0.0) for state in ['queued', 'running']])
+                for d_id in destination_ids]
+              )
               available_cores = destination.context['destination_total_cores'] - destination_cores_committed
               available_mem = float(destination.context['destination_total_mem']) - (float(destination_mem_committed)/1024)
  

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -73,6 +73,9 @@ destinations:
     context:
       destination_total_cores: 176  # reduced from 192 while galaxy-w3 is training-only
       destination_total_mem: 687  # reduced from 750 while galaxy-w3 is training-only
+      shared_resource_destination_ids:
+        - slurm-training
+        - interactive_pulsar
     tags: {{ job_conf_limits.environments['slurm'].tags }}
     scheduling:
       accept:


### PR DESCRIPTION
The local TPV ranking function looks at the resources used as a proportion of total resources at a destination. When the slurm-training destination is in use the jobs do not count towards the slurm destination’s resource use but they should. If the training jobs are not accounted for, the slurm destination appears to be be more available than it is, so it gets too many jobs.