### PR TITLE
use conda for snpeff version 5.2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3145,6 +3145,16 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/.*:
     cores: 3
     mem: 11.5
+    rules:
+    - id: snpeff_singularity_rule
+      if: |
+        # do not use singularity for this version due to a problem with snpeff data urls, manually fixed in conda env
+        snpeff_use_conda = False
+        if helpers.tool_version_eq(tool, '5.2+galaxy0'):
+          snpeff_use_conda = True
+        snpeff_use_conda
+      params:
+        singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_get_chr_names/.*:
     params:
       singularity_enabled: false  # both installed versions pass tests without singularity enabled, fail 1/2 with singularity enabled


### PR DESCRIPTION
version '5.2+galaxy0’ of snpeff has a problem with data URLs and needs to be run with a conda environment with config files edited as described in Galaxy EU’s issue https://github.com/usegalaxy-eu/issues/issues/777