### PR TITLE
add inputs.nfsclient to telegraf_plugins_extra for monitoring client NFS connections

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -411,19 +411,13 @@ gie_proxy_virtualenv: "{{ galaxy_root }}/gie-proxy/venv"
 gie_proxy_setup_service: systemd
 gie_proxy_sessions_path: "{{ galaxy_mutable_data_dir }}/interactivetools_map.sqlite"
 
-# Telegraf extra stuff for statsd and nfsclient
+# Telegraf extra stuff for statsd (Note: nfsclient plugin defined in host_vars)
 telegraf_plugins_extra:
   listen_galaxy_routes:
     plugin: "statsd"
     config:
       - service_address = ":8125"
       - metric_separator = "."
-  listen_galaxy_nfs:
-    plugin: "nfsclient"
-    config:
-      - fullstat = true
-      - include_operations = ["READ", "WRITE", "GETATTR", "LOOKUP", "ACCESS"]
-      - include_mounts = ["/mnt/scratch", "/mnt/user-data-volA", "/mnt/user-data-volB","/mnt/user-data-volD"]
 
 # lsyncd
 lsyncd_source: /mnt/galaxy

--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -119,3 +119,17 @@ cvmfs_quota_limit: 40000
 nfs_monitor_servers_host:
 - identifier: "{{ hostvars['galaxy']['internal_ip'] }}"
   name: galaxy
+
+# Telegraf extra stuff for statsd and nfsclient
+telegraf_plugins_extra:
+  listen_galaxy_routes:
+    plugin: "statsd"
+    config:
+      - service_address = ":8125"
+      - metric_separator = "."
+  listen_galaxy_nfs:
+    plugin: "nfsclient"
+    config:
+      - fullstat = true
+      - include_operations = ["READ", "WRITE", "GETATTR", "LOOKUP", "ACCESS"]
+      - include_mounts = ["/mnt/galaxy", "/mnt/scratch", "/mnt/user-data-volA", "/mnt/user-data-volB","/mnt/user-data-volD"]

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -985,3 +985,17 @@ nfs_monitor_servers_galaxy_and_galaxy_handlers:
 nfs_monitor_servers_host: []
 
 nfs_monitor_servers: "{{ nfs_monitor_servers_galaxy_and_galaxy_handlers + nfs_monitor_servers_host }}"
+
+# Telegraf extra stuff for statsd and nfsclient
+telegraf_plugins_extra:
+  listen_galaxy_routes:
+    plugin: "statsd"
+    config:
+      - service_address = ":8125"
+      - metric_separator = "."
+  listen_galaxy_nfs:
+    plugin: "nfsclient"
+    config:
+      - fullstat = true
+      - include_operations = ["READ", "WRITE", "GETATTR", "LOOKUP", "ACCESS"]
+      - include_mounts = ["/mnt/scratch", "/mnt/user-data-volA", "/mnt/user-data-volB","/mnt/user-data-volD"]


### PR DESCRIPTION
This will add telegraf monitoring of client NFS connections on galaxyservers group VMs. It limits monitored mounts to `/mnt/scratch`, `/mnt/user-data-volA`, `/mnt/user-data-volB`, `/mnt/user-data-volD`. To conserve storage it only monitors operations `READ`, `WRITE`, `GETATTR`, `LOOKUP`, `ACCESS`.

Status: TESTED. Ready to merged.

Before merging
- the changes that will be made to `/etc/telegraf/telegraf.d/` need to be confirmed (done)
- and the telegraf plugin tested on dev (done).
