### PR TITLE
tools for pulsar 20260513

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml
@@ -368,6 +368,8 @@ tools:
       singularity_enabled: true
       tmp_dir: true
   toolshed.g2.bx.psu.edu/repos/iuc/isescan/isescan/.*:
+    # note about pulsar - this tool does not always produce all files in the wrapper's outputs. It runs ok on pulsar
+    # but then when it comes to postprocessing, retries many times for the absent files making it unattractive to schedule it to pulsar. novoplasty is similar
     cores: 2
     mem: 10
   toolshed.g2.bx.psu.edu/repos/bgruening/itsx/itsx/.*:
@@ -889,6 +891,8 @@ tools:
         accept:
         - pulsar
   toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper/.*:
+    context:
+      max_concurrent_job_count_for_tool_user: 2
     cores: 5
     mem: 19.1
     rules:
@@ -1983,6 +1987,9 @@ tools:
     mem: 31
     params:
       singularity_enabled: true
+    scheduling:
+      accept:
+      - pulsar
   toolshed.g2.bx.psu.edu/repos/iuc/funannotate.*:
     params:
       singularity_enabled: true


### PR DESCRIPTION
fastplong can run on pulsar
isescan would be able to but the wrapper has optional outputs and pulsar retries transfers for every output file that doesn’t exist … added a note about this