### PR TITLE
upgrade galaxy to release 26.1

### DIFF
--- a/host_vars/galaxy.usegalaxy.org.au.yml
+++ b/host_vars/galaxy.usegalaxy.org.au.yml
@@ -35,7 +35,7 @@ interactive_tools_server_name: "usegalaxy.org.au"
 
 # Using release_25.1_au_dev branch of AU's fork of the galaxy codebase for AAI compatibility
 galaxy_repo: https://github.com/usegalaxy-au/galaxy.git
-galaxy_commit_id: release_26.0_au
+galaxy_commit_id: release_26.1_au
 
 galaxy_virtualenv_command: "/usr/bin/python3.11 -m venv"
 


### PR DESCRIPTION
Placeholder PR to add notes about upcoming release update

- What branch is will be used? Dev “release_26.1_au_dev” contains Marius M PR (to do: request backport) + a commit from Nuwan that is essential for login to work. Marius M has made a PR to python-social-auth to fix the same thing as Nuwan’s commit fixes. GA may or may not need to use a branch for release 26.1
[ Updated: release_26.1_au branch is the one ]

- One-off update required of authnz db records:
```
UPDATE oidc_user_authnz_tokens
SET provider = 'auth0'
WHERE provider = 'oidc';
```
- Updates to oidc_backends_conf will be needed to go with above change from ‘oidc’ to ‘auth0’ + AAI token expiry changes [ this is done ]

- Follow issue about increased db use: https://github.com/galaxyproject/galaxy/issues/22929. [ issue is resolved ]