### PR TITLE
clean up alphafold rules

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -1139,11 +1139,11 @@ tools:
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*:
     context:
       alphafold_aa_length_max: 3000
-      alphafold_max_input_sequences: 10
-      alphafold_db: /data/v2.3
+      alphafold_max_input_sequences: 10  # overridden for Alphafold_plus group
+      alphafold_db: /data  # overridden for earlier versions
       max_concurrent_job_count_for_tool_user: 2
       pulsar_docker_volumes: 
-        $job_directory:ro,$job_directory/home:rw,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw,/data/alphafold:/data:ro
+        $job_directory:rw,$tool_directory:ro,/tmp:rw,/data/alphafold:/data:ro
     gpus: 1
     cores: 16
     mem: 130
@@ -1154,53 +1154,37 @@ tools:
         ALPHAFOLD_MAX_SEQUENCES={alphafold_max_input_sequences} --env 
         ALPHAFOLD_DB={alphafold_db}
       tmp_dir: true
+    scheduling:
+      require:
+      - pulsar
+      - pulsar-qld-gpu-alphafold
+      - pulsar-qld-gpu
+      accept:
+      - training-exempt
     rules:
-    - if: |
+    - id: alphafold_v2_1_database_rule
+      if: helpers.tool_version_lte(tool, "2.1.2+galaxy4")
+      context:
+        alphafold_db: /data/v2.1
+    - id: alphafold_earlier_v2_3_database_rule
+      if: helpers.tool_version_gt(tool, "2.1.2+galaxy4") and 
+        helpers.tool_version_lt(tool, "2.3.2+galaxy1")
+      context:
+        alphafold_db: /data/v2.3
+    - id: alphafold_plus_group_member_rule
+      if: |
         user_roles = [role.name for role in user.all_roles() if not role.deleted] if user else []
         'Alphafold_plus' in user_roles
       context:
-        alphafold_aa_length_max: 3000
         alphafold_max_input_sequences: 20
-    - if: |
-        user_roles = [role.name for role in user.all_roles() if not role.deleted] if user else []
-        user and 'Alphafold' in user_roles and not 'pulsar_gpu_test' in user_roles
-      scheduling:
-        require:
-        - pulsar
-        - pulsar-qld-gpu-alphafold
-        - pulsar-qld-gpu
-        accept:
-        - training-exempt
-    - if: |
-        user_roles = [role.name for role in user.all_roles() if not role.deleted] if user else []
-        user and user.username in [f'qldgpu{x+1}' for x in range(6)] or 'pulsar_gpu_test' in user_roles
-      scheduling:
-        require:
-        - pulsar-qld-gpu-alphafold
-        - pulsar-qld-gpu
-        accept:
-        - pulsar
-    - if: |
+    - id: alphafold_fail_rule  # user not in group or having other test-user conditions
+      if: |
         not user or not any([
           role for role in user.all_roles() if (
             role.name in ['Alphafold', 'UoM_Vet_Alphafold', 'pulsar_gpu_test'] and not role.deleted
         )]) and user.username not in [f'qldgpu{x+1}' for x in range(6)]
       fail: |
         This tool is currently being beta-tested on GPUs and your account has not been given access. Contact help@genome.edu.au if you think this is in error.
-  toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/2.1.*:
-    inherits: 
-      toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*
-    context:
-      alphafold_db: /data/v2.1
-  toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/2.3.*:
-    inherits: 
-      toolshed.g2.bx.psu.edu/repos/galaxy-australia/alphafold2/alphafold/.*
-    rules:
-    - if: |
-        min_version = '2.3.1+galaxy2'
-        helpers.tool_version_gte(tool, min_version)
-      context:
-        alphafold_db: /data
   toolshed.g2.bx.psu.edu/repos/galaxy-australia/cactus_cactus/cactus_cactus/.*:
     context:
       test_cores: 10
@@ -4406,7 +4390,8 @@ tools:
   alphafold_test.*:
     context:
       alphafold_db: /data
-      pulsar_docker_volumes: '{{ pulsar_docker_volumes }},/data/alphafold:/data:ro'
+      pulsar_docker_volumes: 
+        $job_directory:rw,$tool_directory:ro,/tmp:rw,/data/alphafold:/data:ro
     cores: 16
     mem: 130
     params:


### PR DESCRIPTION
the most common case (latest version of tool) was not the default case + there were a couple of rules that seemed redundant