### PR TITLE
revert to shared-db memory for diamond

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -231,7 +231,6 @@ tools:
     params:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/bgruening/diamond/bg_diamond/.*:
-    mem: 40  # TODO: this is down from shared db's 90 but it probably needs even less
     params:
       singularity_enabled: true
     scheduling:


### PR DESCRIPTION
GA has mem: 40 for diamond while shared-db has mem: 90. It’s rare for a diamond job to use more than 10. This would be a good use case for resubmit.