### PR TITLE
optitype tool requires more memory for large inputs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -4004,6 +4004,14 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/optitype/optitype/.*:
     params:
       singularity_enabled: true
+    rules:
+    - id: optitype_large_input
+      if: input_size > 1
+      cores: 8
+      mem: 120
+      scheduling:
+        accept:
+        - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/orthofinder_onlygroups/orthofinder_onlygroups/.*:
     context:
       max_concurrent_job_count_for_tool_user: 2


### PR DESCRIPTION
As per request:
  Could the memory allocated be increased for the tool Optitype
  (OptiTypeHLA genotyping predictions from NGS data(Galaxy Version 1.3.5+galaxy0))?
  The proteomics researchers that we are helping with workflows are finding that it fails
  due to "job was terminated because it used more memory than it was allocated". -- however
  it works on Galaxy Eu where its max memory usage was 83 GB

`gxadmin local query-tool-memory optitype` shows that jobs failed with 57GB input size, while most jobs have inputs < 1M and these succeed.

EU allocates 12 cores and 256G RAM in their TPV: https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/files/galaxy/tpv/tools.yml

Dropping this to 8 cores and 120G for inputs larger than 1G and allowing to run on pulsar. This may need further tweaking.