### PR TITLE
Increase resources for small hifiasm jobs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -318,8 +318,8 @@ tools:
     rules:
     - id: hifiasm_small_input_rule
       if: input_size < 0.1
-      cores: 4
-      mem: 15.3
+      cores: 8
+      mem: 31.2
     - id: hifiasm_xlarge_input_rule
       if: input_size > 200
       mem: 1922


### PR DESCRIPTION
Out of memory errors for hifiasm are almost all from the <100MB input category and in some cases the inputs are <1MB