### PR TITLE
log slow queries on galaxy-db

### DIFF
--- a/host_vars/galaxy-db.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-db.usegalaxy.org.au.yml
@@ -39,6 +39,7 @@ postgresql_conf:
   # - log_filename: "'postgresql-%Y-%m-%d.log'"
   # - log_statement: all
   # - logging_collector: on  # altering this requires a restart
+  - log_min_duration_statement: 1000
   - wal_level: replica
   - max_wal_senders: 5
   - wal_keep_size: 2GB


### PR DESCRIPTION
Uwe suggested logging slow queries on galaxy-db. Slow queries will be caught in syslog.