### PR TITLE
explicit mem value for fastqc

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -673,7 +673,8 @@ tools:
     context:
       minimum_singularity_version: 0.72+galaxy1
     cores: 4
-    mem: cores * 0.5
+    # mem: cores * 0.5
+    mem: 2
     scheduling:
       accept:
       - pulsar


### PR DESCRIPTION
fastqc is not intended to be pulsar friendly because of its `pulsar_score` value. Since merging the PR setting fastqc’s mem to an expression “cores * 0.5”, fastqc jobs have started going to pulsar.