### PR TITLE
Show 50/50 either tips or tool recommendation

### DIFF
--- a/templates/galaxy/webhooks/tips/script.js.j2
+++ b/templates/galaxy/webhooks/tips/script.js.j2
@@ -5,7 +5,31 @@
 // >>> loadGalaxyTipFunction(5);
 var loadGalaxyTipFunction;
 
+
 $(document).ready( () => {
+
+  function fiftyFifty() {
+    return Date.now() % 2 === 0;
+  }
+
+  function removeToolRecommendationElement() {
+    let attempts = 0;
+    const maxAttempts = 10;
+    const interval = setInterval(() => {
+      const el = document.getElementById('tool-recommendation');
+      if (el && el.parentElement) {
+        el.parentElement.remove();
+        clearInterval(interval);
+      } else if (attempts >= maxAttempts) {
+        clearInterval(interval);
+      }
+      attempts++;
+    }, 100);
+  }
+
+  // Either show tips or tool recommender
+  fiftyFifty() && return;
+  removeToolRecommendationElement();
 
   const GITHUB_BRANCH = "{% if 'dev' in inventory_hostname %}dev{% else %}main{% endif %}";
   const TIPS_GITHUB_URL = `https://api.github.com/repos/usegalaxy-au/galaxy-tips/contents/tips?ref=${GITHUB_BRANCH}`;


### PR DESCRIPTION
So Galaxy tips are working on prod, but I didn't realise we actually have the tool recommendation feature turned on! I guess it only displays for tools that it has data for.

It think both are nice features, so for now I've added a bit of code to the webhook that will show either a Galaxy Tip, or the tool recommendations thing.

This is the current weird experience:

[Screencast from 2025-08-22 06-35-48.webm](https://github.com/user-attachments/assets/a2a72fff-408b-46ef-8dde-4a87acb08711)
