### PR TITLE
add -XX:-UsePerfData to prokka’s production env vars

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -423,6 +423,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/crs4/prokka/prokka/.*:
     cores: 8
     mem: 30.7
+    env:
+      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -XX:-UsePerfData -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
+      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -XX:-UsePerfData -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
     params:
       tmp_dir: true
     scheduling:


### PR DESCRIPTION
Disable UsePerfData in prokka’s java options.

This may or may not solve file collision from prokka jobs running on the same worker.

```
-XX:+UsePerfData
Enables the perfdata feature. This option is enabled by default to allow JVM monitoring and performance testing. Disabling it suppresses the creation of the hsperfdata_userid directories. To disable the perfdata feature, specify -XX:-UsePerfData.
```