### PR TITLE
readd cached explicit singularity to container resolvers

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -273,6 +273,8 @@ group_galaxy_config:
 
     container_resolvers:
       - type: explicit  # use Docker if <container type="docker"> and use Singularity if <container type="singularity"> (comment from EU)
+      - type: cached_explicit_singularity
+        cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
       # CVMFS
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all


### PR DESCRIPTION
Not sure if this is necessary but it seems like a good idea. For reference [container_resolvers_conf.yml.sample](https://github.com/galaxyproject/galaxy/blob/release_26.0/lib/galaxy/config/sample/container_resolvers.yml.sample)