### PR TITLE
Remove some built-in Get Data tools from tool conf

### DIFF
--- a/files/galaxy/config/tool_conf.xml
+++ b/files/galaxy/config/tool_conf.xml
@@ -4,26 +4,12 @@
     <section id="getext" name="Get Data">
         <tool file="data_source/upload.xml" hidden="True"/>
         <tool file="data_source/ucsc_tablebrowser.xml"/>
-        <!-- <tool file="data_source/ucsc_tablebrowser_test.xml" /> -->
-        <tool file="data_source/ucsc_tablebrowser_archaea.xml"/>
         <tool file="data_source/sra.xml"/>
         <tool file="data_source/ebi_sra.xml"/>
-        <tool file="data_source/fly_modencode.xml"/>
         <tool file="data_source/intermine.xml"/>
         <tool file="data_source/flymine.xml"/>
-        <!-- <tool file="data_source/flymine_test.xml" /> -->
-        <tool file="data_source/modmine.xml"/>
         <tool file="data_source/mousemine.xml"/>
-        <tool file="data_source/ratmine.xml"/>
-        <tool file="data_source/yeastmine.xml"/>
-        <tool file="data_source/worm_modencode.xml"/>
-        <tool file="data_source/wormbase.xml"/>
-        <!-- <tool file="data_source/wormbase_test.xml" /> -->
-        <tool file="data_source/zebrafishmine.xml"/>
-        <tool file="data_source/eupathdb.xml"/>
         <tool file="data_source/hbvar.xml"/>
-        <tool file="data_source/gramene_mart.xml"/>
-        <tool file="data_source/metabolicmine.xml"/>
     </section>
     <section id="send" name="Send Data">
         <tool file="data_export/export_remote.xml" />


### PR DESCRIPTION
GA team has audited Get Data tools and flagged these for exclusion as they link to URLs that do not resolve

EuPathDB
GrameneMart
metabolicMine
modENCODE fly
modENCODE modMine
modENCODE worm
Ratmine
UCSC Archaea
WormBase
YeastMine
ZebrafishMine