### PR TITLE
Increase memory allocation for cellranger tool

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -4290,7 +4290,7 @@ tools:
       tmp_dir: true
   cellranger:
     cores: 6
-    mem: 20
+    mem: 40
     params:
       singularity_enabled: true
     rules:


### PR DESCRIPTION
@cat-bro  increase memory size for cellranger from 20GB to 40GB