### PR TITLE
Fix alphafold rule for anonymous user

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1136,13 +1136,13 @@ tools:
       tmp_dir: true
     rules:
     - if: |
-        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user_roles = [role.name for role in user.all_roles() if not role.deleted] if user else []
         'Alphafold_plus' in user_roles
       context:
         alphafold_aa_length_max: 3000
         alphafold_max_input_sequences: 20
     - if: |
-        user_roles = [role.name for role in user.all_roles() if not role.deleted]
+        user_roles = [role.name for role in user.all_roles() if not role.deleted] if user else []
         user and 'Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles
       scheduling:
         require:
@@ -1152,8 +1152,8 @@ tools:
         accept:
         - training-exempt
     - if: |
-        user_roles = [role.name for role in user.all_roles() if not role.deleted]
-        user.username in [f'qldgpu{x+1}' for x in range(6)] or 'pulsar_gpu_test' in user_roles
+        user_roles = [role.name for role in user.all_roles() if not role.deleted] if user else []
+        user and user.username in [f'qldgpu{x+1}' for x in range(6)] or 'pulsar_gpu_test' in user_roles
       scheduling:
         accept:
         - pulsar


### PR DESCRIPTION
Fix rule conditions so that the anonymous user gets the same fail message as anyone not in the Alphafold group.