### PR TITLE
interactive tools need fewer volumes

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -119,7 +119,7 @@ destinations:
     params:
       submit_native_specification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={round(mem*1024)} --partition={partition}"
       docker_enabled: true
-      docker_volumes: "{{ slurm_docker_volumes }}"
+      docker_volumes: "{{ slurm_gxit_docker_volumes }}"
       docker_sudo: false
       docker_net: bridge
       docker_auto_rm: true

--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -640,6 +640,10 @@ slurm_singularity_volumes_list:
   - /cvmfs/data.galaxyproject.org:ro
   - /tmp:rw
 
+slurm_gxit_docker_volumes_list:
+  - $job_directory:rw
+  - /tmp:rw
+
 pulsar_singularity_volumes_list:
   - $job_directory:rw
   - $tool_directory:ro
@@ -653,6 +657,7 @@ pulsar_docker_volumes_list: "{{ pulsar_singularity_volumes_list }}"
 # comma separated strings for the job conf
 slurm_singularity_volumes: "{{ slurm_singularity_volumes_list | join(',') }}"
 pulsar_singularity_volumes: "{{ pulsar_singularity_volumes_list | join(',') }}"
+slurm_gxit_docker_volumes: "{{ slurm_gxit_docker_volumes_list | join(',') }}"
 slurm_docker_volumes: "{{ slurm_docker_volumes_list | join(',') }}"
 pulsar_docker_volumes: "{{ pulsar_docker_volumes_list | join(',') }}"
 


### PR DESCRIPTION
An IT running on slurm is using embedded pulsar and does not need the other volumes that slurm docker jobs would have.