### PR TITLE
revert to previous working version of galaxyproject.nginx

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -6,7 +6,7 @@ roles:
 - name: galaxyproject.galaxy
   version: 0.11.5
 - name: galaxyproject.nginx
-  version: 1.0.0
+  version: 0.7.1  # NOTE: version 1.0.0 exists but fails on dev (16/09/2025)
 - name: galaxyproject.postgresql
   version: 1.1.8
 - name: galaxyproject.postgresql_objects


### PR DESCRIPTION
The new version is failing on dev and will probably also fail on production. The previous version works so keep using that one for now.