### PR TITLE
jenkins task to run galaxy update configs playbook

### DIFF
--- a/galaxy_update_configs_playbook.yml
+++ b/galaxy_update_configs_playbook.yml
@@ -18,7 +18,8 @@
       listen: "remote restart galaxy"
   tasks:
     - name: Template and copy config files
-      when: not ansible_user == 'jenkins_bot'  # do not let the automatic process object store or restart galaxy
+      # jenkins_bot does not update object store etc unless jenkins_exec has been set to true in command
+      when: (ansible_user != 'jenkins_bot') or (ansible_user == 'jenkins_bot' and jenkins_exec|d(False))
       block: 
       - name: copy job_conf file
         # Note: This step requires only the restart of galaxy processes running on galaxy-handlers VM

--- a/jenkins/phone_in_utils/run_galaxy_update_configs.sh
+++ b/jenkins/phone_in_utils/run_galaxy_update_configs.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+source jenkins/utils.sh
+
+activate_virtualenv
+echo "secret" > .vault_pass.txt  # ansible needs .vault_pass.txt to exist
+
+ansible-playbook -i hosts galaxy_update_configs_playbook.yml --extra-vars "ansible_user=jenkins_bot jenkins_exec=True" --vault-password-file "$VAULT_PASS"


### PR DESCRIPTION
Add a clause for jenkins_bot to be able to run all of the tasks in the galaxy_update_configs playbook and a script for jenkins to run this on demand (not connected to a trigger or cron)