### PR TITLE
dev pulsar jwds on dev handlers

### DIFF
--- a/host_vars/dev-handlers.gvl.org.au.yml
+++ b/host_vars/dev-handlers.gvl.org.au.yml
@@ -5,7 +5,11 @@ add_hosts_head: yes
 add_hosts_workers: yes
 add_hosts_handlers: no
 
-attached_volumes: []
+attached_volumes:
+  - device: /dev/vdb
+    path: /pvol
+    fstype: ext4
+    partition: 1
 
 shared_mounts:
   - path: /mnt/galaxy
@@ -31,9 +35,16 @@ galaxy_fetch_dependencies: false
 galaxy_manage_mutable_setup: false
 galaxy_build_client: false
 
+nginx_upload_store_base_dir: /pvol/upload_store
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/handlers_job_files"
 nginx_ssl_servers:
   - galaxy-handlers
+
+pulsar_job_working_directory: /pvol/pulsar_job_working_directory
+
+host_galaxy_extra_dirs:
+  - "{{ galaxy_data_path }}/data-4-pulsar"
+  - "{{ pulsar_job_working_directory }}"
 
 host_galaxy_config_gravity:  # overridden from entry in dev.usegalaxy.org.au
   process_manager: systemd

--- a/templates/galaxy/config/dev_object_store_conf.yml.j2
+++ b/templates/galaxy/config/dev_object_store_conf.yml.j2
@@ -17,6 +17,19 @@ backends:
     - type: not_backed_up
     - type: short_term
       message: "Data stored here is scheduled for removal after {{ galaxy_scratch_storage_days }} days of inactivity"
+- id: dev_objects_4_pulsar
+  name: Dev object store folder 4 for pulsar outputs only
+  device: dev_volume
+  weight: 0
+  type: disk
+  store_by: uuid
+  files_dir: {{ galaxy_data_path }}/data-4-pulsar
+  allow_selection: true
+  extra_dirs:
+  - type: temp
+    path: {{ galaxy_data_path }}/tmp/scratch
+  - type: job_work
+    path: {{ pulsar_job_working_directory }}  # this is accessible from dev-handlers but not dev
 - id: dev_objects_3
   name: Dev object store folder 3
   device: dev_volume


### PR DESCRIPTION
Separate job working directories for pulsar jobs. This will be possible to do per job in future releases but at the moment it needs to be controlled by object store backend.

This is motivated by the fact that jobs that run on pulsar use /mnt/scratch/ on production for the galaxy job working directories, leading to lots of file posting to /mnt/scratch at the end of jobs. Occasionally for these are big files, for hifiasm in particular these can be be 100GB+ files.

This needs testing on dev because it puts galaxy JWDs for pulsar jobs on a path that is not accessible from the web server, and galaxy may not be OK with this even though I’m pretty sure that apart from job_files API (which is handled from the handlers server), gunicorn does not need to be able to see job working directories.