### PR TITLE
gtdbtk v220 tpv rule

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2012,7 +2012,7 @@ tools:
       - pulsar
     rules:
     - id: gtdbtk_reference_data_scheduling_rule
-    - if: |
+      if: |
         require_custom_indices_db = True
         min_cvmfs_version = '2.4.0+galaxy0'
         # above a certain version of gtdbtk, reference data


### PR DESCRIPTION
gtdbtk is only allowed to run where the custom indices reference data exists (pqhm1) but for recent versions this doesn’t matter because it is using a db in CVMFS