### PR TITLE
set singularity_enabled to false for some tools following jenkins_bot weekend testing

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -370,8 +370,8 @@ tools:
       cores: 3
       mem: 11.5
   toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/.*:
-    context:
-      minimum_singularity_version: '0.5'
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/bgruening/wordcloud/wordcloud/.*:
     mem: 10
   toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_pca/bio3d_pca/.*:
@@ -514,6 +514,9 @@ tools:
       if: 1 <= input_size < 20
       cores: 8
       mem: 30.7
+  toolshed.g2.bx.psu.edu/repos/devteam/categorize_elements_satisfying_criteria/categorize_elements_satisfying_criteria/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/.*:
     context:
       max_concurrent_job_count_for_tool_user: 2
@@ -527,10 +530,19 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/.*:
     context:
       minimum_singularity_version: '1.4'
+  toolshed.g2.bx.psu.edu/repos/devteam/compute_motif_frequencies_for_all_motifs/compute_motif_frequencies_for_all_motifs/.*:
+    params:
+      singularity_enabled: false
+  toolshed.g2.bx.psu.edu/repos/devteam/compute_motifs_frequency/compute_motifs_frequency/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1:
     params:
       singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/devteam/condense_characters/.*:
+    params:
+      singularity_enabled: false
+  toolshed.g2.bx.psu.edu/repos/devteam/count_gff_features/count_gff_features/.*:
     params:
       singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/devteam/coverage/gops_coverage_1/1.0.0:
@@ -579,6 +591,9 @@ tools:
     scheduling:
       accept:
       - pulsar
+  toolshed.g2.bx.psu.edu/repos/devteam/draw_stacked_barplots/draw_stacked_barplots/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/devteam/dwt_cor_ava_perclass/compute_p-values_correlation_coefficients_feature_occurrences_between_two_datasets_using_discrete_wavelet_transfom/.*:
     params:
       singularity_enabled: false
@@ -835,6 +850,9 @@ tools:
       if: input_size < 1
       cores: 1
       mem: 3.8
+  toolshed.g2.bx.psu.edu/repos/devteam/pileup_interval/pileup_interval/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/devteam/poisson2test/poisson2test/1.0.0:
     params:
       singularity_enabled: false
@@ -2646,7 +2664,8 @@ tools:
     - id: optitype_singularity_override_rule
       if: helpers.tool_version_eq(tool, "1.3.5+galaxy0")
       params:
-        singularity_container_id_override: /cvmfs/singularity.galaxyproject.org/all/optitype:1.3.5--hdfd78af_2
+        singularity_container_id_override: 
+          /cvmfs/singularity.galaxyproject.org/all/optitype:1.3.5--hdfd78af_2
     - id: optitype_large_input
       if: input_size > 1
       cores: 8
@@ -2721,6 +2740,9 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/plasmidfinder/plasmidfinder/.*:
     cores: 6
     mem: 23
+  toolshed.g2.bx.psu.edu/repos/iuc/pmids_to_pubtator_matrix/pmids_to_pubtator_matrix/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/iuc/polypolish/polypolish/.*:
     mem: 23
   toolshed.g2.bx.psu.edu/repos/iuc/porechop/porechop/.*:
@@ -3508,6 +3530,9 @@ tools:
       if: 0.2 <= input_size < 10
       cores: 8
       mem: 30.7
+  toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_alignment/NmrAlignment/.*:
+    params:
+      singularity_enabled: false
   toolshed.g2.bx.psu.edu/repos/maxlcummins/emmtyper/emmtyper/.*:
     params:
       singularity_enabled: false


### PR DESCRIPTION
mostly old devteam tools

```
# no module named < module_name >
toolshed.g2.bx.psu.edu/repos/devteam/pileup_interval/pileup_interval/1.0.3
toolshed.g2.bx.psu.edu/repos/devteam/count_gff_features/count_gff_features/0.2
# < dependency >: not found
toolshed.g2.bx.psu.edu/repos/devteam/draw_stacked_barplots/draw_stacked_barplots/1.0.0
toolshed.g2.bx.psu.edu/repos/devteam/compute_motifs_frequency/compute_motifs_frequency/1.0.0
toolshed.g2.bx.psu.edu/repos/devteam/compute_motif_frequencies_for_all_motifs/compute_motif_frequencies_for_all_motifs/1.0.0
toolshed.g2.bx.psu.edu/repos/devteam/categorize_elements_satisfying_criteria/categorize_elements_satisfying_criteria/1.0.0
toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_alignment/NmrAlignment/2.0.4
# not clear why
toolshed.g2.bx.psu.edu/repos/iuc/pmids_to_pubtator_matrix/pmids_to_pubtator_matrix/0.0.2+galaxy0
toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.8
```