### PR TITLE
Remove dropbox and google drive from user file source options pending configuration

### DIFF
--- a/templates/galaxy/config/file_source_templates.yml.j2
+++ b/templates/galaxy/config/file_source_templates.yml.j2
@@ -2,11 +2,13 @@
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_aws_public_bucket.yml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_azure.yml"
-- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_dropbox.yml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_elabftw.yaml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_ftp.yml"
-- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_google_drive.yml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_invenio.yaml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_rspace.yaml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_s3fs.yml"
 - include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_webdav.yml"
+{% if inventory_hostname.startswith('dev') %}
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_dropbox.yml"
+- include: "{{ galaxy_server_dir }}/lib/galaxy/files/templates/examples/production_google_drive.yml"
+{% endif %}


### PR DESCRIPTION
These work on Galaxy Europe but not GA. Galaxy Europe is passing these environment variable to their handlers:
`GALAXY_DROPBOX_APP_CLIENT_ID={{ dropbox_app_client_id }} GALAXY_DROPBOX_APP_CLIENT_SECRET={{ dropbox_app_client_secret }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_ID={{ google_drive_oauth_client_id }} GALAXY_GOOGLE_DRIVE_APP_CLIENT_SECRET={{ google_drive_oauth_client_secret }}`

Both of these require apps created from an account. Setting them up straightforward enough but we need to use an email account (help@genome?) and not add tech debt by using keys from a personal account.