### PR TITLE
apply prokka java env fix to default tool

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/default_tool.yml.j2
@@ -8,8 +8,8 @@ tools:
     env: 
       HDF5_USE_FILE_LOCKING: "FALSE"
       SINGULARITYENV_HDF5_USE_FILE_LOCKING: "FALSE"
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
+      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -XX:-UsePerfData -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
+      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -XX:-UsePerfData -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
     context:
       partition: main
       test_cores: 1  # TODO: test_mem?

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -425,9 +425,6 @@ tools:
   toolshed.g2.bx.psu.edu/repos/crs4/prokka/prokka/.*:
     cores: 8
     mem: 30.7
-    env:
-      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -XX:-UsePerfData -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
-      SINGULARITYENV__JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G -XX:-UsePerfData -Djava.io.tmpdir=$_GALAXY_JOB_TMP_DIR
     params:
       tmp_dir: true
     scheduling:


### PR DESCRIPTION
`-XX:-UsePerfData` seems safe for all java jobs running on galaxy. It is needed for snpSift errors arising from file collision on galaxy workers.