### PR TITLE
snpeff download v5.2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3155,6 +3155,17 @@ tools:
         snpeff_use_conda
       params:
         singularity_enabled: false
+  toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_download/.*:
+    rules:
+    - id: snpeff_singularity_rule
+      if: |
+        # Same issue as snpEff above
+        snpeff_use_conda = False
+        if helpers.tool_version_eq(tool, '5.2+galaxy0'):
+          snpeff_use_conda = True
+        snpeff_use_conda
+      params:
+        singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_get_chr_names/.*:
     params:
       singularity_enabled: false  # both installed versions pass tests without singularity enabled, fail 1/2 with singularity enabled


### PR DESCRIPTION
snpEff_download needs the same edited conda env as snpEff, all other subtools seem OK