### PR TITLE
restrict pqhm2 to only jobs that have to run there

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -269,7 +269,7 @@ destinations:
     tags: {{ job_conf_limits.environments['pulsar-qld-high-mem2'].tags }}
     scheduling:
       accept:
-        - pulsar-qld-high-mem2
+        # - pulsar-qld-high-mem2  # normally this is accepted and not required, except when the machine needs a rest
         - cvmfs_cache_100plus
         - cvmfs_cache_800plus
         - ncbi_fcs_gx_db


### PR DESCRIPTION
it is taking 5 minutes to ssh into pqhm2. It needs a rest, but there are a couple of tools that will only run there, so keep it online