### PR TITLE
Allow jobs to be scheduled to pqhm2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -274,7 +274,6 @@ destinations:
         - ncbi_fcs_gx_db
       require:
         - pulsar
-        - pulsar-qld-high-mem2
   pulsar-nci-training:
     inherits: _pulsar_destination
     runner: pulsar-nci-training_runner


### PR DESCRIPTION
It was available only to tools with the pulsar-qld-high-mem2 tag, GA needs more big pulsars online.