### PR TITLE
remove container override from find_subsequences

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -282,7 +282,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/bgruening/find_subsequences/bg_find_subsequences/.*:
     params:
       singularity_enabled: true
-      singularity_container_id_override: /cvmfs/singularity.galaxyproject.org/all/biopython:1.70--np112py36_1
   toolshed.g2.bx.psu.edu/repos/bgruening/fpocket/.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
Bjoern has made a biopython 1.65 container which should be discoverable and it should just work :crossed_fingers: