### PR TITLE
increase min_accepted_mem from 40 to 62.51 on pqhm1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -240,7 +240,7 @@ destinations:
     runner: pulsar-qld-high-mem1_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 40
+    min_accepted_mem: 62.51
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07


### PR DESCRIPTION
More medium-sized jobs should to go to mel3/QLD. pqhm0 can keep accepting medium-sized jobs.