### PR TITLE
more memory for bakta

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -215,7 +215,7 @@ destinations:
     runner: pulsar-qld-high-mem0_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 30
+    min_accepted_mem: 40
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07
@@ -235,7 +235,7 @@ destinations:
     runner: pulsar-qld-high-mem1_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 62.51
+    min_accepted_mem: 40
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1386,7 +1386,7 @@ tools:
     context:
       max_concurrent_job_count_for_tool_user: 5
     cores: 8
-    mem: 30.7
+    mem: 70
     params:
       singularity_enabled: true
     scheduling:


### PR DESCRIPTION
bakta has been failing with out of memory errors but these do not show up in `gxadmin local query-oom-jobs` because the jobs are ‘ok’ and there is nothing in tool_stderr. The job outputs in these cases are empty. Set min_mem to 40 on pqhm0 and pqhm1 to attract jobs like this because bakta runs super well on the standalone pulsars as opposed to the clusters.