### PR TITLE
revert dev to normal release fork

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -75,7 +75,8 @@ host_galaxy_extra_dirs:
   - "{{ galaxy_root }}/object_store_cache"
 
 galaxy_repo: https://github.com/usegalaxy-au/galaxy.git
-galaxy_commit_id: release_26.0_au_dev  # the production release is release_26.0_au, this is that plus https://github.com/galaxyproject/galaxy/pull/22477
+#galaxy_commit_id: release_26.0_au_dev  # the production release is release_26.0_au, this is that plus https://github.com/galaxyproject/galaxy/pull/22477
+galaxy_commit_id: release_26.0_au
 
 galaxy_virtualenv_command: "/usr/bin/python3.11 -m venv"
 


### PR DESCRIPTION
release_26.0_au_dev contains extra commits that break galaxy (not because of those commits but because we need to add some others to scaffold them), so go back to stable ‘release_26.0_au’ for now