### PR TITLE
Let pqhm1 run medium-sized jobs

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -247,7 +247,7 @@ destinations:
     runner: pulsar-qld-high-mem1_runner
     max_accepted_cores: 240
     max_accepted_mem: 3845.07
-    min_accepted_mem: 62.51
+    min_accepted_mem: 30  # usually set to 62.51, 30 is an unusual config value for this due to many small/medium jobs, (2026-05-07 CB)
     context:
       destination_total_cores: 240
       destination_total_mem: 3845.07


### PR DESCRIPTION
Small/medium pulsars are flat out, allow pqhm1 to take jobs with mem as low as 30