### PR TITLE
move purge_dups off pulsar as well

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2906,9 +2906,9 @@ tools:
     mem: 30.7
     params:
       singularity_enabled: true
-    scheduling:
-      accept:
-      - pulsar
+    # scheduling:  # moved off pulsar due to very large jobs being staged out, though the pulsar score of this tool is ~1 and it should in theory be worth it to send to pulsar
+    #   accept:
+    #   - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/qualimap_.*:
     params:
       singularity_enabled: true  


### PR DESCRIPTION
This tool is OK on pulsar. Moving it off today to alleviate transport congestion.