### PR TITLE
Make 26.1 run on dev

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -150,7 +150,8 @@ tpv_packages: |
 additional_packages:
   - flower
   - pkce  # TODO: there is a bug in the conditional dependency checker in release_26.0
-  - gravity==1.2.2  # new release fixing with handler restarts
+
+galaxy_fetch_dependencies_with_uv: false  # new in galaxyproject.galaxy role as of 0.12.7 (release_26.1)
 
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,8 +4,8 @@ collections:
 
 roles:
 - name: galaxyproject.galaxy
-  # src: https://github.com/galaxyproject/ansible-galaxy
-  version: 0.12.7
+  src: https://github.com/galaxyproject/ansible-galaxy
+  version: cd835d778891539934c3da3b90d9b2ed4914c86f
 - name: galaxyproject.nginx
   version: 0.7.1  # NOTE: version 1.0.0 exists but fails on dev (16/09/2025)
 - name: galaxyproject.postgresql

--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -75,17 +75,17 @@
   url_regex: '^drs://aaidemo\.bioplatforms\.com/'
   oidc_auth_provider: auth0
 
-- type: webdav
-  id: agrf_nextcloud
-  label: AGRF Nextcloud
-  doc: Import your files from AGRF's Nextcloud server. Configure access in User -> Preferences -> Manage Information
-  url: https://agrf-data.agrf.org.au
-  root: /remote.php/dav/files/${user.preferences['agrf_nextcloud_account|username']}/
-  login: ${user.preferences['agrf_nextcloud_account|username']}
-  password: ${user.user_vault.read_secret('preferences/agrf_nextcloud_account/password')}
-  writable: true
-  # Set the following settings to avoid loading entire files into memory
-  # useful when dealing with big files
-  use_temp_files: true
-  temp_path: "{{ galaxy_tmp_dir }}/webdav"
+# - type: webdav
+#   id: agrf_nextcloud
+#   label: AGRF Nextcloud
+#   doc: Import your files from AGRF's Nextcloud server. Configure access in User -> Preferences -> Manage Information
+#   url: https://agrf-data.agrf.org.au
+#   root: /remote.php/dav/files/${user.preferences['agrf_nextcloud_account|username']}/
+#   login: ${user.preferences['agrf_nextcloud_account|username']}
+#   password: ${user.user_vault.read_secret('preferences/agrf_nextcloud_account/password')}
+#   writable: true
+#   # Set the following settings to avoid loading entire files into memory
+#   # useful when dealing with big files
+#   use_temp_files: true
+#   temp_path: "{{ galaxy_tmp_dir }}/webdav"
 {% endif %}


### PR DESCRIPTION
update galaxy role version

stop pinning gravity

galaxy role now installs dependencies with uv by default, I switched this off because of errors with the r-space package.

comment out ARGF file source because it’s not compatible with changes in galaxy (pydantic error) and galaxy would not start