### PR TITLE
minimum_singularity_version for panaroo

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1237,10 +1237,10 @@ tools:
       accept:
       - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/panaroo/panaroo/.*:
+    context:
+      minimum_singularity_version: '1.5.2+galaxy0'
     cores: 8
     mem: 31.2
-    params:
-      singularity_enabled: true
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
Setting minumum_singularity_version as a context variable means that all versions >= minumum_singularity_version will be given ‘singularity_enabled: true'