### PR TITLE
restrict DATA_FETCH to handler_0

### DIFF
--- a/templates/galaxy/config/galaxy_job_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_job_conf.yml.j2
@@ -3,6 +3,11 @@ handling:
     - db-skip-locked
   max_grab: 8
   ready_window_size: 120  # Increased from 20 to 120 on 17/10/24 due to jobs not scheduling when there are many jobs in new state with TPV limits, see issue https://github.com/usegalaxy-au/infrastructure/issues/2254
+tools:
+  - id: __DATA_FETCH__
+    handler: handler_0
+  - id: upload1
+    handler: handler_0
 runners:
   local:
     load: galaxy.jobs.runners.local:LocalJobRunner


### PR DESCRIPTION
Whatever is holding the handlers up apparently comes from DATA_FETCH jobs.  These have been restricted to run on handler_0 only which simplifies things a bit. handler_0 is being restarted regularly and the other handlers are fine now.