### PR TITLE
pulsar status and capacity updates

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -164,7 +164,7 @@ destinations:
         - funannotate
         - eggnog
         - medaka_venv_211
-        - training # Temporary reroute while training pulsar is offline
+        # - training # Temporary reroute while training pulsar is offline
         # - pulsar-blast  # alternate location for pulsar blast jobs when pulsar-qld-blast is unavailable
       require:
         - pulsar
@@ -280,6 +280,7 @@ destinations:
         - cvmfs_cache_100plus
         - cvmfs_cache_800plus
         - ncbi_fcs_gx_db
+        - gffread_destination  # special mapping because gffread is a dangerous tool that can take over jwd space
       require:
         - pulsar
         # - pulsar-qld-high-mem2
@@ -300,11 +301,10 @@ destinations:
         - bakta_database
         - funannotate
         - eggnog
+        - medaka_venv_211
       require:
         - pulsar
         - training
-        - offline
-
   pulsar-qld-blast:
     inherits: _pulsar_destination
     runner: pulsar-qld-blast_runner
@@ -328,8 +328,8 @@ destinations:
     max_accepted_cores: 16
     max_accepted_mem: 62.5
     context:
-      destination_total_cores: 112
-      destination_total_mem: 437.5
+      destination_total_cores: 64  # usually 112, reduced while some workers are in drain for maintenance
+      destination_total_mem: 250 #  usually 437.5, reduced while some workers are in drain for maintenance
     tags: {{ job_conf_limits.environments['pulsar-QLD'].tags }}
     scheduling:
       accept:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -586,12 +586,9 @@ tools:
     params:
       singularity_enabled: true
     scheduling:
-      require:
-        - slurm  # prokka inherits 'accept: pulsar' from tpv-shared-db
-    # scheduling:  # prokka is normally a good tool to have running on pulsar. It is switching to slurm-only while galaxy-handlers VM is under stress (cause unknown as of 27/11/25)
-    #   accept:
-    #   - pulsar
-    #   - pulsar-quick
+      accept:
+      - pulsar
+      - pulsar-quick
     rules:
     - id: prokka_small_input_rule
       if: input_size < 0.001
@@ -637,8 +634,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/bowtie_wrappers/bowtie_wrapper/.*:
     inherits: toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/.*
     scheduling:
-      require:
-        - slurm  # this can run on pulsar but has high input+output size per CPU-time
+      accept:
+        - pulsar
   toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/.*:
     cores: 8
     mem: 30.7
@@ -797,11 +794,6 @@ tools:
       if: 0.01 <= input_size < 2
       cores: 4
       mem: 15.3
-    - id: fastqc_large_input_rule
-      if: input_size > 20
-      scheduling:
-        require:
-          - slurm
   toolshed.g2.bx.psu.edu/repos/devteam/flanking_features/flanking_features_1/.*:
     params:
       singularity_enabled: true
@@ -836,7 +828,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      require:
+      prefer:
       - pulsar-qld-high-mem2
   toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/.*:
     cores: 5
@@ -1235,12 +1227,6 @@ tools:
       accept:
       - pulsar
       - pulsar-quick
-    rules:
-    - id: hifiadapterfilt_large_input_rule
-      if: input_size > 40
-      scheduling:
-        require:
-          - slurm
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/hifiasm_meta/hifiasm_meta/.*:
     cores: 16
     mem: 62
@@ -2078,6 +2064,8 @@ tools:
           require_custom_indices_db = False
         require_custom_indices_db
       scheduling:
+        accept:
+        - training-exempt
         require:
         - gtdbtk_database
   toolshed.g2.bx.psu.edu/repos/iuc/gtdb_to_taxdump/gtdb_to_taxdump/.*:
@@ -3797,6 +3785,7 @@ tools:
     scheduling:
       accept:
       - pulsar
+      - training-exempt
       require:
       - verkko_venv
   toolshed.g2.bx.psu.edu/repos/iuc/volcanoplot/volcanoplot/.*:


### PR DESCRIPTION
reduce available cores/mem for pulsar-QLD temporarily.

put pulsar-nci-training back online

go through tags to make sure that for tools that require a tag, either the tag is accepted by training resources or the tool has the training-exempt tag.