### PR TITLE
temp_file_limit for galaxy-db

### DIFF
--- a/host_vars/galaxy-db.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-db.usegalaxy.org.au.yml
@@ -44,6 +44,7 @@ postgresql_conf:
   # - wal_level: replica
   # - max_wal_senders: 5
   # - wal_keep_size: 2GB
+  - temp_file_limit: 20GB
 
 postgresql_pgdata: "/data/production"
 


### PR DESCRIPTION
galaxy-db has ~70GB of free space most of the time. The disk space for temporary files can be constrained: From the docs:

```
temp_file_limit (integer)
Specifies the maximum amount of disk space that a process can use for temporary files, such as sort and hash temporary files, or the storage file for a held cursor. A transaction attempting to exceed this limit will be canceled. If this value is specified without units, it is taken as kilobytes. -1 (the default) means no limit. Only superusers can change this setting.

This setting constrains the total space used at any instant by all temporary files used by a given PostgreSQL process. It should be noted that disk space used for explicit temporary tables, as opposed to temporary files used behind-the-scenes in query execution, does not count against this limit.
```