### PR TITLE
lots of memory for sceasy

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3171,9 +3171,9 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/sceasy_convert/sceasy_convert/.*:
-    mem: 62
+    mem: 100
     params:
-      singularity_enabled: false  # 2026-01-13: test using conda environment
+      singularity_enabled: true
     rules:
     - id: sceasy_convert_small_input_rule
       if: input_size < 0.5


### PR DESCRIPTION
Igor’s job on Galaxy Europe was allocated 3.8GB and used 92GB. This is possible when strict OOM killing is not in effect.