### PR TITLE
Update galaxy-db.usegalaxy.org.au.yml

### DIFF
--- a/host_vars/galaxy-db.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-db.usegalaxy.org.au.yml
@@ -17,7 +17,7 @@ postgresql_conf:
   #   CPUs num: 8
   #   Connections num: 100
   #   Data Storage: san
-  - max_connections: 300
+  - max_connections: 350
   - listen_addresses: "'*'"   # Allow remote connections
   - data_directory: "'/data/production'"
   - shared_buffers: 16GB


### PR DESCRIPTION
raise max_connections to 350 to stop it exceeding its limit of 300.

what could we do to reduce it? Run fewer job handlers? It’s not clear how many connections each one accounts for.