### PR TITLE
disable juypter notebook

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3952,8 +3952,8 @@ tools:
           not may_use_ITs
         fail:
           'You must wait {interactive_tool_embargo_days} days before being able to use this tool. Please email help@genome.edu.au if you need access sooner or have any questions.'
-  interactive_tool_jupyter_notebook:
-    inherits: restricted_interactive_tool
+#  interactive_tool_jupyter_notebook:
+#    inherits: restricted_interactive_tool
   interactive_tool_phyloseq:
     params:
       docker_run_extra_arguments: "--user $UID:$GID"


### PR DESCRIPTION
Juypter notebook being used to run crypto miners