### PR TITLE
add pkce to additional packages

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -153,6 +153,7 @@ additional_packages:
   - botocore==1.40.18
   - aiobotocore==2.24.2
   - s3fs==2024.9.0
+  - pkce  # TODO: there is a bug in the conditional dependency checker in release_26.0
 
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 


### PR DESCRIPTION
TODO: address this is galaxy. oidc.py imports pkce but pkce is a conditional dependency which probably shouldn’t be conditional