### PR TITLE
hisat2 pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2005,6 +2005,9 @@ tools:
       max_concurrent_job_count_for_tool_user: 4
     params:
       tmp_dir: true
+    scheduling:
+      accept:
+      - pulsar
     rules:
     - id: hisat2_small_input_rule
       if: input_size < 0.5
@@ -2018,9 +2021,6 @@ tools:
       if: input_size >= 12
       cores: 36
       mem: 500
-      scheduling:
-        accept:
-        - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/.*:
     context:
       max_concurrent_job_count_for_tool_user: 4


### PR DESCRIPTION
Hisat2 can run on pulsar. I can’t remember why we were only sending the large ones there.