### PR TITLE
dev rule to give special object store id to pulsar jobs

### DIFF
--- a/dev-handlers_playbook.yml
+++ b/dev-handlers_playbook.yml
@@ -34,6 +34,7 @@
         - "{{ galaxy_user_singularity_cachedir }}"
         - "{{ galaxy_user_singularity_tmpdir }}"
   roles:
+    - attached-volumes
     - galaxyproject.repos
     - role: mounts
       tags: mounts

--- a/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/dev/total_perspective_vortex/dev_destinations.yml.j2
@@ -69,6 +69,12 @@ destinations:
             docker_set_user: '1000'
             docker_memory: '{mem}G'
             docker_sudo: false
+      - id: pulsar_jobs_set_object_store_if_unset
+        # we have an object store for pulsar jobs
+        # but object store set at the user level takes priority
+        if: not entity.params.get('object_store_id')
+        params:
+          object_store_id: dev_objects_4_pulsar
   
   slurm:
     inherits: _slurm_destination

--- a/host_vars/dev-handlers.gvl.org.au.yml
+++ b/host_vars/dev-handlers.gvl.org.au.yml
@@ -29,7 +29,7 @@ shared_mounts:
 galaxy_config_file: /opt/galaxy/galaxy.yml
 
 # galaxy role applied to dev-handlers machine is only needed for gravity and the galaxy config files. Skip other tasks
-galaxy_manage_paths: false
+galaxy_manage_paths: true  # we want dirs on dev-handlers created by the galaxy role
 galaxy_manage_clone: false
 galaxy_fetch_dependencies: false
 galaxy_manage_mutable_setup: false


### PR DESCRIPTION
Having a JWD path that only exists on the handlers server is working on dev.