### PR TITLE
phm1 offline, pqhm1 pulsar-quick

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -179,6 +179,7 @@ destinations:
         - cvmfs_cache_800plus
       require:
         - pulsar
+        - offline
   pulsar-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-high-mem2_runner
@@ -254,7 +255,7 @@ destinations:
         - verkko_venv
       require:
         - pulsar
-        - offline
+        - pulsar-quick
   pulsar-qld-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem2_runner


### PR DESCRIPTION
pulsar-high-mem1 is Shut Off. The Melbourne Research Cloud may have done this on purpose so I’ll leave it off for now.

pulsar-qld-high-mem1 was set offline to wait for reboot but the last remaining job has been running for ages. Put it back online with pulsar-quick tag.