### PR TITLE
attach volumes by uuid

### DIFF
--- a/dev-workers_playbook.yml
+++ b/dev-workers_playbook.yml
@@ -22,39 +22,13 @@
       - galaxyproject.cvmfs
       - dj-wasabi.telegraf
       - acl-on-startup
+      - tmp-relocation
       - clean-tmpdisk
   post_tasks:
       - name: restart munge
         systemd:
             name: munge
             state: restarted
-      - name: Move /tmp to /mnt
-        block:
-          - name: Create worker tmpdir on /mnt
-            file:
-                path: /mnt/tmpdisk
-                state: directory
-                owner: root
-                group: root
-                mode: '1777'
-          - name: stat links
-            stat:
-                path: /tmp
-            register: links
-          - name: remove old tmp
-            file:
-                path: /tmp
-                state: absent
-            when: links.stat.islnk is defined and not links.stat.islnk
-          - name: Link /tmp to /mnt/tmpdisk
-            file:
-                src: /mnt/tmpdisk
-                dest: /tmp
-                state: link
-            become: yes
-            become_user: root
-            when: links.stat.islnk is defined and not links.stat.islnk
-        when: attached_volumes is defined
       - name: Reload cvmfs config
         command:
           cmd: cvmfs_config reload

--- a/roles/attached-volumes/tasks/set_up_volume.yml
+++ b/roles/attached-volumes/tasks/set_up_volume.yml
@@ -67,13 +67,21 @@
       when: part_info.fstype == ""
     when: num_parts2|int > 0 and attached_volume.partition is defined
 
+  - name: Get UUID of device
+    ansible.builtin.command: "blkid -s UUID -o value {{ device_part_name|d(attached_volume.device) }}"
+    register: disk_uuid
+    changed_when: false
+    failed_when:
+      - disk_uuid.rc != 0
+      - disk_uuid.stdout | trim == ""
+
   - name: "Mount {{ device_part_name|d(attached_volume.device) }} on {{ attached_volume.path }} "
     mount:
       path: "{{ attached_volume.path }}"
-      src: "{{ device_part_name|d(attached_volume.device) }}"
+      src: "UUID={{ disk_uuid.stdout | trim }}"
       fstype: "{{ attached_volume.fstype }}"
       opts: "{{ attached_volume.opts|d('defaults') }}"
-      state: mounted    
+      state: "{{ attached_volume.state|d('mounted') }}"
   when: attached_volume.device is defined and attached_volume.fstype is defined and attached_volume.path is defined
   become: yes
   become_user: root


### PR DESCRIPTION
Add extra step to set_up_volume.yml to get the UUID and mount by that. This works on volumes that are already mounted with src=‘/dev/xyz2’ etc, in that case this changes the fstab to use the UUID.