### PR TITLE
Add vector to prod playbook

### DIFF
--- a/galaxy_playbook.yml
+++ b/galaxy_playbook.yml
@@ -65,6 +65,8 @@
     - galaxyproject.tiaas2
     - role: usegalaxy_eu.walle
       tags: walle
+    - role: vector
+      tags: vector
   post_tasks:
     - name: create dir for galaxy's singularity cache
       file:


### PR DESCRIPTION
I think this is still correct for prod:

```
# galaxyservers.yml
vector_nginx_log_file: /var/log/nginx/access.log
```
