### PR TITLE
update galaxy handlers nginx for pulsar posts

### DIFF
--- a/templates/nginx/galaxy-handlers.j2
+++ b/templates/nginx/galaxy-handlers.j2
@@ -51,13 +51,14 @@ server {
 
 {% endif %}
 
-    location /api {
+    location ~ ^/api/jobs/[^/]+/files$ {
         proxy_pass         http://galaxy;
         proxy_redirect     off;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
+	    proxy_read_timeout 7200;
     }
 
     # error docs
@@ -66,5 +67,10 @@ server {
     location /error {
         ssi on;
         root /etc/nginx;
+    }
+
+    # block everything else
+    location / {
+        return 403;
     }
 }


### PR DESCRIPTION
Add `proxy_read_timeout` for api location, make location specific to api/*/jobs. Without the proxy_read_timeout set high, galaxy has been hanging up on pulsar posts after 10 minutes (504 error) and it needs to stay on the hook for longer when the file is large. This seems to only be necessary when the upload store folder is not on the user data volume.