### PR TITLE
reduce concurrency of fastq_dump and fasterq_dump

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3403,14 +3403,14 @@ tools:
       mem: 30.7
   toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/.*:
     context:
-      max_concurrent_job_count_for_tool_user: 4
+      max_concurrent_job_count_for_tool_user: 1
     cores: 3
     mem: 11.5
     params:
       tmp_dir: true
   toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fastq_dump/.*:
     context:
-      max_concurrent_job_count_for_tool_user: 4
+      max_concurrent_job_count_for_tool_user: 1
     cores: 3
     mem: 11.5
     params:


### PR DESCRIPTION
these tools have been known to be hard on job working directory NFS.