### PR TITLE
try to enforce minimum for ‘SHOVILL_RAM’ environment variable (dev)

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml
@@ -374,6 +374,22 @@ tools:
     params:
       singularity_enabled: true
 
+  toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/.*:
+    cores: 4
+    mem: 15
+    params:
+      singularity_enabled: true
+    env:
+      SHOVILL_RAM: '{ max(mem, 8) }'
+      SINGULARITYENV_SHOVILL_RAM: '{ max(mem, 8) }'
+    scheduling:
+      accept:
+      - pulsar
+    rules:
+    - id: shovill_small_input_rule
+      if: input_size < 0.015
+      cores: 1
+      mem: 3.8
 users:
   test_user:
     rules:


### PR DESCRIPTION
shovill now enforces `—ram 8` or higher which is fine for production shovill jobs but can cause test or training jobs to fail. SHOVILL_RAM is an environment in the tool wrapper.