### PR TITLE
increase worker count further in galaxy.usegalaxy.org.au.yml

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -112,7 +112,7 @@ host_galaxy_config_gravity:
     enable_beat: false
   gunicorn:
     - bind: "0.0.0.0:8888"
-      workers: 4
+      workers: 6
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       timeout: 1800
@@ -120,7 +120,7 @@ host_galaxy_config_gravity:
       preload: true
       environment: "{{ galaxy_process_env }}"
     - bind: "0.0.0.0:8889"
-      workers: 4
+      workers: 6
       # Other options that will be passed to gunicorn
       extra_args: '--forwarded-allow-ips="*"'
       timeout: 1800


### PR DESCRIPTION
gunicorn has no `auto` option for this. The galaxy VM has 16 CPUs and runs TUS, gunicorn and gx-it-proxy. 

This is not a substitute for improving disk access times, but if more gunicorn workers can be stably run this could reduce the rate of web access errors.