### PR TITLE
Add new galaxy requirement for release_25.1 with the hope that this will be temporary

### DIFF
--- a/dev-handlers_playbook.yml
+++ b/dev-handlers_playbook.yml
@@ -37,7 +37,7 @@
     - galaxyproject.repos
     - mounts
     - geerlingguy.pip
-    - galaxyproject.galaxy
+    - galaxyproject.galaxy_release_25.1
     # - role: galaxyproject.miniconda  # maybe this is never needed from the handlers playbook, will see
     #   become: true
     #   become_user: galaxy

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -11,19 +11,6 @@
     - secret_group_vars/stats_server_vault
     - secret_group_vars/dev_secrets
     - secret_group_vars/sentry_vault
-  vars:
-    # These variable are workarounds while deploying dev with new release_25.1 (19/10/25) before
-    # the galaxy role has been updated to handle having nodejs already in galaxy's venv
-
-    # How to build the client on dev while this workaround is in place:
-    # As root user:
-    # cd /mnt/galaxy/galaxy-app
-    # . /mnt/galaxy/venv/bin/activate
-    # export PATH="/mnt/galaxy/venv/lib/python3.11/site-packages/nodejs_wheel/bin:$PATH"
-    # make client-production-maps
-
-    - galaxy_node_version: '22.20.0'
-    - galaxy_build_client: false
   pre_tasks:
     - name: Attach volume to instance
       include_role:
@@ -54,7 +41,7 @@
     - mounts
     # - install-tpv # todo: this needs a when clause
     - geerlingguy.pip
-    - role: galaxyproject.galaxy
+    - role: galaxyproject.galaxy_release_25.1
       tags: galaxy
     - role: galaxyproject.miniconda
       become: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,6 +5,9 @@ collections:
 roles:
 - name: galaxyproject.galaxy
   version: 0.12.0
+- name: galaxyproject.galaxy_release_25.1
+  src: https://github.com/galaxyproject/ansible-galaxy
+  version: client-25.1
 - name: galaxyproject.nginx
   version: 0.7.1  # NOTE: version 1.0.0 exists but fails on dev (16/09/2025)
 - name: galaxyproject.postgresql


### PR DESCRIPTION
Nate has made a branch of the galaxyproject.galaxy role that solves the client building issue on release_25.1. The path of least resistance is to duplicate the galaxyproject.galaxy requirement until the branch is merged in.