### PR TITLE
add update reboot playbook

### DIFF
--- a/one-offs/update_reboot_playbook.yml
+++ b/one-offs/update_reboot_playbook.yml
@@ -1,0 +1,12 @@
+- name: Run apt updates and reboot
+  hosts: "{{ target_hosts }}"
+  become: true
+
+  tasks:
+  - name: Update the apt repos and base OS
+    apt:
+      upgrade: dist
+      update_cache: yes
+  - name: Reboot VM
+    reboot:
+      msg: "Rebooting VM"


### PR DESCRIPTION
If apt updates don’t work, might need to run ‘ubuntu_updates_playbook.yml’ that includes more of the common-role activities prior to update.

The reboot may time out for some VMs, in that case they either need extra attention or they just need more time.