### PR TITLE
bwa_mem2: override tbvdb file size rules

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1707,6 +1707,10 @@ tools:
       if: input_size < 2
       cores: 8
       mem: 100
+    - id: tpvdb_bwa_mem2_xlarge_input_rule  # override shared db rule and treat these the same as >64GB
+      if: 32 <= input_size < 64
+      cores: 20
+      mem: 250
     - id: bwa_mem2_fail_rule
       if: input_size > 150
       fail: "Too much data: There is a limit of 150GB of input for bwa_mem2 jobs. Please note that bwa_mem2 will accept compressed fastsanger.gz input data. Email help@genome.edu.au with any enquiries."

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1717,7 +1717,7 @@ tools:
       mem: 250   
     - id: bwa_mem2_fail_rule
       if: input_size > 200
-      fail: "Too much data: There is a limit of 150GB of input for bwa_mem2 jobs. Please note that bwa_mem2 will accept compressed fastsanger.gz input data. Email help@genome.edu.au with any enquiries."
+      fail: "Too much data: There is a limit of 200GB of input for bwa_mem2 jobs. Please note that bwa_mem2 will accept compressed fastsanger.gz input data. Email help@genome.edu.au with any enquiries."
   toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/.*:
     params:
       singularity_enabled: true

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -1694,25 +1694,29 @@ tools:
       prefer:
       - pulsar
     rules:
-    # TODO: address effect of reference genome size from data table (particularly aPseCor3hap2)
-    #- id: bwa_mem2_small_input_rule
-    #  if: input_size < 1
-    #  cores: 8
-    #  mem: 30.7
     - id: bwa_mem2_singularity_override_rule
       if: helpers.tool_version_eq(tool, "2.2.1+galaxy1")
       params:
         singularity_container_id_override: /cvmfs/singularity.galaxyproject.org/all/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07-0
-    - id: bwa_mem2_medium_input_rule
-      if: input_size < 2
+    # override all shared-db file size rules for bwa_mem2 because they do not have higher enough mem values
+    - id: tpvdb_bwa_mem2_small_input_rule
+      if: input_size < 0.25
+      cores: 4
+      mem: 15.5
+    - id: tpvdb_bwa_mem2_medium_input_rule
+      if: 0.25 <= input_size < 16
       cores: 8
       mem: 100
-    - id: tpvdb_bwa_mem2_xlarge_input_rule  # override shared db rule and treat these the same as >64GB
-      if: 32 <= input_size < 64
+    - id: tpvdb_bwa_mem2_large_input_rule
+      if: 16 <= input_size < 32
       cores: 20
       mem: 250
+    - id: tpvdb_bwa_mem2_xlarge_input_rule
+      if: 32 <= input_size < 64
+      cores: 20
+      mem: 250   
     - id: bwa_mem2_fail_rule
-      if: input_size > 150
+      if: input_size > 200
       fail: "Too much data: There is a limit of 150GB of input for bwa_mem2 jobs. Please note that bwa_mem2 will accept compressed fastsanger.gz input data. Email help@genome.edu.au with any enquiries."
   toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/.*:
     params:


### PR DESCRIPTION
Not enough memory in xlarge input rule for bwa_mem2

Override each file size category in shared db. Hopefully this means that another rule “tpvdb_bwa_mem2_history_reference_rule” set there will still apply.