### PR TITLE
comment out tiaas_extra_static_dir

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -317,7 +317,7 @@ tiaas_retain_contact_consent: false
 # Templates to override web content:
 tiaas_templates_dir: files/tiaas/html
 # Static files referenced by above templates:
-tiaas_extra_static_dir: files/tiaas/static
+# tiaas_extra_static_dir: files/tiaas/static
 
 # AAF specific settings
 aaf_issuer_url: "{{ vault_aaf_issuer_url_dev }}"

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -290,7 +290,7 @@ tiaas_retain_contact_consent: false
 # Templates to override web content:
 tiaas_templates_dir: files/tiaas/html
 # Static files referenced by above templates:
-tiaas_extra_static_dir: files/tiaas/static
+# tiaas_extra_static_dir: files/tiaas/static
 
 # AAF specific settings
 aaf_issuer_url: "{{ vault_aaf_issuer_url_prod }}"

--- a/host_vars/staging.gvl.org.au.yml
+++ b/host_vars/staging.gvl.org.au.yml
@@ -245,7 +245,7 @@ tiaas_retain_contact_consent: false
 # Templates to override web content:
 tiaas_templates_dir: files/tiaas/html
 # Static files referenced by above templates:
-tiaas_extra_static_dir: files/tiaas/static
+# tiaas_extra_static_dir: files/tiaas/static
 
 # host-specific settings for postfix
 postfix_host_domain: "staging.gvl.org.au"


### PR DESCRIPTION
tiaas role breaks because `files/tiaas/static` isn’t there anymore, this var is probably not needed