### PR TITLE
Do not use mamba on pulsar-nci-training

### DIFF
--- a/group_vars/pulsar_nci_training/pulsar-nci-training.yml
+++ b/group_vars/pulsar_nci_training/pulsar-nci-training.yml
@@ -6,9 +6,6 @@ use_internal_ips: true
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
 
-# Use mamba as replacement for conda
-pulsar_conda_exec: "mamba"
-
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au
 grafana_server_url: "https://{{ influx_url }}:8086"


### PR DESCRIPTION
Any cluster with conda installed since we stopped pinning it will not have mamba. This was left in by mistake.