### PR TITLE
Fix phastest dev slurm_docker_volumes

### DIFF
--- a/files/galaxy/config/local_tool_conf_dev.xml
+++ b/files/galaxy/config/local_tool_conf_dev.xml
@@ -40,6 +40,7 @@
         <tool file="/mnt/galaxy/local_tools/autocycler/autocycler_trim.xml" />
         <tool file="/mnt/galaxy/local_tools/GlyComboCLI/GlyComboCLI.xml" />
         <tool file="/mnt/galaxy/local_tools/phastest/phastest.xml" />
+        <tool file="/mnt/galaxy/local_tools/phastest/phastest-dev.xml" labels="test" />
 
         <!-- AAGI tools -->
         <tool file="/mnt/galaxy/local_tools/aagi/aagi_001/aagi_001.xml" labels="aagi"/>

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
@@ -296,10 +296,22 @@ tools:
       singularity_volumes: '$defaults,/cvmfs:ro'
   phastest:
     cores: 2
+    context:
+      slurm_docker_volumes: "$defaults,/mnt/galaxy/local_tools/db/phastest:/home/phastest/phastest-app/DB:ro"
     params:
       docker_enabled: true
       docker_sudo: false
-      docker_volumes: "$job_directory:ro,$job_directory/home:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/mnt/galaxy/local_tools/db/phastest:/home/phastest/phastest-app/DB:ro"
+      require_container: true
+    scheduling:
+      require:
+        - slurm
+  phastest_dev:
+    cores: 2
+    context:
+      slurm_docker_volumes: "$defaults,/mnt/galaxy/local_tools/db/phastest:/home/phastest/phastest-app/DB:ro"
+    params:
+      docker_enabled: true
+      docker_sudo: false
       require_container: true
     scheduling:
       require:


### PR DESCRIPTION
@cat-bro was right of course, about the placement of `slurm_docker_volumes`. Seems to work great now, and I've added a second `test` version of the tool so the requesting user can play with `phastest` while I break/develop `phastest_dev`.