### PR TITLE
Biocommons AAI changes

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -201,6 +201,8 @@ host_galaxy_config: # renamed from __galaxy_config
     allow_local_account_creation: false
     disable_local_accounts: true
     enable_oidc: true
+    oidc_auth_pipeline_extra:
+      - "galaxy.authnz.auth0_authnz.sync_user_groups"
     file_path: "{{ galaxy_file_path }}"
     id_secret: "{{ vault_dev_id_secret }}"
     interactivetools_enable: true
@@ -538,3 +540,4 @@ auth0_client_id: "{{ vault_auth0_client_id_dev }}"
 auth0_client_secret: "{{ vault_auth0_client_secret_dev }}"
 auth0_oidc_endpoint: "{{ vault_auth0_oidc_endpoint_dev }}"
 auth0_audience: "{{ vault_auth0_audience_dev }}"
+auth0_registration_endpoint: "{{ vault_auth0_registration_endpoint_dev }}"

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -198,6 +198,8 @@ host_galaxy_config: # renamed from __galaxy_config
     enable_celery_tasks: true
     enable_mulled_containers: true
     enable_notification_system: true
+    allow_local_account_creation: false
+    disable_local_accounts: true
     enable_oidc: true
     file_path: "{{ galaxy_file_path }}"
     id_secret: "{{ vault_dev_id_secret }}"

--- a/templates/galaxy/config/oidc_backends_config.xml.j2
+++ b/templates/galaxy/config/oidc_backends_config.xml.j2
@@ -17,6 +17,7 @@
         <redirect_uri>{{ galaxy_config['galaxy']['galaxy_infrastructure_url'] }}/authnz/oidc/callback</redirect_uri>
         <oidc_endpoint>{{ auth0_oidc_endpoint }}</oidc_endpoint>
         <accepted_audiences>{{ auth0_audience }}</accepted_audiences>
+        <username_key>https://biocommons.org.au/username</username_key>
         <extra_scopes>roles</extra_scopes>
         <custom_button_text>BioCommons (via Auth0)</custom_button_text>        
     </provider>

--- a/templates/galaxy/config/oidc_backends_config.xml.j2
+++ b/templates/galaxy/config/oidc_backends_config.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <OIDC>
+{% if not inventory_hostname.startswith('dev') %}
     <provider name="Keycloak">
         <label>AAF</label>
         <require_create_confirmation>true</require_create_confirmation>
@@ -10,6 +11,7 @@
         <well_known_oidc_config_uri>{{ aaf_issuer_url }}.well-known/openid-configuration</well_known_oidc_config_uri>
         <icon>https://swift.rc.nectar.org.au/v1/AUTH_377/public/Galaxy/AAF_BTN_Sign_in_med_gradient_orange_FIN2020.png</icon>
     </provider>
+{% endif %}
 {% if inventory_hostname.startswith('dev') %}
     <provider name="oidc">
         <client_id>{{ auth0_client_id }}</client_id>

--- a/templates/galaxy/config/oidc_backends_config.xml.j2
+++ b/templates/galaxy/config/oidc_backends_config.xml.j2
@@ -19,7 +19,8 @@
         <accepted_audiences>{{ auth0_audience }}</accepted_audiences>
         <username_key>https://biocommons.org.au/username</username_key>
         <extra_scopes>roles</extra_scopes>
-        <custom_button_text>BioCommons (via Auth0)</custom_button_text>        
+        <custom_button_text>BioCommons (via Auth0)</custom_button_text>
+        <end_user_registration_endpoint>{{ auth0_registration_endpoint }}</end_user_registration_endpoint>
     </provider>
 {% endif %}
 </OIDC>


### PR DESCRIPTION
This is a WIP but shows the current changes needed to update the config for https://github.com/usegalaxy-au/galaxy/pull/4 - including new config options that have been added via PRs to Galaxy main.

Note this PR removes the AAF OIDC login option in dev - the UI changes to point to the BioCommons login/register pages work best when only a single OIDC provider is configured.