### PR TITLE
fix volumes string for data managers

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3970,7 +3970,7 @@ tools:
     mem: 19.1
   .*data_manager.*:
     context:
-      singularity_volumes: '$job_directory:rw,$galaxy_root:ro,$tool_directory:ro,/mnt/user-data-volA:ro,/mnt/user-data-volB:ro,/mnt/user-data-volC:ro,/mnt/user-data-volD:ro,/mnt/user-data-qld:ro,/mnt/user-data-pawsey:ro,/mnt/custom-indices:rw,/cvmfs/data.galaxyproject.org:ro,/tmp:rw'
+      singularity_volumes: '$job_directory:rw,$galaxy_root:ro,$tool_directory:ro,/mnt/user-data-volA:ro,/mnt/user-data-volB:ro,/mnt/user-data-volD:ro,/mnt/user-data-qld:ro,/mnt/custom-indices:rw,/cvmfs/data.galaxyproject.org:ro,/tmp:rw'
     cores: 5
     mem: 19.1
     params:


### PR DESCRIPTION
singularity_volumes for data managers has been overridden to allow /mnt/custom-indices to be `rw`. Remove /mnt/user-data-volC and /mnt/user-data-pawsey from this list.