### PR TITLE
msconvert slurm partition for staging

### DIFF
--- a/group_vars/staging_slurm.yml
+++ b/group_vars/staging_slurm.yml
@@ -31,6 +31,10 @@ slurm_partitions:
       Default: YES
       MaxTime: '30-00:00:00'
       State: UP
+    - name: msconvert
+      nodes: "staging-w1"
+      Default: NO
+      State: UP
 
 slurm_controller_host: staging-queue
 


### PR DESCRIPTION
waste of time to configure staging… msconvert jobs won’t run there because of a partition that is used on prod. I hope there will be no need to merge this.