### PR TITLE
pmel2 offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -142,6 +142,7 @@ destinations:
         - eggnog
       require:
         - pulsar
+        - offline
   pulsar-mel3:
     inherits: _pulsar_destination
     runner: pulsar-mel3_runner


### PR DESCRIPTION
CVMFS transport endpoints are not connected on pulsar-mel2. Setting it offline to fix this.