### PR TITLE
miniconda_distribution must be set

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -205,6 +205,7 @@ galaxy_cvmfs_server_urls:
 # miniconda
 miniconda_install: true
 miniconda_update: false
+miniconda_distribution: miniconda
 
 miniconda_channels:
   - conda-forge

--- a/requirements.yml
+++ b/requirements.yml
@@ -43,7 +43,7 @@ roles:
 - src: geerlingguy.docker  # TODO: test upgrading to latest version
   version: 4.1.3
 - name: galaxyproject.miniconda
-  version: 0.3.3
+  version: 0.3.4
 - name: usegalaxy_eu.influxdb
   version: v6.0.8
 - name: cloudalchemy.grafana


### PR DESCRIPTION
Since role version 0.3.3 playbooks have been sporadically failing with the miniconda role. It turns out that there are now many ways to install conda with the variable `miniconda_distribution` whose default has been set to `miniforge`. Setting it to `miniconda` allows the role to see that the executable is already there, and nothing breaks.