### PR TITLE
Make long running task async

### DIFF
--- a/roles/galaxy_labs_engine/handlers/main.yml
+++ b/roles/galaxy_labs_engine/handlers/main.yml
@@ -4,5 +4,7 @@
     python manage.py update_cache -y
   args:
     chdir: "{{ labs_config_root }}"
+  async: 600
+  poll: 5
   tags:
     - always


### PR DESCRIPTION
Prevent task SSH timeout as this task can run for over a minute:

```
RUNNING HANDLER [galaxy_labs_engine : update labs cache] ***********************
fatal: [galaxy-labs]: UNREACHABLE! => {
    "changed": false,
    "unreachable": true
}

MSG:

Failed to connect to the host via ssh: Shared connection to 138.44.7.160 closed.
```