### PR TITLE
set QLD pulsars offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -243,6 +243,7 @@ destinations:
         # - phastest  # alternative phastest pulsar while phm2 is offline
       require:
         - pulsar
+        - offline
   pulsar-qld-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem1_runner
@@ -265,6 +266,7 @@ destinations:
         # - gffread_destination  # while pqhm2 is offline
       require:
         - pulsar
+        - offline
   pulsar-qld-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-qld-high-mem2_runner
@@ -284,6 +286,7 @@ destinations:
         - gffread_destination  # special mapping because gffread is a dangerous tool that can take over jwd space
       require:
         - pulsar
+        - offline
   pulsar-nci-training:
     inherits: _pulsar_destination
     runner: pulsar-nci-training_runner
@@ -341,6 +344,7 @@ destinations:
         - eggnog
       require:
         - pulsar
+        - offline
         # - pulsar-quick  # tag given to tools where jobs are bound to complete in less than a day
     rules:
       - id: bakta_pulsar_QLD_solo_rule  # bakta is prone to OOM errors when two jobs run on the same node


### PR DESCRIPTION
pulsar-QLD and pulsar-high-mems offline

Not doing anything with pulsar-qld-blast and gpu pulsars because the jobs have nowhere else to go, so they can just queue while VMs are unavailable