### PR TITLE
No small/large distinction for metaphlan

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2197,13 +2197,8 @@ tools:
       cores: 16
       mem: 62
   toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/.*:
-    cores: 16
-    mem: 62
-    rules:
-    - id: metaphlan_small_input_rule
-      if: input_size < 0.001
-      cores: 4
-      mem: 15.3
+    cores: 8
+    mem: 31
   toolshed.g2.bx.psu.edu/repos/iuc/metaphlan2/metaphlan2/.*:
     inherits: toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/.*
     params:


### PR DESCRIPTION
The smaller size of metaphlan jobs have been running out of memory for input sizes as small as 1Kb. The larger size of metaphlan jobs never seem to use more than 20Gb of RAM.