### PR TITLE
more gunicorn workers and fewer retries for pulsar IO

### DIFF
--- a/group_vars/pulsarservers.yml
+++ b/group_vars/pulsarservers.yml
@@ -47,9 +47,9 @@ pulsar_yaml_config:
           preprocess_action_interval_start: 2
           preprocess_action_interval_step: 2
           preprocess_action_interval_max: 60
-          postprocess_action_max_retries: 18
-          postprocess_action_interval_start: 2
-          postprocess_action_interval_step: 2
+          postprocess_action_max_retries: 5
+          postprocess_action_interval_start: 45
+          postprocess_action_interval_step: 10
           postprocess_action_interval_max: 120
           min_polling_interval: 15
   dependency_resolution:

--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -46,7 +46,7 @@ host_galaxy_config_gravity:
   gunicorn:
     - bind: "0.0.0.0:8888"
       # performance options
-      workers: 2
+      workers: 4
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       preload: true
@@ -55,7 +55,7 @@ host_galaxy_config_gravity:
       environment: "{{ galaxy_process_env }}"
     - bind: "0.0.0.0:8889"
       # performance options
-      workers: 2
+      workers: 4
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       preload: true


### PR DESCRIPTION
Unlike pulsar preprocessing retries which can resume uploading a file a X bytes and keep going, in postprocessing pulsar posts the file back and it has to succeed in one go. Subsequent retries start again from the beginning. Given this, it is probably a bad idea to retry the post 18 times.

More gunicorn workers -> more big files that can be in transit without the request queue getting so long that everything starts to time out.