### PR TITLE
Add dirtyfrag mitigation playbook

### DIFF
--- a/one-offs/disable_algif_playbook.yml
+++ b/one-offs/disable_algif_playbook.yml
@@ -1,17 +1,20 @@
 - name: Disable algif_aead kernel module
-  hosts:
-    - galaxy_group
-    - production_pulsars
-    - pulsar_workers
-    - dev_group
-    - staging_group
-    - qaai_group
-    - stats
-    - jenkins
-    - pulsar-qld-gpu-dev
-    - pulsar-nci-test
-    - pulsar_nci_test_workers
+  hosts: "{{ target_hosts | default(default_target_hosts) }}"
   become: true
+
+  vars:
+    default_target_hosts:
+      - galaxy_group
+      - production_pulsars
+      - pulsar_workers
+      - dev_group
+      - staging_group
+      - qaai_group
+      - stats
+      - jenkins
+      - pulsar-qld-gpu-dev
+      - pulsar-nci-test
+      - pulsar_nci_test_workers
 
   tasks:
     - name: Prevent algif_aead from loading

--- a/one-offs/mitigate_dirtyfrag_playbook.yml
+++ b/one-offs/mitigate_dirtyfrag_playbook.yml
@@ -1,0 +1,39 @@
+- name: Mitigate DirtyFrag
+  hosts: "{{ target_hosts | default(default_target_hosts) }}"
+  become: true
+
+  vars:
+    default_target_hosts:
+      - galaxy_group
+      - production_pulsars
+      - pulsar_workers
+      - dev_group
+      - staging_group
+      - qaai_group
+      - stats
+      - jenkins
+      - pulsar-qld-gpu-dev
+      - pulsar-nci-test
+      - pulsar_nci_test_workers
+
+  tasks:
+    - name: Disable loading of DirtyFrag-related modules
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/dirtyfrag.conf
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          install esp4 /bin/false
+          install esp6 /bin/false
+          install rxrpc /bin/false
+
+    - name: Unload DirtyFrag-related modules if currently loaded
+      ansible.builtin.command: "modprobe -r {{ item }}"
+      loop:
+        - esp4
+        - esp6
+        - rxrpc
+      register: dirtyfrag_rmmod
+      changed_when: dirtyfrag_rmmod.rc == 0
+      failed_when: false


### PR DESCRIPTION
There is a new cve https://github.com/V4bel/dirtyfrag. The aarnet team has verified that this is legit and affects ubuntu 22.04.

This lists as default all the hosts, or most of them. There is nowhere we can run this on all VMs because of internal IPs, hence the ’target_hosts’ variable. I’d need to run it on nci workers from the nci-build VM.

chatgpt has a reverse for this as well should we need it

```
- name: Remove DirtyFrag mitigation
  become: true
  block:
    - name: Remove modprobe override
      ansible.builtin.file:
        path: /etc/modprobe.d/dirtyfrag.conf
        state: absent

    - name: Reload modules if desired
      ansible.builtin.command: "modprobe {{ item }}"
      loop:
        - esp4
        - esp6
        - rxrpc
      failed_when: false
```