### PR TITLE
return pqgpu3 to regular schedule

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -382,18 +382,6 @@ destinations:
       require:
         - pulsar
         - pulsar-qld-gpu
-  _pulsar_qld_gpu_rescue_mode:  # when gpu pulsars have to run normal jobs
-    abstract: true
-    inherits: _pulsar_destination
-    max_accepted_cores: 64
-    max_accepted_mem: 582
-    max_accepted_gpus: 1
-    context:
-      destination_total_cores: 64
-      destination_total_mem: 582
-    scheduling:
-      require:
-        - pulsar
   pulsar-qld-gpu1:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu1_runner
@@ -409,15 +397,12 @@ destinations:
         - pulsar-qld-gpu2
         - pulsar-qld-gpu-alphafold
   pulsar-qld-gpu3:
-    inherits: _pulsar_qld_gpu_rescue_mode
+    inherits:  _pulsar_qld_gpu
     runner: pulsar-qld-gpu3_runner
     scheduling:
       accept:
         - pulsar-qld-gpu3
         - pulsar-qld-gpu-alphafold
-      require:
-        - pulsar-qld-rescue
-        - offline
   pulsar-qld-gpu4:
     inherits: _pulsar_qld_gpu
     runner: pulsar-qld-gpu4_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1576,8 +1576,6 @@ tools:
     scheduling:
       accept:
       - pulsar
-      prefer:
-      - pulsar-qld-rescue
   toolshed.g2.bx.psu.edu/repos/iuc/chromeister/chromeister/.*:
     cores: 1
     mem: 3.8
@@ -2324,7 +2322,6 @@ tools:
       - pulsar-training-large
       prefer:
       - pulsar-qld-high-mem2
-      - pulsar-qld-rescue
     rules:
     - id: mothur_cluster_split_medium_input_rule
       if: 0.00015 <= input_size < 0.1


### PR DESCRIPTION
When most of the high memory pulsars were offline, pulsar-qld-gpu3 was diverted to running normal jobs. This is no longer needed.