### PR TITLE
dev playbook: add more role tags and fix nginx logrotate

### DIFF
--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -46,6 +46,7 @@
     - role: galaxyproject.miniconda
       become: true
       become_user: galaxy
+      tags: miniconda
     - role: galaxy_extensions
       tags: extensions
     - role: usegalaxy_eu.galaxy_subdomains
@@ -58,7 +59,8 @@
     - geerlingguy.nfs
     - galaxyproject.slurm
     - galaxyproject.cvmfs
-    - galaxyproject.gxadmin
+    - role: galaxyproject.gxadmin
+      tags: gxadmin
     - remote-pulsar-cron
     - galaxy-pg-cleanup
     - galaxyproject.tiaas2
@@ -118,8 +120,7 @@
     - name: Add lines to postrotate task in nginx logrotate conf
       lineinfile:
         path: /etc/logrotate.d/nginx
-        line: "{{ item }}"
+        regexp: '^\s*cp\s+{{ nginx_log_olddir_root | regex_escape }}/\*\s+{{ nginx_long_term_log_dir | regex_escape }}/$'
+        line: "\t\tcp {{ nginx_log_olddir_root }}/*.gz {{ nginx_long_term_log_dir }}/"
         insertafter: "\tpostrotate"
-      with_items:
-        - "\t\tcp {{ nginx_log_olddir_root }}/* {{ nginx_long_term_log_dir }}/"
       tags: nginx


### PR DESCRIPTION
tags for miniconda and gxadmin

fix the bug in nginx logrotate that causes all of the uncompressed logs to go to nginx_long_term_log_dir. Then I can fix in galaxy playbook if this is not also bugged in some way