### PR TITLE
never clean up binette jobs (setting cleanup_jobs in params in tpv: it works!)

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1542,6 +1542,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/binette/binette/.*:
     params:
       singularity_enabled: true
+      cleanup_job: never  # TODO: this should be temporary (take note of whether this actually works)
   toolshed.g2.bx.psu.edu/repos/iuc/biobox_add_taxid/biobox_add_taxid/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
In theory the cleanup_job parameter should be overridable. I need to look at green jobs with unexpected outputs whose working directories immediately disappear after job execution.