### PR TITLE
extend client body timeout galaxy handlers

### DIFF
--- a/templates/nginx/galaxy-handlers.j2
+++ b/templates/nginx/galaxy-handlers.j2
@@ -51,6 +51,8 @@ server {
 {% if galaxy_config['galaxy']['nginx_upload_job_files_store'] is defined %}
 
     location /_job_files {
+        client_body_timeout 600s;  # default 60s, affects only POST requests because they have a client body
+
         if ($request_method != POST) {
                 rewrite "" /api/jobs/$arg_job_id/files last;
         }


### PR DESCRIPTION
Big files coming from pulsar are at risk of timing out if there is a break of more than a minute between successive reads. This has been happening often enough to risk jobs failings since there are only 5 retries per file.  Set `client_body_timeout` to 600s (default 60s).

https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout