### PR TITLE
update stats certbot vars

### DIFF
--- a/host_vars/stats.usegalaxy.org.au.yml
+++ b/host_vars/stats.usegalaxy.org.au.yml
@@ -24,7 +24,7 @@ certbot_share_key_users:
   - influxdb
 certbot_post_renewal: |
     systemctl restart nginx || true
-    systemctl restart influxdb || true
+    systemctl restart docker || true
 certbot_domains:
  - "{{ hostname }}"
 certbot_agree_tos: --agree-tos


### PR DESCRIPTION
Update post hook for certbot so that docker is restarted instead of influxdb when the cert is updated. This should stop influxdb running out of cert.