### PR TITLE
Add exception for tiberius_models in  check_data_tables_for_dups.py

### DIFF
--- a/jenkins/check_data_tables/check_data_tables_for_dups.py
+++ b/jenkins/check_data_tables/check_data_tables_for_dups.py
@@ -15,6 +15,7 @@ same value.
 SKIP_TABLES = [
     "busco_database_options",  # does not contain file paths
     "indexed_maf_files",
+    "tiberius_models",  # does not contain file paths
 ]
 
 # Known duplicate entries to ignore for specific tables


### PR DESCRIPTION
No need to check this data table - the script is trying to detect reference file double-ups and this is not that.