### PR TITLE
conda singularity in conda

### DIFF
--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_default_tool.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_default_tool.yml.j2
@@ -20,6 +20,8 @@ tools:
       pulsar_singularity_volumes: "{{ pulsar_singularity_volumes }}"
       pulsar_docker_volumes: "{{ pulsar_docker_volumes }}"
 
+      conda_singularity_base_id: /cvmfs/main.galaxyproject.org/singularity/usegalaxy.org-legacy-environment--0
+
     scheduling:
       reject:
         - offline

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -84,6 +84,23 @@ destinations:
     scheduling:
       accept:
         - slurm
+  legacy_slurm:  # conda in singularity
+    inherits: _slurm_destination
+    runner: slurm
+    context:
+      slurm_singularity_volumes: '{{ slurm_singularity_volumes }},/mnt/galaxy/tool_dependencies/_conda:rw'
+    params:
+      singularity_enabled: true
+      singularity_volumes: '{ slurm_singularity_volumes }'
+      singularity_default_container_id: '{ singularity_default_container_id }'
+      container_override:
+      - type: singularity
+        shell: /bin/bash
+        resolve_dependencies: true
+        identifier: '{ conda_singularity_base_id }'
+    scheduling:
+      require:
+        - legacy_slurm
   interactive_pulsar:
     runner: pulsar_embedded
     context:

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_vortex_config.yml.j2
@@ -1,7 +1,15 @@
 tools:
   __DATA_FETCH__:
+    # context:
+    #   conda_singularity_base_id: /cvmfs/main.galaxyproject.org/singularity/rockylinux:9.5.20241118--0
     params:
       tmp_dir: True
+    # env: # these env vars are because a container is being used now and the galaxy venv is no longer active
+    #   SINGULARITYENV_PREPEND_PATH: /mnt/galaxy/venv/bin
+    #   SINGULARITYENV_PYTHONPATH: /mnt/galaxy/galaxy-app/lib
+    # scheduling:
+    #   require:
+    #     - legacy_slurm
   interactive_tool_.*:
     context:
       require_login: true
@@ -428,6 +436,10 @@ tools:
     mem: 60
     params:
       singularity_enabled: true
+  toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_uniq_tool/.*:
+    scheduling:
+      require:
+        - legacy_slurm
 
   toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/.*:
     cores: 4


### PR DESCRIPTION
This is a rebase from ages ago and it looks like I went down a rabbit hole.

The important bit is `resolve dependencies` which is telling galaxy to run in a container but use a conda env
```
      container_override:
      - type: singularity
        shell: /bin/bash
        resolve_dependencies: true
        identifier: '{ conda_singularity_base_id }'
```