### PR TITLE
override tpvdb fail rule for trinity

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3619,6 +3619,8 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
+    context:
+      input_size_limit: 30
     cores: 60
     mem: 961
     params:
@@ -3634,8 +3636,7 @@ tools:
       mem: 30.7
     - id: tpvdb_trinity_fail_rule
       if: input_size >= 30
-      fail: Too much data, we cannot support such large Trinity assemblies with our
-        backend.
+      fail: 'Over input size limit. There is a limit of {input_size_limit}GB input data for the tool {tool.id}'
   toolshed.g2.bx.psu.edu/repos/iuc/trinity_abundance_estimates_to_matrix/trinity_abundance_estimates_to_matrix/.*:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/trinity_align_and_estimate_abundance/trinity_align_and_estimate_abundance/.*:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3632,10 +3632,10 @@ tools:
       if: input_size < 0.1
       cores: 8
       mem: 30.7
-    - id: trinity_fail_rule
+    - id: tpvdb_trinity_fail_rule
       if: input_size >= 30
       fail: Too much data, we cannot support such large Trinity assemblies with our
-        backend. Please use another server for your job.
+        backend.
   toolshed.g2.bx.psu.edu/repos/iuc/trinity_abundance_estimates_to_matrix/trinity_abundance_estimates_to_matrix/.*:
     mem: 8
   toolshed.g2.bx.psu.edu/repos/iuc/trinity_align_and_estimate_abundance/trinity_align_and_estimate_abundance/.*:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -3635,7 +3635,7 @@ tools:
       cores: 8
       mem: 30.7
     - id: tpvdb_trinity_fail_rule
-      if: input_size >= 30
+      if: input_size >= input_size_limit
       fail: 'Over input size limit. There is a limit of {input_size_limit}GB input data for the tool {tool.id}'
   toolshed.g2.bx.psu.edu/repos/iuc/trinity_abundance_estimates_to_matrix/trinity_abundance_estimates_to_matrix/.*:
     mem: 8


### PR DESCRIPTION
There is a limit of 1GB in tpv-shared-db for trinity with advice for users to run their jobs with rnaspades instead. We tried it out but users are writing in, so this PR is to override the shared-db rule.