### PR TITLE
update amqp max retries for pulsar

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -70,7 +70,7 @@ pulsar_yaml_config:
   message_queue_url: "pyamqp://{{ pulsar_rabbit_username }}:{{ rabbitmq_password_galaxy_au }}@{{ pulsar_queue_url }}:5671/{{ pulsar_rabbit_vhost }}?ssl=1"
   min_polling_interval: 0.5
   amqp_publish_retry: True
-  amqp_publish_retry_max_retries: 5
+  amqp_publish_retry_max_retries: 20
   amqp_publish_retry_interval_start: 10
   amqp_publish_retry_interval_step: 10
   amqp_publish_retry_interval_max: 60


### PR DESCRIPTION
I think pulsar "ghost jobs” (jobs running in galaxy but long since finished on pulsar) could be coming about sometimes when pulsar sends the acknowledgment while the job’s handler is restarting.