### PR TITLE
replace pnci-test missing nfs exports

### DIFF
--- a/host_vars/pulsar-nci-test/pulsar-nci-test.usegalaxy.org.au.yml
+++ b/host_vars/pulsar-nci-test/pulsar-nci-test.usegalaxy.org.au.yml
@@ -39,3 +39,8 @@ ssh_config_entries:
   user: ubuntu
   hosts: "{{ groups['pulsar_nci_test_workers'] }}"
   ip_field: internal_ip
+
+# geerlingguy.nfs
+nfs_exports:
+    - "{{ pulsar_custom_indices_dir }}  10.0.0.0/22(rw,async,no_root_squash,no_subtree_check)"
+    - "/mnt/pulsar  10.0.0.0/22(rw,async,no_root_squash,no_subtree_check)"


### PR DESCRIPTION
There may have been a default value for this in pulsarservers.yml that was removed