### PR TITLE
Add logrotate tasks to common role

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -2,8 +2,7 @@
 
 add_hosts_handlers: yes
 
-# Login override - checksum for Login.vue
-galaxy_login_checksum_expected: fd733fa7ea21a22f6f99a095f8c2646b
+common_logrotate_manage_rsyslog: true
 
 # total perspective vortex
 # tpv_version: "2.2.4"
@@ -74,8 +73,8 @@ galaxy_pulsar_job_working_directory: "{{ galaxy_tmp_dir }}/pulsar_jwds"
 host_galaxy_extra_dirs:
   - "{{ galaxy_pulsar_job_working_directory }}"
 
-galaxy_repo: https://github.com/galaxyproject/galaxy.git
-galaxy_commit_id: release_25.0
+galaxy_repo: https://github.com/usegalaxy-au/galaxy.git
+galaxy_commit_id: release_25.0_au_dev
 
 galaxy_virtualenv_command: "/usr/bin/python3.11 -m venv"
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -16,3 +16,8 @@ common_sacct_format: "jobid%8,partition%9,jobname%30,alloccpus,elapsed,totalcpu,
 common_bashrc_dir: /etc/bashrc_common
 common_bashrc_vars_file: "{{ common_bashrc_dir }}/common_variables"
 common_bashrc_functions_file: "{{ common_bashrc_dir }}/common_functions"
+
+common_logrotate_manage_rsyslog: false
+common_logrotate_rsyslog_file: /etc/logrotate.d/rsyslog
+common_logrotate_rsyslog_rotate_count: 14
+common_logrotate_rsyslog_frequency: daily

--- a/roles/common/tasks/logrotate.yml
+++ b/roles/common/tasks/logrotate.yml
@@ -1,0 +1,12 @@
+---
+- name: Set logrotate frequency for rsyslog
+  ansible.builtin.replace:
+      path: "{{ common_logrotate_rsyslog_file }}"
+      regexp: '^(\s*)(daily|weekly|monthly)\b'
+      replace: '\1{{ common_logrotate_rsyslog_frequency }}'
+- name: Set logrotate count for rsyslog
+  ansible.builtin.replace:
+      path: "{{ common_logrotate_rsyslog_file }}"
+      regexp: '^(\s*)rotate\s+\d+'
+      replace: '\1rotate {{ common_logrotate_rsyslog_rotate_count }}'
+

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -91,6 +91,10 @@
   tags:
     - users
 
+- name: Update logrotate rsyslog config
+  import_tasks: logrotate.yml
+  when: "{{ common_logrotate_manage_rsyslog }}"
+
 - name: Add extra ssh keys
   include_tasks: extra_keys.yml
   loop: "{{ extra_keys }}"


### PR DESCRIPTION
Add tasks to the common role to update the frequency of log rotation of syslog. Root disks on galaxy/galaxy-handlers have too much space taken up by uncompressed syslog files because logs are rotated weekly. Switch this on on dev first to test it.

Put dev onto release_25.0_au_dev branch which is the same as release_25.0 but will need to be rebased regularly.

Switch on daily cron jobs to clean up tmpdisk folders. Keep it switched off on galaxy workers for now.