### PR TITLE
Give bakta option of going to pulsar-mel2 or pulsar-QLD but allocate it extra cores/mem on QLD

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -143,6 +143,7 @@ destinations:
       accept:
         - pulsar-mel2
         - bakta_database
+        - bakta_solo_destination
         - eggnog
       require:
         - pulsar
@@ -336,10 +337,17 @@ destinations:
         - cvmfs_cache_100plus
         - funannotate
         - bakta_database
+        - bakta_solo_destination
         - eggnog
       require:
         - pulsar
         # - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
+    rules:
+      - id: bakta_pulsar_QLD_solo_rule  # bakta is prone to OOM errors when two jobs run on the same node
+        if: |
+          'toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta' in tool.id
+        cores: 16
+        mem: 62
   pulsar-azure:
     inherits: _pulsar_destination
     runner: pulsar_azure_0_runner

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -1582,7 +1582,7 @@ tools:
       require:
       - bakta_database
       prefer:
-      - pulsar-mel2
+      - bakta_solo_destination
     rules:
     - id: bakta_pulsar_rule
       if: |

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -1573,7 +1573,7 @@ tools:
       singularity_enabled: true
   toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/.*:
     context:
-      max_concurrent_job_count_for_tool_user: 2
+      max_concurrent_job_count_for_tool_user: 3
     cores: 8
     mem: 31.2
     params:


### PR DESCRIPTION
bakta is prone to OOM errors when more than one job runs on the same node, so jobs have been allocated to a single pulsar cluster with uniform worker size (pulsar-mel2 or pulsar-QLD). Recently there are so many that galaxy cannot keep up if they only go to the one pulsar cluster.