### PR TITLE
nginx server tokens off

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -342,3 +342,6 @@ aai_enabled: false
 aai_logins_only: "{{ aai_enabled }}"  # finer point of control in order to continue allowing local logins on dev
 
 aaf_enabled: "{{ not aai_enabled }}"  # legacy AAF login option will disappear (I think)
+
+# for any VM using geerlingguy.nginx. This is not for galaxyproject.nginx
+nginx_server_tokens: "off"

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -53,6 +53,7 @@ nginx_enable_default_server: false
 nginx_ssl_servers:
   - galaxy
 nginx_conf_http:
+  server_tokens: off
   client_max_body_size: 240g
   gzip_proxied: "any"
   gzip_static: "on" # The ngx_http_gzip_static_module module allows sending precompressed files with the ".gz" filename extension instead of regular files.

--- a/group_vars/rabbitservers.yml
+++ b/group_vars/rabbitservers.yml
@@ -27,6 +27,7 @@ nginx_enable_default_server: false
 nginx_ssl_servers:
   - rabbitmq
 nginx_conf_http:
+  server_tokens: off
   client_max_body_size: 1g
 nginx_remove_default_vhost: true
 

--- a/host_vars/dev-queue.gvl.org.au.yml
+++ b/host_vars/dev-queue.gvl.org.au.yml
@@ -106,6 +106,7 @@ nginx_enable_default_server: false
 nginx_ssl_servers:
   - rabbitmq
 nginx_conf_http:
+  server_tokens: off
   client_max_body_size: 1g
 nginx_remove_default_vhost: true
 

--- a/host_vars/galaxy-queue.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-queue.usegalaxy.org.au.yml
@@ -108,6 +108,7 @@ nginx_enable_default_server: false
 nginx_ssl_servers:
   - rabbitmq
 nginx_conf_http:
+  server_tokens: off
   client_max_body_size: 1g
 nginx_remove_default_vhost: true
 

--- a/host_vars/jenkins.yml
+++ b/host_vars/jenkins.yml
@@ -57,6 +57,7 @@ nginx_enable_default_server: false
 nginx_ssl_servers:
   - jenkins
 nginx_conf_http:
+  server_tokens: off
   client_max_body_size: 1g
 nginx_remove_default_vhost: true
 nginx_ssl_role: usegalaxy_eu.certbot

--- a/host_vars/stats.usegalaxy.org.au.yml
+++ b/host_vars/stats.usegalaxy.org.au.yml
@@ -38,6 +38,7 @@ nginx_ssl_servers:
   #- influxdb-ssl
   - grafana-ssl
 nginx_conf_http:
+  server_tokens: off
   client_max_body_size: 1g
 
 # Nginx Letsencrypt bindings


### PR DESCRIPTION
Biocloud have asked for nginx server tokens to be off so `curl -I <url>` does not reveal our nginx version. I can’t imagine that switching these off breaks anything.

There are two nginx roles being used on various VMs. For VMs using galaxyproject.nginx, the setting can be added to `nginx_conf_http`. For VMs using geerlingguy.nginx there is a variable `nginx_server_tokens`.
