### PR TITLE
add exception for data table check

### DIFF
--- a/jenkins/check_data_tables/check_data_tables_for_dups.py
+++ b/jenkins/check_data_tables/check_data_tables_for_dups.py
@@ -11,6 +11,7 @@ SKIP_TABLES = [
 KNOWN_CVMFS_DUPLICATES = {
     "bowtie2_indexes": ["loxAfr1", "rheMac2", "rheMac3"],
     "tophat2_indexes": ["loxAfr1", "rheMac2", "rheMac3"],
+    "ncbi_fcs_gx_divisions": ["prok:CFB group bacteria", "unkn:unknown"],
 }
 
 


### PR DESCRIPTION
The check_data_table_for_dups.py script is looking at data table entries and checking for duplicate values within a table. The point of this is to detect when reference data GA has in custom-indices is added to /cvmfs with the same key. If the duplicated values both comes from cvmfs they can be ignored.