### PR TITLE
set SHOVILL_RAM on production

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3233,6 +3233,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/.*:
     cores: 10
     mem: 38.3
+    env:
+      SHOVILL_RAM: '{ max(mem, 8) }'  # shovill 1.4.1+ sets a minimum of 8 for --ram argument
+      SINGULARITYENV_SHOVILL_RAM: '{ max(mem, 8) }'
     params:
       singularity_enabled: true
     scheduling:


### PR DESCRIPTION
shovill jobs will fail automatically if `—ram` is below 8. This value is controlled by `$SHOVILL_RAM` in the wrapper.