### PR TITLE
metawrapmg_binning: one job per user, do not run on pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1248,13 +1248,14 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/metawrapmg_binning/metawrapmg_binning/.*:
     context:
       test_cores: 10
+      max_concurrent_job_count_for_tool_user: 1
     cores: 16
-    mem: 64
+    mem: 62
     params:
       singularity_enabled: true
-    scheduling:
-      accept:
-      - pulsar
+    #scheduling:
+    #  accept:
+    #  - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/panaroo/panaroo/.*:
     context:
       minimum_singularity_version: '1.5.2+galaxy0'


### PR DESCRIPTION
metawrap jobs on pulsar appear to be finishing OK but the tool_stderr files are so absolutely huge that pulsar cannot post them back. Given this, running them on slurm doesn’t seem like a great idea either, but if only one job can run per user a time we can look into the tool before it breaks something.

The largest tool_stderr file is 656GB but there are a bunch in the same ballpark.