### PR TITLE
update pulsar score slurm threshold

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -20,7 +20,7 @@ tools:
       # pulsar score
       pulsar_score: null  # scores set in tool_pulsar_scores.yml. Not every tool will have a score
       pulsar_score_pulsar_threshold: 10  # above this score, prefer to send jobs to pulsar
-      pulsar_score_slurm_threshold: 0.3  # below this score, prefer to send jobs to slurm
+      pulsar_score_slurm_threshold: 0.25  # below this score, prefer to send jobs to slurm  # adjusted from 0.3 to 0.25 to reduce slurm jam 2/10/25
       pulsar_score_slurm_max_cores: 12  # if cores >= this number, do not set preference for slurm
       pulsar_score_slurm_max_mem: 48  # if mem >= this number, do not set preference for slurm
  


### PR DESCRIPTION
Tools with a score under the pulsar score slurm threshold have a ‘prefer: slurm’ tag added which means that if slurm is in the candidate destinations, this is where they will go, even if they are pulsar-able.

If this is set to 0.25 instead of 0.3, some jobs will be mapped according to destination availability instead of sent straight to slurm, such as fastqc jobs.