### PR TITLE
pulsar-quick tag for pqhm1

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -265,6 +265,7 @@ destinations:
         # - gffread_destination  # while pqhm2 is offline
       require:
         - pulsar
+        - pulsar-quick
   pulsar-qld-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem2_runner


### PR DESCRIPTION
keep VM online but it can only accept jobs that ought to run quickly