### PR TITLE
local tool conf: change key ‘label’ to ‘labels'

### DIFF
--- a/files/galaxy/config/local_tool_conf.xml
+++ b/files/galaxy/config/local_tool_conf.xml
@@ -9,19 +9,19 @@
         <tool file="/mnt/galaxy/local_tools/fgenesh/7.2.2/fgenesh_merge.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/fgenesh/7.2.2/fgenesh_get_mrnas_gc.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/fgenesh/7.2.2/fgenesh_to_genbank.xml" labels="test"/>
-        <tool file="/mnt/galaxy/local_tools/fgenesh/7.2.2/fgenesh_get_proteins.xml" label="test"/>
-	<tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_annotate.xml" labels="test"/>
-        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_renumber.xml" label="test"/>
-        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_get_mrnas.xml" label="test"/>
-        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_annotate_mrnas.xml" label="test"/>
-        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_check_mrna.xml" label="test"/>
+        <tool file="/mnt/galaxy/local_tools/fgenesh/7.2.2/fgenesh_get_proteins.xml" labels="test"/>
+	    <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_annotate.xml" labels="test"/>
+        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_renumber.xml" labels="test"/>
+        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_get_mrnas.xml" labels="test"/>
+        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_annotate_mrnas.xml" labels="test"/>
+        <tool file="/mnt/galaxy/local_tools/fgenesh/2024.2/fgenesh_check_mrna.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/cellranger/cellranger.xml" labels="test"/>
         <tool file="/mnt/galaxy/local_tools/alphafold/alphafold.xml" labels="test"/>
     </section>
     <section id="interactivetools" name="Interactive Tools">
-	<tool file="/mnt/galaxy/local_tools/interactive_tool/lfq/interactivetool_lfqanalyst.xml" />
-	<tool file="/mnt/galaxy/local_tools/interactive_tool/tmt/interactivetool_tmtanalyst.xml" />
-	<tool file="/mnt/galaxy/local_tools/interactive_tool/usegalaxy_eu/interactivetool_phyloseq.xml" />
+	    <tool file="/mnt/galaxy/local_tools/interactive_tool/lfq/interactivetool_lfqanalyst.xml" />
+	    <tool file="/mnt/galaxy/local_tools/interactive_tool/tmt/interactivetool_tmtanalyst.xml" />
+	    <tool file="/mnt/galaxy/local_tools/interactive_tool/usegalaxy_eu/interactivetool_phyloseq.xml" />
         <tool file="/mnt/galaxy/local_tools/interactivetool_ena_upload_table_builder.xml"/>
     </section>
 </toolbox>


### PR DESCRIPTION
labels is the key: without ‘labels=“test”’ everyone can see the tools because that’s how the filter works