### PR TITLE
pulsar-QLD requires pulsar-quick tag.

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -242,7 +242,6 @@ destinations:
         - eggnog
       require:
         - pulsar
-        # - pulsar-quick
   pulsar-qld-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem1_runner
@@ -339,7 +338,7 @@ destinations:
         - bakta_database
       require:
         - pulsar
-        # - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
+        - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner


### PR DESCRIPTION
Several pulsar-QLD workers will be offline at various times next week.