### PR TITLE
fix container resolvers configuration

### DIFF
--- a/group_vars/galaxyservers.yml
+++ b/group_vars/galaxyservers.yml
@@ -289,8 +289,8 @@ group_galaxy_config:
       - type: cached_mulled_singularity
         cache_directory: /cvmfs/singularity.galaxyproject.org/all
         cache_directory_cacher_type: dir_mtime     
-      # local cache
-      - type: cached_mulled_singularity
+      # local cache (fetch if not present)
+      - type: mulled_singularity
         cache_directory: "{{ galaxy_tools_indices_dir }}/cache/singularity"
         cache_directory_cacher_type: dir_mtime
 


### PR DESCRIPTION
Change fallback container resolver from `cached_mulled_singularity` to `mulled_singularity`. With this change, biocontainers can be fetched when they are not present in cvmfs