### PR TITLE
add data42 as an object store backend for pulsar outputs only (revert of revert)

### DIFF
--- a/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
+++ b/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/destinations.yml.j2
@@ -65,6 +65,13 @@ destinations:
             docker_memory: '{mem}G'
             docker_sudo: false
 
+      # - id: pulsar_jobs_set_object_store_if_unset
+      #   # we have an object store for pulsar jobs
+      #   # but object store set at the user level takes priority
+      #   if: not entity.params.get('object_store_id')
+      #   params:
+      #     object_store_id: data42
+
   slurm:
     inherits: _slurm_destination
     runner: slurm

--- a/galaxy-handlers_playbook.yml
+++ b/galaxy-handlers_playbook.yml
@@ -48,12 +48,6 @@
         path: "{{ item }}"
       with_items:
         - "{{ qld_file_mounts_path }}"
-    - name: create celery tmp dir
-      file:
-        state: directory
-        path: "{{ galaxy_celery_tmp_dir }}"
-        owner: galaxy
-        group: galaxy
   roles:
         - role: mounts
           tags: mounts

--- a/host_vars/galaxy-handlers.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-handlers.usegalaxy.org.au.yml
@@ -24,13 +24,19 @@ shared_mounts: "{{ galaxy_mount + galaxy_server_and_worker_shared_mounts }}"
 galaxy_config_file: /opt/galaxy/galaxy.yml
 
 # galaxy role applied to dev-handlers machine is only needed for gravity and the galaxy config files. Skip other tasks
-galaxy_manage_paths: false
+galaxy_manage_paths: true  # manage paths on /pvol, /pvol2
 galaxy_manage_clone: false
 galaxy_fetch_dependencies: false
 galaxy_manage_mutable_setup: false
 galaxy_build_client: false
 
 galaxy_celery_tmp_dir: /pvol/celery_tmp
+
+pulsar_job_working_directory: /pvol2/pulsar_job_working_directory
+
+host_galaxy_extra_dirs:
+  - "{{ galaxy_celery_tmp_dir }}"
+  - "{{ pulsar_job_working_directory }}"
 
 upload_store_volume_dir: /pvol2
 nginx_upload_job_files_store_dir: "{{ nginx_upload_store_base_dir }}/handlers_job_files"

--- a/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
+++ b/host_vars/galaxy-user-nfs.usegalaxy.org.au.yml
@@ -30,6 +30,7 @@ nfs_data32_dir: "{{ volD_path }}/data32"
 nfs_data34_dir: "{{ volD_path }}/data34"
 nfs_data38_dir: "{{ volD_path }}/data38"
 nfs_data41_dir: "{{ volD_path }}/data41"
+nfs_data42_dir: "{{ volD_path }}/data42"
 
 attached_volumes:
   - device: /dev/vdb

--- a/templates/galaxy/config/galaxy_object_store_conf.yml.j2
+++ b/templates/galaxy/config/galaxy_object_store_conf.yml.j2
@@ -1,8 +1,16 @@
 type: distributed
 search_for_missing: false
 backends:
+- id: data42
+  weight: 0
+  type: disk
+  store_by: uuid
+  files_dir: /mnt/user-data-volD/data42
+  extra_dirs:
+    - type: job_work
+      path: {{ pulsar_job_working_directory }}
 - id: data41
-  weight: 1
+  weight: 0
   type: disk
   store_by: uuid
   files_dir: /mnt/user-data-volD/data41


### PR DESCRIPTION
Add data42 with weight 0 and job working directory on galaxy-handlers /pvol2 (2.5T vol, sharing space the with nginx upload store folder)

This change is because pulsars post a lot of things back to the job working directory on galaxy. Most of these are tiny but some are large files, 100GB+ in the case of hifiasm outputs.

I have tested this out on dev and it works, so I think it’s worth trying on production.

There is a TPV rule for _pulsar_destination that is commented out, uncommenting this will activate the setting of object store ID for pulsar jobs.