### PR TITLE
Add new config options for release_26.1

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -209,6 +209,8 @@ group_galaxy_config:
     enable_notification_system: true
     expose_potentially_sensitive_job_metrics: true
     load_tool_shed_datatypes: false # Recommended by @Marius as __DATA_FETCH__ tool was stalling.
+    enable_mcp_server: true
+    enable_statsd_middleware: false
 
     static_enabled: true
     show_welcome_with_login: false
@@ -302,33 +304,6 @@ group_galaxy_config:
     tool_help_boost: 1
     tool_search_limit: 160
 
-    # amqp_internal_connection: 'pyamqp://galaxy_internal:more_queues@localhost:5672/galaxy_internal' # this needs configuration
-
-    # data_manager_config_file: /mnt/galaxy-app/config/data_manager_conf.xml.sample  # should we be templating these?
-
-    # migrated_tools_config: /mnt/galaxy/var/migrated_tools_conf.xml
-    # datatypes_config_file: /mnt/galaxy-app/config/datatypes_conf.xml
-
-    # interactive_environment_plugins_directory: config/plugins/interactive_environments
-
-    # dynamic_proxy_prefix: galaxy/gie_proxy
-    # dynamic_proxy_external_proxy: true
-    # dynamic_proxy_debug: true
-    # dynamic_proxy_manage: false
-    #
-    # use_pbkdf2: false
-    # smtp_server: localhost
-    # set_metadata_externally: true
-    # retry_metadata_internally: true
-
-    # ftp_upload_dir: /mnt/ftp/galaxy_prod  # prob not relevant to dev, or if we want this for dev we need to configure something
-    # ftp_upload_site: 'ftp.usegalaxy.org.au'
-    # enable_openid: true
-    # slow_query_log_threshold: .5
-
-    # collect_outputs_from: job_working_directory # surely this is not a real path?  Relative to something?
-    # rsync_url: 'rsync://scofield.bx.psu.edu/indexes'
-    # len_file_path: /mnt/galaxy-app/tool-data/len
 
 # galaxy_config_template_src_dir: templates/galaxy  ## this var has been moved to all.yml
 group_galaxy_config_templates:

--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -209,7 +209,6 @@ group_galaxy_config:
     enable_notification_system: true
     expose_potentially_sensitive_job_metrics: true
     load_tool_shed_datatypes: false # Recommended by @Marius as __DATA_FETCH__ tool was stalling.
-    enable_mcp_server: true
     enable_statsd_middleware: false
 
     static_enabled: true

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -203,6 +203,7 @@ host_galaxy_config: # renamed from __galaxy_config
     enable_mulled_containers: true
     enable_notification_system: true
     enable_oidc: true
+    enable_tool_requests: true
     file_path: "{{ galaxy_file_path }}"
     id_secret: "{{ vault_dev_id_secret }}"
     interactivetools_enable: true

--- a/host_vars/dev.gvl.org.au.yml
+++ b/host_vars/dev.gvl.org.au.yml
@@ -198,6 +198,7 @@ host_galaxy_config: # renamed from __galaxy_config
       microbiology.dev.gvl.org.au: microbiology
     email_from: <galaxy-no-reply@usegalaxy.org.au>
     enable_beta_containers_interface: true
+    enable_mcp_server: true
     enable_beta_tool_formats: true  # user defined tools new as of release_25.0
     enable_celery_tasks: true
     enable_mulled_containers: true

--- a/templates/galaxy/config/file_sources_conf.yml.j2
+++ b/templates/galaxy/config/file_sources_conf.yml.j2
@@ -68,20 +68,6 @@
   secret: {{ vault_nectar_melbournegvl_cb_ec2_secret_key }}
   key: {{ vault_nectar_melbournegvl_cb_ec2_access_key }}
   writable: true
-
-# - type: webdav
-#   id: agrf_nextcloud
-#   label: AGRF Nextcloud
-#   doc: Import your files from AGRF's Nextcloud server. Configure access in User -> Preferences -> Manage Information
-#   url: https://agrf-data.agrf.org.au
-#   root: /remote.php/dav/files/${user.preferences['agrf_nextcloud_account|username']}/
-#   login: ${user.preferences['agrf_nextcloud_account|username']}
-#   password: ${user.user_vault.read_secret('preferences/agrf_nextcloud_account/password')}
-#   writable: true
-#   # Set the following settings to avoid loading entire files into memory
-#   # useful when dealing with big files
-#   use_temp_files: true
-#   temp_path: "{{ galaxy_tmp_dir }}/webdav"
 {% endif %}
 
 {% if aai_enabled and __galaxy_major_version is version('26.1', '>=') and bpa_data_portal_file_source_enabled|d(true) %}


### PR DESCRIPTION
there are lots of new config options in release_26.1, see [release notes](https://docs.galaxyproject.org/en/latest/releases/26.1_announce.html)

This sets `enable_statsd_middleware: false` for production and `enable_mcp_server: true` and `enable_tool_requests: true` for dev only.

Here is a full list of new config options. Some have sensible defaults, some aren’t relevant to us, some I don’t understand properly so have not added them.
```
agent_model_capabilities_file
bulk_storage_operation_completed_run_retention_days
bulk_storage_operation_dataset_minimum_days_to_expiration
celery_user_concurrency_limit
enable_mcp_server
enable_sse_connection_metrics
enable_sse_updates
enable_statsd_middleware
enable_tool_requests
gtn_database_path
gtn_database_refresh_interval
gtn_database_url
history_audit_monitor_poll_interval
iwc_manifest_refresh_interval
kombu_sqla_transport_cleanup_interval
mcp_server_path
prune_expired_bulk_storage_operations_interval
queue_metrics_interval
recover_stale_bulk_storage_operation_runs_interval
sentry_client_traces_sample_rate
tool_tag_mappings_file
vault_token_renewal_interval
```