### PR TITLE
make gffread go to pqhm2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -756,6 +756,8 @@ tools:
     scheduling:
       accept:
       - pulsar
+      require:
+      - pulsar-qld-high-mem2
   toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/.*:
     cores: 5
     mem: 19.1


### PR DESCRIPTION
This is not fair on pqhm2 but is better than it filling up galaxy jwds