### PR TITLE
remove rstudio

### DIFF
--- a/templates/galaxy/config/tool_conf_interactive.xml.j2
+++ b/templates/galaxy/config/tool_conf_interactive.xml.j2
@@ -1,8 +1,8 @@
 <toolbox monitor="true">
     <section id="interactivetools" name="Interactive Tools">
         <tool file="interactive/interactivetool_ethercalc.xml" />
-        <tool file="interactive/interactivetool_rstudio.xml" />
         <!--
+        <tool file="interactive/interactivetool_rstudio.xml" />
         <tool file="interactive/interactivetool_jupyter_notebook.xml" />
         -->
         <tool file="interactive/interactivetool_phinch.xml" />


### PR DESCRIPTION
Jupyter and Rstudio make GA vulnerable to CVEs where shell users can gain root access. They won’t be able to be reinstated until configurations and job destinations have been updated to make this less of a risk.  Galaxy Main has these running on remote pulsars which would be ideal moving forward, as these VMs do not have access to galaxy’s config/tools/files etc.