### PR TITLE
more gunicorn workers on web server

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -112,7 +112,7 @@ host_galaxy_config_gravity:
     enable_beat: false
   gunicorn:
     - bind: "0.0.0.0:8888"
-      workers: 2
+      workers: 3
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       timeout: 1800
@@ -120,7 +120,7 @@ host_galaxy_config_gravity:
       preload: true
       environment: "{{ galaxy_process_env }}"
     - bind: "0.0.0.0:8889"
-      workers: 2
+      workers: 3
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       timeout: 1800


### PR DESCRIPTION
Increase worker count from 2 to 3 for each gunicorn process.

This is motivated by time periods with errors in the nginx error log such as "connect() failed (111: Unknown error) while connecting to upstream" or "no live upstreams while connecting to upstream”. These may be due to the gunicorn backlogs being saturated during bursts of activity. Having more workers to reduce the backlog could help.

Biocommons canary (service-alerts channel) has reported timeouts, I have also had some 502 errors running tool tests.