### PR TITLE
back up venv list

### DIFF
--- a/jenkins/config_backup/config_backup_playbook.yml
+++ b/jenkins/config_backup/config_backup_playbook.yml
@@ -41,10 +41,10 @@
         command: /mnt/galaxy/venv/bin/pip freeze
         register: pip_packages
       - name: Save package list locally
-        local_action:
-          module: copy
+        copy:
           content: "{{ pip_packages.stdout }}"
           dest: "{{ config_backup_dir }}/galaxy_venv/venv_packages.txt"
+        delegate_to: localhost
 - hosts:
     - galaxy-backup
   become: true


### PR DESCRIPTION
Galaxy Australia has a private github repo containing useful backups: files managed by galaxy, tiaas and history mailer dbs, probably should contain media site db as well.

This is to save a daily copy of pip list so it is easy to see when packages change.