### PR TITLE
galaxy-db postgresql log to syslog

### DIFF
--- a/host_vars/galaxy-db.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-db.usegalaxy.org.au.yml
@@ -37,8 +37,9 @@ postgresql_conf:
   - max_parallel_maintenance_workers: 4
   - temp_buffers: 64MB
   # - log_filename: "'postgresql-%Y-%m-%d.log'"
-  # - log_statement: all
-  # - logging_collector: on  # altering this requires a restart
+  - log_destination: syslog
+  - log_statement: none
+  - logging_collector: off  # altering this requires a restart
   - log_min_duration_statement: 1000
   - wal_level: replica
   - max_wal_senders: 5


### PR DESCRIPTION
I added `log_min_duration_statement` yesterday but it doesn’t work, my slow queries are not logged. Apparently log_destination needs to be ’syslog’ (it defaults to stderr). Other settings are to ensure that syslog won’t suddenly be getting verbose logging from postgresql.