### PR TITLE
pulsar-nci-training is offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -159,7 +159,7 @@ destinations:
         - bakta_database
         - funannotate
         - eggnog
-        # - training # Temporary reroute while training pulsar is offline
+        - training # Temporary reroute while training pulsar is offline
         # - pulsar-blast  # alternate location for pulsar blast jobs when pulsar-qld-blast is unavailable
       require:
         - pulsar
@@ -294,6 +294,7 @@ destinations:
       require:
         - pulsar
         - training
+        - offline
 
   pulsar-qld-blast:
     inherits: _pulsar_destination


### PR DESCRIPTION
Unexpectedly offline. Openstack dashboard says it is running but I can’t view the logs: it spins forever, and I can’t ssh to it