### PR TITLE
stop old panaroo running on pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1241,9 +1241,12 @@ tools:
       minimum_singularity_version: '1.5.2+galaxy0'
     cores: 8
     mem: 31.2
-    scheduling:
-      accept:
-      - pulsar
+    rules:
+    - id: panaroo_pulsar_rule
+      if: helpers.tool_version_gte(tool, '1.5.2+galaxy0')
+      scheduling:
+        accept:
+        - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/smudgeplot/smudgeplot/.*:
     cores: 8
     mem: 500


### PR DESCRIPTION
The conda environment for version 1.5.0 builds wrong now. The local conda environment was built a couple of years ago and works, so old versions of this should run locally