### PR TITLE
additional venv packages

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -145,7 +145,6 @@ tpv_packages: |
 
 additional_packages:
   - flower
-  - 'fastapi<0.118' # TODO: follow up with galaxy
 
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -5,9 +5,23 @@ add_hosts_handlers: yes
 common_logrotate_manage_rsyslog: true
 
 # total perspective vortex
-tpv_version: "3.1.1"
+tpv_version: "3.1.2"
 # tpv_repo: https://github.com/usegalaxy-au/total-perspective-vortex
 # tpv_commit_id: d8e336b1cc889237c155d0ad318051c36e5636e6
+
+tpv_packages: |
+  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
+
+additional_packages:
+  - flower
+  # specific pinnings of packages so that boto3 installation will work
+  # boto3 is used for s3 file sources on dev, not used on production yet
+  - boto3==1.40.18
+  - botocore==1.40.18
+  - aiobotocore==2.24.2
+  - s3fs==2024.9.0
+
+galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 
 # variables for attaching mounted volume to application server
 attached_volumes:


### PR DESCRIPTION
Galaxy is no longer installing fastapi as a conditional requirement. ChatGPT recommended specific versions of various packages that allow boto3 to be installed without conflicts. boto3 is needed for s3 file sources but it conflicts with existing packages unless they are pinned.