### PR TITLE
update tpv for stringtie

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -3323,6 +3323,8 @@ tools:
   toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/.*:
     cores: 5
     mem: 19.1
+    params:
+      singularity_enabled: false  # switched back to conda because of unexplained job failure, 2/7/26
     rules:
     - id: stringtie_small_input_rule
       if: input_size < 0.2


### PR DESCRIPTION
Tool tests pass with singularity, we’re putting it back to conda as trial and error for a user’s silent job failures