### PR TITLE
drop some old python pinned versions in galaxy_additional_venv_requirements

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -144,10 +144,7 @@ tpv_packages: |
   {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
 
 additional_packages:
-  - redis
   - flower
-  - watchdog==2.2.1
-  - fs.dropboxfs==1.0.1  # (latest version requires python 3.11)
 
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 


### PR DESCRIPTION
galaxy installs redis

watchdog was pinned in 2023 due to a job handler memory leak when GA was getting ready for the ETCA move. Hopefully this is no longer an issue.

dev and production use python 3.11, so no need to pin fs.dropboxfs.