### PR TITLE
fix: wrong DRS URL for staging bioplatforms

### DIFF
--- a/host_vars/qaai.gvl.org.au.yml
+++ b/host_vars/qaai.gvl.org.au.yml
@@ -422,4 +422,4 @@ auth0_profile_url: "{{ vault_auth0_profile_url_qaai }}"
 auth0_domain: "{{ vault_auth0_domain_qaai }}"
 
 # for BPA file source
-bpa_data_portal_drs_url_regex: '^drs://staging\.bioplatforms\.com/'
+bpa_data_portal_drs_url_regex: '^drs://aaiquality\.bioplatforms\.com/'


### PR DESCRIPTION
Sorry, got mixed up about which staging server we were using to test this, this should have the right value now.