### PR TITLE
stop pinning gx_it_proxy

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -131,7 +131,6 @@ host_galaxy_config_gravity:
     upload_dir: "{{ galaxy_tus_upload_store }}"
   gx_it_proxy:
     enable: true
-    version: 0.0.6  # this is the only version that will work on 11/2/25
     ip: "{{ gie_proxy_ip }}"
     port: "{{ gie_proxy_port }}"
     sessions: "{{ gie_proxy_sessions_path }}"


### PR DESCRIPTION
gx_it_proxy version had to be pinned for the previous release, but doing so breaks ITs in this release.