### PR TITLE
reduce number of backups kept on galaxy-backup

### DIFF
--- a/host_vars/galaxy-backup.yml
+++ b/host_vars/galaxy-backup.yml
@@ -37,6 +37,7 @@ weekly_backup_day: 6  #Weekly backups will run on this day of the week
 retention_day: 6       #Keep daily backups for this many days (6 days)
 retention_week: 21     #Keep weekly backups for this many days (21 days = 3 weeks)
 retention_month: 61    #Keep monthly backups for this many days (61 days ~ 2 months)
+retention_disk: 3      #Keep backups on disk for this many days
 
 extra_keys:
   - id: internal_hop_key


### PR DESCRIPTION
The backup triggers a disk alert every morning because the volume goes over 90% for a little while. This needn’t happen because JL added the option of having fewer copies on the disk than in the swift bucket.