### PR TITLE
try out cvmfs singularity on pulsar nci training

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -282,6 +282,23 @@ destinations:
       require:
         - pulsar
         - training
+    rules:
+      - id: pulsar_destination_singularity_rule  # override rule on _pulsar_destination with the same name
+        if: entity.params.get('singularity_enabled')
+        params:
+            singularity_volumes: '{ pulsar_singularity_volumes }'
+            container_resolvers: 
+              - type: explicit_singularity
+              - type: cached_mulled_singularity
+                cache_directory: /cvmfs/singularity.galaxyproject.org/all
+                cache_directory_cacher_type: dir_mtime
+              - type: mulled_singularity
+            singularity_default_container_id: "{{ singularity_default_container_id }}"
+            dependency_resolution: none
+        env:
+          SINGULARITY_CACHEDIR: /mnt/pulsar/deps/singularity
+          SINGULARITY_TMPDIR: /mnt/pulsar/deps/singularity/tmp
+
   pulsar-qld-blast:
     inherits: _pulsar_destination
     runner: pulsar-qld-blast_runner


### PR DESCRIPTION
Years ago we tried using singularity containers from CVMFS. There were performance issues on pulsar-nci-training in particular, where test jobs for busco were taking hours to run. It may be different now because Steele and Alex fixed the stratum 1 server and because the CVMFS caches are bigger on the worker nodes.

It would be very good :crossed_fingers: if this were to work out because with the current configuration, galaxy needs to contact quay.io for every single pulsar singularity job and this has been timing out lately.

There is an explanation of `cache_directory_cacher_type: dir_mtime` here: https://github.com/galaxyproject/galaxy/blob/da7fdc814d94a795f50de6856c9b86086c0baac8/doc/source/admin/container_resolvers.rst#parameters