### PR TITLE
data40 and data41 as equal-weight object store folders on different volumes

### DIFF
--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -13,6 +13,7 @@ nfs_data33_dir: "{{ volA_path }}/data33"
 nfs_data36_dir: "{{ volA_path }}/data36"
 nfs_data37_dir: "{{ volA_path }}/data37"
 nfs_data39_dir: "{{ volA_path }}/data39"
+nfs_data40_dir: "{{ volA_path }}/data40"
 
 # volume B (50 TB)
 # data folders moved to QLD, September 2025 (data08, data09, data12, data15, data17, data20)
@@ -28,6 +29,7 @@ nfs_data31_dir: "{{ volD_path }}/data31"
 nfs_data32_dir: "{{ volD_path }}/data32"
 nfs_data34_dir: "{{ volD_path }}/data34"
 nfs_data38_dir: "{{ volD_path }}/data38"
+nfs_data41_dir: "{{ volD_path }}/data41"
 
 attached_volumes:
   - device: /dev/vdb
@@ -63,6 +65,8 @@ nfs_dirs:
   - "{{ nfs_data37_dir }}"
   - "{{ nfs_data38_dir }}"
   - "{{ nfs_data39_dir }}"
+  - "{{ nfs_data40_dir }}"
+  - "{{ nfs_data41_dir }}"
 
 nfs_exports:
   - "{{ volA_path }} {{ hostvars['galaxy'].internal_ip.split('.')[:-1] | join('.') }}.0/24(rw,async,no_root_squash,no_subtree_check)"

--- a/templates/galaxy/config/galaxy_object_store_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.yml.j2
@@ -1,8 +1,18 @@
 type: distributed
 search_for_missing: false
 backends:
-- id: data39
+- id: data41
   weight: 1
+  type: disk
+  store_by: uuid
+  files_dir: /mnt/user-data-volD/data41
+- id: data40
+  weight: 1
+  type: disk
+  store_by: uuid
+  files_dir: /mnt/user-data-volA/data40
+- id: data39
+  weight: 0
   type: disk
   store_by: uuid
   files_dir: /mnt/user-data-volA/data39


### PR DESCRIPTION
Add data40 to volA and data41 to volD. A dataset created in galaxy will go to either one or the other. Because of the central location of the upload store folder this should be OK.