### PR TITLE
Make acl role restart instead of start and give it a tag in playbooks

### DIFF
--- a/dev-handlers_playbook.yml
+++ b/dev-handlers_playbook.yml
@@ -35,7 +35,8 @@
         - "{{ galaxy_user_singularity_tmpdir }}"
   roles:
     - galaxyproject.repos
-    - mounts
+    - role: mounts
+      tags: mounts
     - geerlingguy.pip
     - galaxyproject.galaxy
     # - role: galaxyproject.miniconda  # maybe this is never needed from the handlers playbook, will see
@@ -52,7 +53,8 @@
     - usegalaxy_eu.apptainer
     - dj-wasabi.telegraf
     - usegalaxy_eu.flower
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
   post_tasks:
     - name: Make local_tool directory group-writable by machine users
       file:

--- a/dev-pulsar_playbook.yml
+++ b/dev-pulsar_playbook.yml
@@ -30,7 +30,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/dev-workers_playbook.yml
+++ b/dev-workers_playbook.yml
@@ -14,14 +14,16 @@
   roles:
       - common
       - geerlingguy.pip
-      - mounts
+      - role: mounts
+        tags: mounts
       - galaxyproject.repos
       - galaxyproject.slurm
       - geerlingguy.docker
       - usegalaxy_eu.apptainer
       - galaxyproject.cvmfs
       - dj-wasabi.telegraf
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - clean-tmpdisk
   post_tasks:
       - name: restart munge
@@ -58,3 +60,6 @@
       - name: Reload cvmfs config
         command:
           cmd: cvmfs_config reload
+      - name: Run disable-cgroups-v2 role
+        include_role:
+          name: disable-cgroups-v2

--- a/dev_playbook.yml
+++ b/dev_playbook.yml
@@ -38,7 +38,8 @@
   roles:
     - geerlingguy.nfs
     - galaxyproject.repos
-    - mounts
+    - role: mounts
+      tags: mounts
     # - install-tpv # todo: this needs a when clause
     - geerlingguy.pip
     - role: galaxyproject.galaxy
@@ -68,7 +69,8 @@
     - usegalaxy_eu.apptainer
     - dj-wasabi.telegraf
     - postfix-mail-relay
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - role: usegalaxy_eu.walle
       tags: walle
     - role: vector

--- a/galaxy-handlers_playbook.yml
+++ b/galaxy-handlers_playbook.yml
@@ -73,7 +73,8 @@
         - geerlingguy.docker
         - dj-wasabi.telegraf
         - usegalaxy_eu.flower
-        - acl-on-startup
+        - role: acl-on-startup
+          tags: setfacl
         - nfs-monitor
   post_tasks:
     - name: Make local_tool directory group-writable by machine users

--- a/galaxy-workers_playbook.yml
+++ b/galaxy-workers_playbook.yml
@@ -67,7 +67,8 @@
       - role: dj-wasabi.telegraf
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - clean-tmpdisk
   post_tasks:
       - name: restart munge

--- a/galaxy_playbook.yml
+++ b/galaxy_playbook.yml
@@ -54,7 +54,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - geerlingguy.nfs
     - galaxyproject.gxadmin

--- a/pulsar-QLD_playbook.yml
+++ b/pulsar-QLD_playbook.yml
@@ -28,7 +28,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-QLD_workers_playbook.yml
+++ b/pulsar-QLD_workers_playbook.yml
@@ -16,12 +16,14 @@
   roles:
       - common
       - galaxyproject.slurm
-      - mounts
+      - role: mounts
+        tags: mounts
       - galaxyproject.repos
       - galaxyproject.cvmfs
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - dj-wasabi.telegraf
       - tmp-relocation
       - clean-tmpdisk

--- a/pulsar-high-mem1_playbook.yml
+++ b/pulsar-high-mem1_playbook.yml
@@ -27,7 +27,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-high-mem2_playbook.yml
+++ b/pulsar-high-mem2_playbook.yml
@@ -28,7 +28,8 @@
     - gantsign.golang
     - cyverse-ansible.singularity
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-mel2_playbook.yml
+++ b/pulsar-mel2_playbook.yml
@@ -28,7 +28,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-mel2_workers_playbook.yml
+++ b/pulsar-mel2_workers_playbook.yml
@@ -16,12 +16,14 @@
   roles:
       - common
       - galaxyproject.slurm
-      - mounts
+      - role: mounts
+        tags: mounts
       - galaxyproject.repos
       - galaxyproject.cvmfs
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - dj-wasabi.telegraf
       - tmp-relocation
       - clean-tmpdisk

--- a/pulsar-mel3_playbook.yml
+++ b/pulsar-mel3_playbook.yml
@@ -28,7 +28,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-mel3_workers_playbook.yml
+++ b/pulsar-mel3_workers_playbook.yml
@@ -17,12 +17,14 @@
   roles:
     - common
     - galaxyproject.slurm
-    - mounts
+    - role: mounts
+      tags: mounts
     - galaxyproject.repos
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - tmp-relocation
     - clean-tmpdisk

--- a/pulsar-nci-test_playbook.yml
+++ b/pulsar-nci-test_playbook.yml
@@ -35,7 +35,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-nci-test_workers_playbook.yml
+++ b/pulsar-nci-test_workers_playbook.yml
@@ -23,12 +23,14 @@
   roles:
       - common
       - galaxyproject.slurm
-      - mounts
+      - role: mounts
+        tags: mounts
       - galaxyproject.repos
       - galaxyproject.cvmfs
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - dj-wasabi.telegraf
       - tmp-relocation
       - clean-tmpdisk

--- a/pulsar-nci-training_playbook.yml
+++ b/pulsar-nci-training_playbook.yml
@@ -36,7 +36,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-nci-training_workers_playbook.yml
+++ b/pulsar-nci-training_workers_playbook.yml
@@ -24,12 +24,14 @@
   roles:
       - common
       - galaxyproject.slurm
-      - mounts
+      - role: mounts
+        tags: mounts
       - galaxyproject.repos
       - galaxyproject.cvmfs
       - usegalaxy_eu.apptainer
       - geerlingguy.docker
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - dj-wasabi.telegraf
       - tmp-relocation
       - clean-tmpdisk

--- a/pulsar-qld-blast_playbook.yml
+++ b/pulsar-qld-blast_playbook.yml
@@ -21,7 +21,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-qld-gpu-dev_playbook.yml
+++ b/pulsar-qld-gpu-dev_playbook.yml
@@ -26,7 +26,8 @@
         group: "{{ pulsar_user.name }}"
   roles:
     - common
-    - mounts
+    - role: mounts
+      tags: mounts
     - geerlingguy.pip
     - galaxyproject.repos
     - pulsar-pre-tasks
@@ -40,7 +41,8 @@
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
     - nvidia-ctk
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-qld-gpu_playbook.yml
+++ b/pulsar-qld-gpu_playbook.yml
@@ -24,7 +24,8 @@
         group: "{{ pulsar_user.name }}"
   roles:
     - common
-    - mounts
+    - role: mounts
+      tags: mounts
     - geerlingguy.pip
     - galaxyproject.repos
     - pulsar-pre-tasks
@@ -38,7 +39,8 @@
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
     - nvidia-ctk
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/pulsar-qld-high-mem_playbook.yml
+++ b/pulsar-qld-high-mem_playbook.yml
@@ -24,7 +24,8 @@
     - galaxyproject.cvmfs
     - usegalaxy_eu.apptainer
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/qaai_playbook.yml
+++ b/qaai_playbook.yml
@@ -70,7 +70,8 @@
     - usegalaxy_eu.apptainer
     # - dj-wasabi.telegraf
     # - postfix-mail-relay
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     # - role: usegalaxy_eu.walle
     #   tags: walle
   post_tasks:

--- a/roles/acl-on-startup/tasks/main.yml
+++ b/roles/acl-on-startup/tasks/main.yml
@@ -6,4 +6,4 @@
   systemd:
     name: start-acl
     enabled: true  # will start on reboot
-    state: started  # will start now if not running
+    state: restarted  # will start (run setfacl command) any time this is run

--- a/staging-pulsar_playbook.yml
+++ b/staging-pulsar_playbook.yml
@@ -29,7 +29,8 @@
     - gantsign.golang
     - cyverse-ansible.singularity
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - dj-wasabi.telegraf
     - pulsar-post-tasks
     - slurm-post-tasks

--- a/staging-workers_playbook.yml
+++ b/staging-workers_playbook.yml
@@ -14,14 +14,16 @@
   roles:
       - common
       - geerlingguy.pip
-      - mounts
+      - role: mounts
+        tags: mounts
       - galaxyproject.repos
       - galaxyproject.slurm
       - galaxyproject.cvmfs
       - gantsign.golang
       - cyverse-ansible.singularity
       - geerlingguy.docker
-      - acl-on-startup
+      - role: acl-on-startup
+        tags: setfacl
       - dj-wasabi.telegraf
   post_tasks:
       - name: restart munge

--- a/staging_playbook.yml
+++ b/staging_playbook.yml
@@ -44,7 +44,8 @@
     - gantsign.golang
     - cyverse-ansible.singularity
     - geerlingguy.docker
-    - acl-on-startup
+    - role: acl-on-startup
+      tags: setfacl
     - galaxyproject.gxadmin
     - dj-wasabi.telegraf
     - postfix-mail-relay


### PR DESCRIPTION
The acl-on-startup service runs setfacl when a VM is rebooted, allowing the docker user access to the docker api. Docker access also falls over sometimes when docker is updated during ‘apt upgrade dist’. By restarting the service when the role is run, docker access can be quickly restored from the playbook.

Also add a tag for the mounts role since we always need to check these after an outage or reboot.