### PR TITLE
remove pulsar-quick tag from pqhm1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -235,6 +235,7 @@ destinations:
         - eggnog
       require:
         - pulsar
+        - pulsar-quick
   pulsar-qld-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem1_runner
@@ -255,7 +256,6 @@ destinations:
         - verkko_venv
       require:
         - pulsar
-        - pulsar-quick
   pulsar-qld-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem2_runner


### PR DESCRIPTION
pqhm1 is the only pulsar that has all of the gtdbtk reference data and there are no other good places for gtdbtk to run

pqhm0 can have pulsar-quick tag instead