### PR TITLE
increase mem for gff converter tools

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -4008,6 +4008,10 @@ tools:
     inherits: wig_to_bigWig
   CONVERTER_fasta_to_fai:
     mem: 10
+  CONVERTER_gff_to_fli_0:
+    mem: 12
+  CONVERTER_gff_to_interval_index_0:
+    mem: 12
   CONVERTER_interval_to_bigwig_0:
     inherits: wig_to_bigWig
   CONVERTER_wig_to_bigwig:


### PR DESCRIPTION
Built in tools CONVERTER_gff_to_fli_0 and CONVERTER_gff_to_interval_index_0. It seems suspicious that these would fail for files as small as 80MB.