### PR TITLE
set context variables for slurm training max cores mem

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -34,6 +34,10 @@ tools:
       pulsar_docker_volumes: "{{ pulsar_docker_volumes }}"
       singularity_default_container_id: "{{ singularity_default_container_id }}"
 
+      # training destination overridable cores/mem values
+      slurm_training_max_cores: 2
+      slurm_training_max_mem: 7.6
+
     scheduling:
       reject:
         - offline

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -2256,6 +2256,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/kallisto_quant/kallisto_quant/.*:
     context:
       max_concurrent_job_count_for_tool_user: 3
+      slurm_training_max_cores: 4
+      slurm_training_max_mem: 15.5
     cores: 5
     mem: 19.1
     params:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/users.yml.j2
@@ -29,8 +29,8 @@ users:
               )
               training_job_matches_specs = slurm_preferred_for_training or helpers.tag_values_match(entity, include_tags, exclude_tags)
             training_job_matches_specs
-          max_cores: 2
-          max_mem: max_cores * 3.8
+          max_cores: slurm_training_max_cores
+          max_mem: slurm_training_max_mem
           context:
             partition: training
           scheduling:


### PR DESCRIPTION
Give default tool extra context variables

```
      slurm_training_max_cores: 2
      slurm_training_max_mem: 7.6
```

that can be overridden at entity level. The use case is kallisto_quant which is being used in an upcoming training. It’s not compatible with pulsar and needs more than 7.6GB RAM.