### PR TITLE
create one-off playbook for broken apt-key in dj-wasabi.telegraf

### DIFF
--- a/one-offs/telegraf_install_with_fix_for_broken_apt-key.yml
+++ b/one-offs/telegraf_install_with_fix_for_broken_apt-key.yml
@@ -1,0 +1,47 @@
+- hosts: all
+  become true
+
+  pre_tasks:
+      # the following is a workaround for dj-wasabi.telegraf role breaking on new VMs
+      # the issue is that the dj-wasabi.telegraf role is not dearmoring the downloaded key
+      # the dearmored key location is then passed to dj-wasabi.telegraf via a variable
+      - name: Ensure /etc/apt/keyrings exists
+        ansible.builtin.file:
+          path: /etc/apt/keyrings
+          state: directory
+          mode: "0755"
+        become: true
+
+      - name: Fetch InfluxData key (ascii)
+        ansible.builtin.get_url:
+          url: https://repos.influxdata.com/influxdata-archive.key
+          dest: /etc/apt/keyrings/influxdata-archive.asc
+          mode: "0644"
+        register: influx_key
+        until: influx_key is succeeded
+        retries: 3
+        delay: 2
+        become: true
+
+      - name: Dearmor into a binary keyring if key has changed
+        ansible.builtin.command: >
+          gpg --batch --yes --dearmor
+          -o /etc/apt/keyrings/influxdata-archive.gpg
+          /etc/apt/keyrings/influxdata-archive.asc
+        when: influx_key.changed
+        become: true
+
+      - name: Ensure permissions on keyring
+        ansible.builtin.file:
+          path: /etc/apt/keyrings/influxdata-archive.gpg
+          owner: root
+          group: root
+          mode: "0644"
+        become: true
+
+  roles:
+      - role: dj-wasabi.telegraf
+        vars:
+          # override the role’s internal set_fact when create telegraf.list
+          telegraf_repository_params: "[signed-by=/etc/apt/keyrings/influxdata-archive.gpg]"
+


### PR DESCRIPTION
This is the workaround for the `dj-wasabi.telegraf` role breaking on new VMs.

Rather than adding this code to every playbook that installs `dj-wasabi.telegraf`, it makes sense to have it as a standalone in one-offs. Then commenting out the role in the specific VMs playbook.

Alternatively, remove the actual install from here and ensure that `telegraf_repository_params` is set in each playbook that installs telegraf.

Either way works, Installing here just keeps it tightly tied to the workaround, while setting in each playbook ensures order of operations is unchanged.

@cat-bro I'm leaning towards the latter option, but documenting here for posterity.