### PR TITLE
Remove old CVMFS GPG key before it breaks `apt update`

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,6 +14,24 @@
     state: present
   when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_version'] is version('22.04', '<')
 
+- name: Remove problematic CernVM GPG key from legacy keyring
+  ansible.builtin.apt_key:
+    url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
+    state: absent
+  ignore_errors: true
+
+- name: Remove problematic CernVM repository configuration (incorrect filename)
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/cernvm.list.list
+    state: absent
+  ignore_errors: true
+
+- name: Remove problematic CernVM repository configuration (correct future filename)
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/cernvm.list
+    state: absent
+  ignore_errors: true
+
 - name: Update the apt repos and base OS
   apt:
       upgrade: dist


### PR DESCRIPTION
I think `common` role is the right place to do this, that's where `apt update` runs (and fails).