### PR TITLE
Update dev_destinations.yml.j2 for tpv 3.1.1

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -153,6 +153,7 @@ destinations:
         - pulsar
     rules:
       - id: pulsar_destination_docker_rule
+        if: entity.params.get('docker_enabled')
         params:
             docker_volumes: $job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold:/data:ro
             docker_set_user: '1000'


### PR DESCRIPTION
rule inheritance breaks TPV because the pydantic model expects every member of `rules` to have an `if`.

This is probably not a bug but a change in behaviour that needs to be accommodated.