### PR TITLE
pqhm2 offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -261,6 +261,7 @@ destinations:
         - gtdbtk_database
         - verkko_venv
         - medaka_venv_211
+        - gffread_destination  # while pqhm2 is offline
       require:
         - pulsar
   pulsar-qld-high-mem2:
@@ -282,6 +283,7 @@ destinations:
         - gffread_destination  # special mapping because gffread is a dangerous tool that can take over jwd space
       require:
         - pulsar
+        - offline
         # - pulsar-qld-high-mem2
   pulsar-nci-training:
     inherits: _pulsar_destination

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -829,7 +829,7 @@ tools:
       accept:
       - pulsar
       prefer:
-      - pulsar-qld-high-mem2
+      - gffread_destination
   toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/.*:
     cores: 5
     mem: 19.1


### PR DESCRIPTION
pqhm2 was shut down today without notice, can probably be restarted tomorrow. fix gffread destination in absence of pqhm2. ncbi_fcs_gx jobs have nowhere else to go.