### PR TITLE
Fix gunicorn WSGI module path

### DIFF
--- a/roles/galaxy_labs_engine/templates/docker-compose.yml.j2
+++ b/roles/galaxy_labs_engine/templates/docker-compose.yml.j2
@@ -67,7 +67,7 @@ services:
         --capture-output
         --log-level info
         -c {{ labs_config_root }}/gunicorn.py
-        app.wsgi:application
+        labs_engine.app.wsgi:application
     restart: always
     working_dir: "{{ labs_django_root }}"
 


### PR DESCRIPTION
Missed a teeny bit of config here in labs engine role