### PR TITLE
stop prokka going to pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -571,10 +571,10 @@ tools:
     mem: 30.7
     params:
       singularity_enabled: true
-    scheduling:
-      accept:
-      - pulsar
-      - pulsar-quick
+    # scheduling:  # prokka is normally a good tool to have running on pulsar. It is switching to slurm-only while galaxy-handlers VM is under stress (cause unknown as of 27/11/25)
+    #   accept:
+    #   - pulsar
+    #   - pulsar-quick
     rules:
     - id: prokka_small_input_rule
       if: input_size < 0.001


### PR DESCRIPTION
A high number of prokka jobs on pulsar are causing admin overhead during a time of galaxy-handlers running badly. Hopefully this is a temporary move.