### PR TITLE
pqhm0 cvmfs cache for kraken2

### DIFF
--- a/host_vars/pulsar-qld-high-mem0.yml
+++ b/host_vars/pulsar-qld-high-mem0.yml
@@ -30,7 +30,7 @@ use_internal_ips: false
 
 # cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 819200
+cvmfs_quota_limit: 1638400
 
 #Monitoring for Staging. Once all VM monitoring has moved to stats.usegalaxy.org.au, this can be put in all.yml and removed here.
 influx_url: stats.usegalaxy.org.au


### PR DESCRIPTION
Extend the cvmfs cache on pqhm0 with the aim of making this the preferred destination for kraken2 jobs, some of which use large dbs in cvmfs. [edited: original text said pqhm1]