### PR TITLE
override container for find_subsequences

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -282,6 +282,7 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/find_subsequences/bg_find_subsequences/.*:
     params:
       singularity_enabled: true
+      singularity_container_id_override: /cvmfs/singularity.galaxyproject.org/all/biopython:1.70--np112py36_1
   toolshed.g2.bx.psu.edu/repos/bgruening/fpocket/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
find_subsequences has never worked on GA and is uninstallable but it in the GTN. It requires biopython 1.65 and there is no container for this. Trial and error with existing biopython containers.