### PR TITLE
set melbourne pulsars to offline

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -147,7 +147,7 @@ destinations:
         - eggnog
       require:
         - pulsar
-        - pulsar-quick  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
+        - offline  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
   pulsar-mel3:
     inherits: _pulsar_destination
     runner: pulsar-mel3_runner
@@ -169,7 +169,7 @@ destinations:
         # - pulsar-blast  # alternate location for pulsar blast jobs when pulsar-qld-blast is unavailable
       require:
         - pulsar
-        - pulsar-quick  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
+        - offline  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
   pulsar-high-mem1:
     inherits: _pulsar_destination
     runner: pulsar-high-mem1_runner
@@ -187,7 +187,7 @@ destinations:
         - cvmfs_cache_800plus
       require:
         - pulsar
-        - pulsar-quick  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
+        - offline  # TODO: remove this after MRC hypervisor restarts 13-17 July '26
   pulsar-high-mem2:
     inherits: _pulsar_destination
     runner: pulsar-high-mem2_runner
@@ -202,7 +202,7 @@ destinations:
       accept:
         - cvmfs_cache_100plus
         - cvmfs_cache_800plus
-        - phastest
+        # - phastest  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
       require:
         - pulsar
         - pulsar-high-mem2
@@ -243,7 +243,7 @@ destinations:
         - bakta_database
         - funannotate
         - eggnog
-        # - phastest  # alternative phastest pulsar while phm2 is offline
+        - phastest  # alternative phastest pulsar while phm2 is offline
       require:
         - pulsar
   pulsar-qld-high-mem1:

--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -337,7 +337,7 @@ tools:
       accept:
       - pulsar
       - pulsar-quick
-      - pulsar-high-mem2
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
   toolshed.g2.bx.psu.edu/repos/bgruening/salmonquantmerge/salmonquantmerge/.*:
     cores: 2
     mem: 7.6
@@ -732,7 +732,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-high-mem2  # TODO: remove tag when other high memory pulsars are back
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
   toolshed.g2.bx.psu.edu/repos/devteam/kraken2tax/Kraken2Tax/.*:
     cores: 1
     mem: 3.8
@@ -1396,7 +1396,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-high-mem2
+      # - pulsar-high-mem2 # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
   toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/.*:
     context:
       max_concurrent_job_count_for_tool_user: 3
@@ -1942,7 +1942,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-high-mem2
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
     rules:
     - id: get_organelle_from_reads_large_input_rule
       if: input_size > 2
@@ -2079,7 +2079,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-high-mem2
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
   toolshed.g2.bx.psu.edu/repos/iuc/hyphy_absrel/hyphy_absrel/.*:
     cores: 16
     mem: 62
@@ -2197,7 +2197,7 @@ tools:
       accept:
       - pulsar
       - pulsar-training-large
-      - pulsar-high-mem2
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
       - pulsar-quick
       reject:
       - pulsar-QLD
@@ -2771,7 +2771,7 @@ tools:
     scheduling:
       accept:
       - pulsar
-      - pulsar-high-mem2
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
     rules:
     - id: porechop_small_input_rule
       if: input_size < 0.8
@@ -3500,7 +3500,7 @@ tools:
       - pulsar
       - pulsar-quick
       - pulsar-training-large
-      - pulsar-high-mem2  # TODO: remove tag when other high memory pulsars are back
+      # - pulsar-high-mem2  # # TODO: uncomment this line after MRC hypervisor restarts 13-17 July '26
     rules:
     - id: unicycler_small_input_rule
       if: input_size < 0.05


### PR DESCRIPTION
pmel3, pmel2, phm1 offline

pmel2 not offline so that fgenesh jobs can queue. phastest jobs normally run on phm2, can run on pqhm0 instead.