### PR TITLE
More RAM for large RagTag alignment

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2740,6 +2740,9 @@ tools:
       if: input_size > 1.4
       cores: 8
       mem: 200
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/rapidnj/rapidnj/.*:
     params:
       singularity_enabled: true

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2736,6 +2736,10 @@ tools:
       if: input_size < 0.2
       cores: 4
       mem: 15.3
+    - id: ragtag_large_input_rule
+      if: input_size > 1.4
+      cores: 8
+      mem: 200
   toolshed.g2.bx.psu.edu/repos/iuc/rapidnj/rapidnj/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
Hello! This is a non-urgent request for more RAM for large RagTag jobs.

I tried to do a whole genome alignment with two genomes of around 2 Gigabases each and ran out of RAM (GA job 4043685).

I don't know how much RAM is enough, I haven't tested it locally  

Thanks :)