### PR TITLE
conda auto init false

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -178,6 +178,7 @@ group_galaxy_config:
     user_activation_on: "{{ not aai_enabled }}"
     oidc_auth_pipeline_extra: "{{ aai_enabled | ternary(['galaxy.authnz.auth0_authnz.sync_user_groups'], [])}}"
 
+    conda_auto_init: false
     check_migrate_tools: false
     log_level: TRACE
     new_file_path: "{{ galaxy_tmp_dir }}/scratch"


### PR DESCRIPTION
This value apparently defaulting to true caused the handlers to go into a restart loop. Prior this this I have not been aware of its effects

from galaxy.yml.sample

```
  # Set to true to instruct Galaxy to install Conda from the web
  # automatically if it cannot find a local copy and conda_exec is not
  # configured. The default is true if running Galaxy from source, and
  # false if running from installed packages.
  #conda_auto_init: false
```