### PR TITLE
pulsar-QLD to use new CVMFS stratum 1 server

### DIFF
--- a/group_vars/pulsar_QLD/pulsar-QLD.yml
+++ b/group_vars/pulsar_QLD/pulsar-QLD.yml
@@ -6,6 +6,17 @@ use_internal_ips: false
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 
+# override for testing new CVMFS stratum 1 server
+galaxy_cvmfs_server_urls:
+  - domain: galaxyproject.org
+    #use_geoapi: yes
+    urls:
+      - "http://cvmfs-s1-biocommons.aarnet.edu.au/cvmfs/@fqrn@"
+      - "http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
+      - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@"
+      - "http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@"
+      - "http://cvmfs1-ufr0.galaxyproject.eu/cvmfs/@fqrn@"
+
 # Monitoring
 telegraf_agent_output:
   - type: influxdb


### PR DESCRIPTION
pulsar-QLD can be switched to using the new server. When this is merged the pulsar-QLD and pulsar-QLD_workers need to be run, with “sudo cvmfs_config reload” also run on each VM.