### PR TITLE
metawrap: revert to original values for pulsar and concurrency, set OPENBLAS_NUM_THREADS to 1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1248,17 +1248,16 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/metawrapmg_binning/metawrapmg_binning/.*:
     context:
       test_cores: 10
-      max_concurrent_job_count_for_tool_user: 1
     env:
-      OPENBLAS_NUM_THREADS: 4
-      SINGULARITYENV_OPENBLAS_NUM_THREADS: 4
+      OPENBLAS_NUM_THREADS: 1
+      SINGULARITYENV_OPENBLAS_NUM_THREADS: 1
     cores: 16
     mem: 62
     params:
       singularity_enabled: true
-    #scheduling:
-    #  accept:
-    #  - pulsar
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/panaroo/panaroo/.*:
     context:
       minimum_singularity_version: '1.5.2+galaxy0'


### PR DESCRIPTION
I’ll PR this env var to the shared db as well, but I’m not sure exactly why this stops the stderr spam