### PR TITLE
Add bring-your-own-file-sources to production

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -145,6 +145,12 @@ tpv_packages: |
 
 additional_packages:
   - flower
+  # specific pinnings of packages so that boto3 installation will work
+  # boto3 is used for s3 file sources
+  - boto3==1.40.18
+  - botocore==1.40.18
+  - aiobotocore==2.24.2
+  - s3fs==2024.9.0
 
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 
@@ -216,6 +222,7 @@ group_galaxy_config:
     tool_sheds_config_file: "{{ galaxy_config_dir }}/tool_sheds_conf.xml"
     user_preferences_extra_conf_path: "{{ galaxy_config_dir }}/user_preferences_extra_conf.yml"
     file_sources_config_file: "{{ galaxy_config_dir }}/file_sources_conf.yml"
+    file_source_templates_config_file: "{{ galaxy_config_dir }}/file_source_templates.yml"
     vault_config_file: "{{ galaxy_config_dir }}/vault_conf.yml"
 
     galaxy_data_manager_data_path: "{{ galaxy_custom_indices_dir }}"
@@ -318,6 +325,8 @@ group_galaxy_config_templates:
     dest: "{{ galaxy_config['galaxy']['user_preferences_extra_conf_path'] }}"
   - src: "{{ galaxy_config_template_src_dir }}/config/file_sources_conf.yml.j2"
     dest: "{{ galaxy_config['galaxy']['file_sources_config_file'] }}"
+  - src: "{{ galaxy_config_template_src_dir }}/config/file_source_templates.yml.j2"
+    dest: "{{ galaxy_config['galaxy']['file_source_templates_config_file'] }}"
 
 
 galaxy_config_templates: "{{ group_galaxy_config_templates + host_galaxy_config_templates|d([]) }}"

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -12,17 +12,6 @@ tpv_version: "3.1.2"
 tpv_packages: |
   {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
 
-additional_packages:
-  - flower
-  # specific pinnings of packages so that boto3 installation will work
-  # boto3 is used for s3 file sources on dev, not used on production yet
-  - boto3==1.40.18
-  - botocore==1.40.18
-  - aiobotocore==2.24.2
-  - s3fs==2024.9.0
-
-galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
-
 # variables for attaching mounted volume to application server
 attached_volumes:
   - device: /dev/vdb
@@ -116,8 +105,6 @@ host_galaxy_config_templates:
     dest: "{{ galaxy_toolbox_filters_dir }}/aagi_filters.py"
   - src: "{{ galaxy_config_template_src_dir }}/config/object_store_templates.yml.j2"
     dest: "{{ galaxy_config_dir }}/object_store_templates.yml"
-  - src: "{{ galaxy_config_template_src_dir }}/config/file_source_templates.yml.j2"
-    dest: "{{ galaxy_config_dir }}/file_source_templates.yml"
 
 host_galaxy_config_files:
   - src: "{{ galaxy_config_file_src_dir }}/config/oidc_config.xml"
@@ -222,7 +209,6 @@ host_galaxy_config: # renamed from __galaxy_config
     oidc_auth_pipeline_extra:
       - "galaxy.authnz.auth0_authnz.sync_user_groups"
     file_path: "{{ galaxy_file_path }}"
-    file_source_templates_config_file: "{{ galaxy_config_dir }}/file_source_templates.yml"
     id_secret: "{{ vault_dev_id_secret }}"
     interactivetools_enable: true
     interactivetools_map: "{{ gie_proxy_sessions_path }}"


### PR DESCRIPTION
There are useful things here that people can already use if they have access. Unfortunately the generic S3 template does not work for my university S3 storage because it is finicky about how the data is read and written. We may have the option of developing something specific  for this in the future.

In the meantime this should be enabled.

This PR also adds the additional venv packages for boto3. There may be other packages that need to be installed for other file source types - cross that bridge when we come to it.