### PR TITLE
extend training rule conditions for require slurm

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -571,6 +571,9 @@ tools:
     mem: 30.7
     params:
       singularity_enabled: true
+    scheduling:
+      require:
+        - slurm  # prokka inherits 'accept: pulsar' from tpv-shared-db
     # scheduling:  # prokka is normally a good tool to have running on pulsar. It is switching to slurm-only while galaxy-handlers VM is under stress (cause unknown as of 27/11/25)
     #   accept:
     #   - pulsar

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
@@ -18,7 +18,15 @@ users:
               include_tags = []
               exclude_tags = ['pulsar', 'training-exempt']
               # slurm preferred for training if the tool can run on pulsar but has a low pulsar_score and no pulsar-training-large tag
-              slurm_preferred_for_training = pulsar_score is not None and pulsar_score < pulsar_score_slurm_threshold and helpers.tag_values_match(entity, match_tag_values=[], exclude_tag_values=['pulsar-training-large', 'training-exempt'])
+              slurm_preferred_for_training = (
+                (pulsar_score is not None
+                and pulsar_score < pulsar_score_slurm_threshold
+                and helpers.tag_values_match(
+                  entity,
+                  match_tag_values=[],
+                  exclude_tag_values=['pulsar-training-large', 'training-exempt']
+                )) or helpers.tag_values_match(entity, match_tag_values=['slurm'], exclude_tag_values=[])
+              )
               training_job_matches_specs = slurm_preferred_for_training or helpers.tag_values_match(entity, include_tags, exclude_tags)
             training_job_matches_specs
           max_cores: 2
@@ -45,7 +53,15 @@ users:
             if training_rules_apply:
               include_tags = ['pulsar']
               exclude_tags = ['pulsar-training-large', 'training-exempt']
-              slurm_preferred_for_training = pulsar_score is not None and pulsar_score < pulsar_score_slurm_threshold
+              slurm_preferred_for_training = (
+                (pulsar_score is not None
+                and pulsar_score < pulsar_score_slurm_threshold
+                and helpers.tag_values_match(
+                  entity,
+                  match_tag_values=[],
+                  exclude_tag_values=['pulsar-training-large', 'training-exempt']
+                )) or helpers.tag_values_match(entity, match_tag_values=['slurm'], exclude_tag_values=[])
+              )
               training_job_matches_specs = (not slurm_preferred_for_training) and helpers.tag_values_match(entity, include_tags, exclude_tags)
             training_job_matches_specs
           max_cores: 4


### PR DESCRIPTION
prokka inherits ‘accept: pulsar’ from tpv-shared-db. To make it not run on pulsar it needs ‘require: slurm’ and an update to training rules so that not every tool with a pulsar tag goes to the training pulsar