### PR TITLE
safety for retry ghost jobs function

### DIFF
--- a/roles/pulsar-post-tasks/tasks/ghost_jobs_functions.yml
+++ b/roles/pulsar-post-tasks/tasks/ghost_jobs_functions.yml
@@ -45,6 +45,10 @@
 
         retry_ghost_jobs () {
             for x in $@; do
+                if [ ! -d "${pulsar_staging_dir}/${x}" ]; then
+                    echo "Directory ${pulsar_staging_dir}/${x} does not exist. Please check the destination of this job. Exiting.";
+                    exit 1;
+                fi
                 set_active_job_file $x;
             done
             sudo systemctl restart pulsar;


### PR DESCRIPTION
Check that the jwd is there before retrying job preprocessing. If the wrong job ID is provided, that job will be set to error state in galaxy.