### PR TITLE
gffread to use docker with file size restrictions

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -711,6 +711,11 @@ tools:
   toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/.*:
     cores: 9
     mem: 65 # was 34.5 - increased to match pulsar-qld-high-mem2 requirements (62.51)
+    params:
+      docker_enabled: true
+      docker_run_extra_arguments: --pids-limit 10000 --ulimit fsize=1000000000 
+        --env TERM=vt100
+      singularity_enabled: false
     scheduling:
       prefer:
       - gffread_destination


### PR DESCRIPTION
Attempt to solve problem of gffread jobs filling disks. `--ulimit fsize=1000000000` is supposed to stop any file in the container exceeding this size. We use it for mothur.