### PR TITLE
switch off user activation on dev

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -254,7 +254,7 @@ host_galaxy_config: # renamed from __galaxy_config
     trs_servers_config_file: "{{ galaxy_config_dir }}/trs_servers_conf.yml"
     # TUS
     tus_upload_store: "{{ galaxy_tus_upload_store }}"
-    user_activation_on: true
+    user_activation_on: false
     watch_job_rules: true # important for total perspective vortex
     welcome_directory: plugins/welcome_page/new_user/static/topics/
 


### PR DESCRIPTION
set `user_activation_on: false` on dev

I’m attaching these variables to a boolean `aai_active` on my QA server branch.  For the moment just set it to false here