### PR TITLE
workaround for broken apt-key in dj-wasabi.telegraf

### DIFF
--- a/galaxy-workers_playbook.yml
+++ b/galaxy-workers_playbook.yml
@@ -18,6 +18,44 @@
           path: "{{ item }}"
         with_items:
           - "{{ qld_file_mounts_path }}"
+
+      # the following is a workaround for dj-wasabi.telegraf role breaking on new VMs
+      # the issue is that the dj-wasabi.telegraf role is not dearmoring the downloaded key
+      # the dearmored key location is then passed to dj-wasabi.telegraf via a variable
+      - name: Ensure /etc/apt/keyrings exists
+        ansible.builtin.file:
+          path: /etc/apt/keyrings
+          state: directory
+          mode: "0755"
+        become: true
+
+      - name: Fetch InfluxData key (ascii)
+        ansible.builtin.get_url:
+          url: https://repos.influxdata.com/influxdata-archive.key
+          dest: /etc/apt/keyrings/influxdata-archive.asc
+          mode: "0644"
+        register: influx_key
+        until: influx_key is succeeded
+        retries: 3
+        delay: 2
+        become: true
+
+      - name: Dearmor into a binary keyring if key has changed
+        ansible.builtin.command: >
+          gpg --batch --yes --dearmor
+          -o /etc/apt/keyrings/influxdata-archive.gpg
+          /etc/apt/keyrings/influxdata-archive.asc
+        when: influx_key.changed
+        become: true
+
+      - name: Ensure permissions on keyring
+        ansible.builtin.file:
+          path: /etc/apt/keyrings/influxdata-archive.gpg
+          owner: root
+          group: root
+          mode: "0644"
+    become: true
+
   roles:
       - common
       - insspb.hostname
@@ -26,7 +64,10 @@
       - galaxyproject.repos
       - galaxyproject.slurm
       - galaxyproject.cvmfs
-      - dj-wasabi.telegraf
+      - role: dj-wasabi.telegraf
+        vars:
+          # override the role’s internal set_fact when create telegraf.list
+          telegraf_repository_params: "[signed-by=/etc/apt/keyrings/influxdata-archive.gpg]"
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
       - acl-on-startup


### PR DESCRIPTION
On new VMs (still ubuntu 22.04) the `dj-wasabi.telegraf` role breaks due to the repo key not being dearmored. Existing VMs that have already added the telegraf repo don't appear to be affected, possibly due to the key already existing in the global keyring `/etc/apt/trusted.gpg`.

This workaround does what the `dj-wasabi.telegraf` role should do: download and dearmor the key (now to `/etc/apt/keyrings/` instead of `/usr/share/keyrings/` as recommended best practice). It then passes the location of the dearmored repo key via a variable `telegraf_repository_params`.

This approach has been manually tested on the new galaxy workers. This serves to make the workaround more permanent and documented.

@cat-bro For noting on new VMs.