### PR TITLE
prokka and java options

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -8,8 +8,8 @@ tools:
     env: 
       HDF5_USE_FILE_LOCKING: "FALSE"
       SINGULARITYENV_HDF5_USE_FILE_LOCKING: "FALSE"
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
+      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
+      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
     context:
       partition: main
       test_cores: 1  # TODO: test_mem?

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -423,6 +423,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/crs4/prokka/prokka/.*:
     cores: 8
     mem: 30.7
+    params:
+      tmp_dir: true
     scheduling:
       accept:
       - pulsar
@@ -822,11 +824,6 @@ tools:
       minimum_singularity_version: 2.18.2
     cores: 3
     mem: 11.5
-    env:
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G 
-        -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G 
-        -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
     params:
       tmp_dir: true
     # scheduling: # these jobs can run on pulsar but it may not be worth transferring them because the job walltime is much quicker than the transport time


### PR DESCRIPTION
make prokka use `tmp_dir: true` to use `<jwd>/tmp` and avoid filename collision in /tmp

extend JAVA_OPTIONS `-Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR` to all job env vars (previously defined for picard only)