### PR TITLE
galaxy-handlers needs its own cvmfs cache location

### DIFF
--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -111,3 +111,6 @@ postfix_hostname: "galaxy-handlers"
 smtp_login: "{{ vault_smtp_login_prod }}"
 smtp_password: "{{ vault_smtp_password_prod }}"
 
+# CVMFS
+cvmfs_cache_base: /pvol/var/lib/cvmfs
+cvmfs_quota_limit: 40000


### PR DESCRIPTION
galaxy-handlers has accidentally inherited the same cache location as galaxy. 

Fixing this probably won’t help, but it’s worth a try. It has been like this for two years.