### PR TITLE
Revert "move nginx upload module on galaxy handlers"

### DIFF
--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -32,7 +32,6 @@ galaxy_build_client: false
 
 galaxy_celery_tmp_dir: /pvol/celery_tmp
 
-upload_store_volume_dir: /pvol2
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/handlers_job_files"
 nginx_ssl_servers:
   - galaxy-handlers


### PR DESCRIPTION
Reverts usegalaxy-au/infrastructure#2912

Moving this folder off the user data volume makes the move from upload store to user data more time consuming than the transfer from an interstate pulsar. It makes sense to move it back.