### PR TITLE
pin social-auth-core and upgrade tpv

### DIFF
--- a/.github/workflows/check_tpv_config.yml
+++ b/.github/workflows/check_tpv_config.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install dependencies
       env:
-        TPV_VERSION: '3.1.3'
+        TPV_VERSION: '3.2.1'
       run: |
         python -m pip install --upgrade pip
         pip install \

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -141,7 +141,7 @@ group_galaxy_extra_dirs:
 
 galaxy_extra_dirs: "{{ group_galaxy_extra_dirs + host_galaxy_extra_dirs|d([]) }}"
 
-tpv_version: "3.1.3"
+tpv_version: "3.2.1"
 
 tpv_packages: |
   {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
@@ -150,6 +150,8 @@ additional_packages:
   - flower
   - pkce  # TODO: there is a bug in the conditional dependency checker in release_26.0
   - "gravity{{ galaxy_commit_id.startswith('release_26.0') | ternary('==1.2.2', '') }}"  # remove this when producition is on 26.1
+  - "social-auth-core{{ galaxy_commit_id.startswith('release_26.1') | ternary('==5.0.2', '') }}"  # release_26.1 branch pins to 4.9.1, TODO: make this unconditional gte once production is on 26.1 
+  # - "social-auth-core>=5.0.2"
 
 galaxy_fetch_dependencies_with_uv: false  # new in galaxyproject.galaxy role as of 0.12.7 (release_26.1)
 

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -80,7 +80,6 @@ host_galaxy_extra_dirs:
 
 galaxy_repo: https://github.com/usegalaxy-au/galaxy.git
 galaxy_commit_id: release_26.1_au_dev  # dev is still initially forked for release_26.1 to include two Marius M PRs and the commit that switches of fixed delegated auth check
-tpv_version: "3.2.1"
 
 galaxy_virtualenv_command: "/usr/bin/python3.11 -m venv"
 

--- a/host_vars/qaai.gvl.org.au.yml
+++ b/host_vars/qaai.gvl.org.au.yml
@@ -64,12 +64,6 @@ host_galaxy_config: # renamed from __galaxy_config
 
 common_logrotate_manage_rsyslog: true
 
-# total perspective vortex
-tpv_version: "3.1.2"
-
-tpv_packages: |
-  {{ tpv_version is defined | ternary(['total-perspective-vortex==' + tpv_version|d('X')], []) }}
-
 galaxy_additional_venv_packages: "{{ tpv_packages + additional_packages }}"
 
 # variables for attaching mounted volume to application server


### PR DESCRIPTION
Upgrade tpv to latest version 3.2.1 in galaxyservers.yml.

Pin social-auth-core if on branch release_26.1* (this would probably be fine without the condition, but we don’t have to test it)

This is now needed for dev.gvl.org.au and qaai.gvl.org.au