### PR TITLE
Add edna dev lab targets dev.gvl.org.au.yml entrypoint

### DIFF
--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -491,7 +491,7 @@ galaxy_subsites:
       }
   - name: edna
     brand: eDNA Lab
-    iframe: "https://labs.usegalaxy.org.au/?content_root=https://github.com/tiffmnelson/galaxy_codex/blob/main/communities/edna/base.yml"
+    iframe: "https://labs.usegalaxy.org.au/?content_root=https://github.com/tiffmnelson/galaxy_codex/blob/main/communities/edna/dev.gvl.org.au.yml"
     wallpaper: false
     tool_sections: []
     custom_css: |


### PR DESCRIPTION
This fixes the internal Galaxy links rendered on edna.dev.gvl.org.au