### PR TITLE
add geerlinguy.jenkins version to requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -74,6 +74,7 @@ roles:
 - name: geerlingguy.java
   version: 2.5.0
 - name: geerlingguy.jenkins
+  version: 5.2.0
 
 # GMS roles
 - name: geerlingguy.nginx


### PR DESCRIPTION
I think this was there before, we may have accidentally rebased it out