### PR TITLE
mem updates for chira and bwa_mem2

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -1740,11 +1740,11 @@ tools:
         singularity_container_id_override: 
           /cvmfs/singularity.galaxyproject.org/all/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07-0
     - id: bwa_mem2_small_input_rule
-      if: input_size < 0.25
+      if: input_size < 0.1
       cores: 4
       mem: 15.5
     - id: bwa_mem2_medium_input_rule
-      if: 0.25 <= input_size < 16
+      if: 0.1 <= input_size < 16
       cores: 8
       mem: 100
     - id: bwa_mem2_large_input_rule
@@ -1817,8 +1817,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/chira_collapse/chira_collapse/.*:
     mem: 12
   toolshed.g2.bx.psu.edu/repos/iuc/chira_map/chira_map/.*:
-    cores: 8
-    mem: 31.2
+    cores: 10
+    mem: 38.5
   toolshed.g2.bx.psu.edu/repos/iuc/chromeister/chromeister/.*:
     cores: 1
     mem: 3.8


### PR DESCRIPTION
change threshold so that any bwa_mem2 job with input > 100MB gets high memory allocation (reduced from 250MB)

increase chira_map memory