### PR TITLE
change scheduling in attempt to clear kraken2 queue

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -226,7 +226,7 @@ destinations:
     runner: pulsar-qld-high-mem0_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 60
+    min_accepted_mem: 400
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2323,6 +2323,7 @@ tools:
       - pulsar
       - pulsar-training-large
       - pulsar-high-mem2
+      - pulsar-qld-high-mem2
       prefer:
       - cvmfs_cache_1600plus
       reject:


### PR DESCRIPTION
There is something wrong with kraken2 jobs with big dbs from CVMFS. The scheduling rules have all big-db jobs going to pqhm0. This change temporarily stops anything with less than 400GB allocated from going to pqhm0, so some queued jobs can be rescheduled to wreak havoc elsewhere.