### PR TITLE
Fix OIDC scope prefix

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -211,7 +211,7 @@ host_galaxy_config: # renamed from __galaxy_config
     object_store_templates_config_file: "{{ galaxy_config_dir }}/object_store_templates.yml"
     oidc_backends_config_file: "{{ galaxy_config_dir }}/oidc_backends_config.xml"
     oidc_config_file: "{{ galaxy_config_dir }}/oidc_config.xml"
-    oidc_scope_prefix: "https://dev.gvl.org.au/api:*"
+    oidc_scope_prefix: "https://dev.gvl.org.au/api"
     panel_views_dir: "{{ galaxy_config_dir }}/tool_panel_filters"
     sentry_dsn: "{{ vault_sentry_dsn_dev }}"
     show_welcome_with_login: false

--- a/templates/galaxy/config/oidc_backends_config.xml.j2
+++ b/templates/galaxy/config/oidc_backends_config.xml.j2
@@ -22,7 +22,7 @@
             <oidc_endpoint>{{ auth0_oidc_endpoint }}</oidc_endpoint>
             <accepted_audiences>{{ auth0_audience }}</accepted_audiences>
             <username_key>https://biocommons.org.au/username</username_key>
-            <extra_scopes>roles,offline_access,{{ galaxy_config.galaxy.oidc_scope_prefix }}</extra_scopes>
+            <extra_scopes>roles,offline_access,{{ galaxy_config.galaxy.oidc_scope_prefix }}:*</extra_scopes>
             <custom_button_text>BioCommons Access</custom_button_text>
             <end_user_registration_endpoint>{{ auth0_registration_endpoint }}</end_user_registration_endpoint>
             <profile_url>{{ auth0_profile_url }}</profile_url>


### PR DESCRIPTION
The OIDC scope prefix was wrong in the Galaxy config (shouldn't have included the `:*`)