### PR TITLE
pulsar-mel2 worker volume update

### DIFF
--- a/group_vars/pulsar_mel2/pulsar-mel2_workers.yml
+++ b/group_vars/pulsar_mel2/pulsar-mel2_workers.yml
@@ -24,7 +24,7 @@ slurm_roles: ['exec']
 
 # galaxyproject.cvmfs
 cvmfs_cache_base: /mnt/var/lib/cvmfs
-cvmfs_quota_limit: 20000
+cvmfs_quota_limit: 102400
 
 # geerlingguy.docker
 docker_daemon_options:

--- a/terraform/pulsar-mel2/pulsar-mel2-initial.tf
+++ b/terraform/pulsar-mel2/pulsar-mel2-initial.tf
@@ -1,3 +1,6 @@
+## Note: Worker volumes were extended from 100GB to 200GB in place
+## so any state file for this will not be accurate (30/3/26)
+
 # Pulsar-mel2
 resource "openstack_compute_instance_v2" "pulsar-mel2" {
   name            = "pulsar-mel2"
@@ -85,49 +88,49 @@ resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w1-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w1-volume"
   description = "Pulsar-mel2 W1 volume"
-  size        = 100
+  size        = 200
 }
 
 resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w2-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w2-volume"
   description = "Pulsar-mel2 W2 volume"
-  size        = 100
+  size        = 200
 }
 
 resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w3-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w3-volume"
   description = "Pulsar-mel2 W3 volume"
-  size        = 100
+  size        = 200
 }
 
 resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w4-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w4-volume"
   description = "Pulsar-mel2 W4 volume"
-  size        = 100
+  size        = 200
 }
 
 resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w5-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w5-volume"
   description = "Pulsar-mel2 W5 volume"
-  size        = 100
+  size        = 200
 }
 
 resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w6-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w6-volume"
   description = "Pulsar-mel2 W6 volume"
-  size        = 100
+  size        = 200
 }
 
 resource "openstack_blockstorage_volume_v2" "pulsar-mel2-w7-volume" {
   availability_zone = "melbourne-qh2"
   name        = "pulsar-mel2-w7-volume"
   description = "Pulsar-mel2 W7 volume"
-  size        = 100
+  size        = 200
 }
 
 # Attachment between application/web server and volume


### PR DESCRIPTION
pmel2 workers had their volumes resized to 200 so that the cvmfs caches could be bigger for bakta jobs