### PR TITLE
pulsar-quick tag for melbourne pulsars

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -147,6 +147,7 @@ destinations:
         - eggnog
       require:
         - pulsar
+        - pulsar-quick  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
   pulsar-mel3:
     inherits: _pulsar_destination
     runner: pulsar-mel3_runner
@@ -168,6 +169,7 @@ destinations:
         # - pulsar-blast  # alternate location for pulsar blast jobs when pulsar-qld-blast is unavailable
       require:
         - pulsar
+        - pulsar-quick  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
   pulsar-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-high-mem1_runner
@@ -185,6 +187,7 @@ destinations:
         - cvmfs_cache_800plus
       require:
         - pulsar
+        - pulsar-quick  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
   pulsar-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-high-mem2_runner


### PR DESCRIPTION
pulsar-quick tag for pulsar-mel2, pulsar-mel3 and pulsar-high-mem1 in preparation for unpredictable outages next week.

pulsar-high-mem2 already runs only fgenesh and a variety of quick tools.