### PR TITLE
add ‘cleanup_job: never’ in metawrap [REVERT ME]

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1251,9 +1251,6 @@ tools:
       max_concurrent_job_count_for_tool_user: 1
     cores: 16
     mem: 62
-    env:
-      USE_OPENMP: 1
-      SINGULARITYENV_USE_OPENMP: 1
     params:
       singularity_enabled: true
       cleanup_job: never   # THIS IS FOR A SINGLE TEST!!! REVERT THIS IMMEDIATELY


### PR DESCRIPTION
temporarily suspend autocleanup to test the size of the stderr on slurm