### PR TITLE
phastest other pulsar

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -240,6 +240,7 @@ destinations:
         - bakta_database
         - funannotate
         - eggnog
+        - phastest  # alternative phastest pulsar while phm2 is offline (18/5/26)
       require:
         - pulsar
   pulsar-qld-high-mem1:


### PR DESCRIPTION
Set up pqhm0 as an alternative destination for phastest which normally runs on phm2