### PR TITLE
hide trinotate

### DIFF
--- a/jenkins/update_labels/hidden_tools.yml
+++ b/jenkins/update_labels/hidden_tools.yml
@@ -13,3 +13,4 @@ hidden_tool_ids:
 - toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/jmoleditor/1.0.0
 - toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/*
 - toolshed.g2.bx.psu.edu/repos/iuc/salsa/salsa/*
+- toolshed.g2.bx.psu.edu/repos/iuc/trinotate/trinotate/*


### PR DESCRIPTION
Hde trinotate from tool panel. This doesn’t work (files it downloads are not available) for periods of time. Action recommended by Igor.