### PR TITLE
fix new ‘when’ clause in common role

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -93,7 +93,7 @@
 
 - name: Update logrotate rsyslog config
   import_tasks: logrotate.yml
-  when: "{{ common_logrotate_manage_rsyslog }}"
+  when: common_logrotate_manage_rsyslog
 
 - name: Add extra ssh keys
   include_tasks: extra_keys.yml


### PR DESCRIPTION
curly brackets not required, provokes ansible warning