### PR TITLE
override container for version of bwa_mem2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1662,6 +1662,10 @@ tools:
     #  if: input_size < 1
     #  cores: 8
     #  mem: 30.7
+    - id: bwa_mem2_singularity_override_rule
+      if: helpers.tool_version_eq(tool, "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.2.1+galaxy1")
+      params:
+        singularity_container_id_override: /cvmfs/singularity.galaxyproject.org/all/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07-0
     - id: bwa_mem2_medium_input_rule
       if: input_size < 2
       cores: 8


### PR DESCRIPTION
Galaxy is choosing the wrong container for a version of bwa_mem2. This is the ID of the container resolved on galaxy, but during container resolution a different one is chosen for pulsar jobs.