### PR TITLE
locally override shared db hifiasm expert rule

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml.j2
@@ -257,6 +257,53 @@ tools:
       scheduling:
         prefer:
         - pulsar-high-mem1
+        rules:
+    - id: tpvdb_hifiasm_expert_memory_rule  # overridden from shared-db to set cores here
+      # The memory requirement of Hifiasm depends on the "Estimated haploid genome size" (hg_size).
+      # If hg_size is set, and it can be calculated automatically, then we can fit memory more efficiently.
+      # This is done for example in the VGP workflows.
+      if: |
+        parameters = {p.name: p.value for p in job.parameters}
+        parameters = tool.params_from_strings(parameters, app)
+
+        advanced_options = parameters.get("advanced_options", dict())
+        hg_size = advanced_options.get("hg_size", "")
+
+        bool(hg_size)
+      cores: 10
+      mem: |
+        from math import ceil
+
+        parameters = {p.name: p.value for p in job.parameters}
+        parameters = tool.params_from_strings(parameters, app)
+
+        advanced_options = parameters.get("advanced_options", dict())
+
+        kcov_default = 36
+        kcov = advanced_options.get("kcov", kcov_default)
+
+        hg_size = advanced_options.get("hg_size", "")
+
+        value = 0
+        if hg_size:
+            conversion_factors = {
+                "k": 1000000,
+                "M": 1000,
+                "G": 1,
+            }
+            conversion_factors = {
+                key.lower(): value for key, value in conversion_factors.items()
+            }
+            suffix = hg_size[-1:].lower()
+            value = hg_size[:len(hg_size) - 1]
+            value = value.replace(",", ".")
+            value = float(value)
+            # compute hg size in Gb
+            value = value / conversion_factors[suffix.lower()]
+            value = ceil(value * (kcov * 2) * 1.75)
+
+        # return the amount of memory needed
+        value
   toolshed.g2.bx.psu.edu/repos/bgruening/interproscan/interproscan/.*:
     context:
       max_concurrent_job_count_for_tool_user: 2


### PR DESCRIPTION
Galaxy EU put a rule in shared-db that calculates mem for hifiasm entirely based on user form input for the values `hg_size` and `kcov` in advanced options. Most users do not set these. This can lead to jobs asking for 60 CPUs and 7 GB of RAM which none of AU’s destinations will accommodate. This change is copypasting the entire rule in order to set cores to 10 when it matches.