### PR TITLE
production to use latest tpv shared db

### DIFF
--- a/templates/galaxy/config/galaxy_job_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_job_conf.yml.j2
@@ -199,7 +199,7 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
-        - https://gxy.io/tpv/db-latest.yml
+        - https://gxy.io/tpv/db-v2.yml
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/default_tool.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/tools.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/tool_pulsar_scores.yml"

--- a/templates/galaxy/config/staging_job_conf.yml.j2
+++ b/templates/galaxy/config/staging_job_conf.yml.j2
@@ -35,7 +35,7 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
-        - https://gxy.io/tpv/db-latest.yml
+        - https://gxy.io/tpv/db-v2.yml
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/staging_tools.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/staging_vortex_config.yml"
         - "{{ galaxy_dynamic_job_rules_dir }}/total_perspective_vortex/staging_destinations.yml"


### PR DESCRIPTION
Versioning has been introduced in the tpv shared db https://github.com/galaxyproject/tpv-shared-database?tab=readme-ov-file#version-guide.

I’d be happy to use the latest updates to shared-db as they come in and revert to a version if this turns out to be a problem.