### PR TITLE
remove webdav task

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -96,15 +96,6 @@
     - name: Install slurm-drmaa
       package:
         name: slurm-drmaa1
-    - name: Uninstall the existing web-dav-client
-      pip:
-        name: "webdavclient3"
-        virtualenv: "{{ galaxy_venv_dir }}"
-        state: absent
-    - name: Workaround content-length header bug in webdav through forcible update to newer version
-      pip:
-        name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
-        virtualenv: "{{ galaxy_venv_dir }}"
     - name: Reload exportfs
       command: exportfs -ra
       become: yes

--- a/galaxy_playbook.yml
+++ b/galaxy_playbook.yml
@@ -84,15 +84,6 @@
         group: devs
         mode: 0775
         state: directory
-    - name: Uninstall the existing web-dav-client  # TODO: these two tasks could be a role
-      pip:
-        name: "webdavclient3"
-        virtualenv: "{{ galaxy_venv_dir }}"
-        state: absent
-    - name: Workaround content-length header bug in webdav through update to newer version
-      pip:
-        name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
-        virtualenv: "{{ galaxy_venv_dir }}"
     - name: set up lsync between /mnt/galaxy and /mnt/ghost-galaxy-app
       include_role:
         name: lsyncd

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -62,15 +62,6 @@
     - name: Install slurm-drmaa
       package:
         name: slurm-drmaa1
-    - name: Uninstall the existing web-dav-client
-      pip:
-        name: "webdavclient3"
-        virtualenv: "{{ galaxy_venv_dir }}"
-        state: absent
-    - name: Workaround content-length header bug in webdav through forcible update to newer version
-      pip:
-        name: "webdavclient3@git+https://github.com/ezhov-evgeny/webdav-client-python-3@0f17fa7946e66f7963db367d0d6b2e7f940ebeb8"
-        virtualenv: "{{ galaxy_venv_dir }}"
     - name: Reload exportfs
       command: exportfs -ra
       become: yes


### PR DESCRIPTION
GA’s playbook uninstall webdav and install it at a specific commit from 2022: https://github.com/ezhov-evgeny/webdav-client-python-3/commit/0f17fa7946e66f7963db367d0d6b2e7f940ebeb8. Galaxy’s conditional requirements now also use a specific commit of webdav (from 2023) https://github.com/ezhov-evgeny/webdav-client-python-3/commit/98c23d1abd15efc3db9cfc756429f00041578bc2

so we can probably use the version from conditional-requirements and stop uninstalling/reinstalling webdav.