### PR TITLE
Make flye training-exempt

### DIFF
--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install \
           total-perspective-vortex==$TPV_VERSION \
+          'gxformat2<=0.24.0' \
           pyyaml \
           galaxy-app
 

--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -29,7 +29,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install \
           total-perspective-vortex==$TPV_VERSION \
-          'pydantic<2.12' \
           pyyaml \
           galaxy-app
 

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -297,7 +297,8 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-training-large
+      - training-exempt  # flye will not run on pulsar-nci-training (fails with SIGILL, only on that pulsar cluster) for an unknown reason (CB 22/04/26)
+      # - pulsar-training-large
     rules:
     - id: flye_small_input_rule
       if: input_size < 0.25


### PR DESCRIPTION
New bug. flye jobs fail on pulsar-nci-training and only pulsar-nci-training, despite the fact that they are using the same singularity container as on other pulsars where flye succeeds.

Set flye as pulsar-exempt so it will just run where it normally would for non-training users, as in anywhere but pulsar-nci-training.